### PR TITLE
Fixes syntax errors on robots.txt

### DIFF
--- a/src/robots.txt
+++ b/src/robots.txt
@@ -1,2 +1,3 @@
 User-agent: *
-sitemap sitemap.xml
+Disallow:
+Sitemap: /sitemap.xml


### PR DESCRIPTION
My syntax for `robots.txt` was hilariously wrong - this fixes it!