### PR TITLE
Preload Google Analytics + caching HTML for 2 hours

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,7 +26,10 @@ url: "https://dylangattey.com"
 permalink: /projects/:title/ #posts
 baseurl: ""
 google_site_verification: U6mU3aPeTRaCoewYQype946HD1HrM9vY96GoEHKCAnc
-preconnect: ["https://use.typekit.net", "https://www.google-analytics.com"]
+preconnect: 
+  - "https://use.typekit.net"
+  - "https://www.google-analytics.com"
+  - "https://d33wubrfki0l68.cloudfront.net"
 
 # Manifest
 lang: en

--- a/_config.yml
+++ b/_config.yml
@@ -15,7 +15,6 @@ social:
 
 # Fonts - if changing this, change the SCSS variables too!!
 font_url: https://use.typekit.net/ytv4uxf.css
-font_preload_urls: ["https://use.typekit.net"]
 use_font_loader: false # whether or not to use async JS to load font
 
 # Breakpoints - if changing these, change the SCSS variables too!!
@@ -27,6 +26,7 @@ url: "https://dylangattey.com"
 permalink: /projects/:title/ #posts
 baseurl: ""
 google_site_verification: U6mU3aPeTRaCoewYQype946HD1HrM9vY96GoEHKCAnc
+preconnect: ["https://use.typekit.net", "https://www.google-analytics.com"]
 
 # Manifest
 lang: en

--- a/src/.htaccess
+++ b/src/.htaccess
@@ -15,30 +15,6 @@ deny from all
 #AIOWPS_DISABLE_INDEX_VIEWS_START
 Options -Indexes
 #AIOWPS_DISABLE_INDEX_VIEWS_END
-#AIOWPS_DISABLE_TRACE_TRACK_START
-RewriteEngine On
-RewriteCond %{REQUEST_METHOD} ^(TRACE|TRACK)
-RewriteCond %{REQUEST_URI} !^/[0-9]+\..+\.cpaneldcv$
-RewriteCond %{REQUEST_URI} !^/\.well-known/acme-challenge/[0-9a-zA-Z_-]+$
-RewriteCond %{REQUEST_URI} !^/\.well-known/pki-validation/[A-F0-9]{32}\.txt(?:\ Comodo\ DCV)?$
-RewriteRule .* - [F]
-#AIOWPS_DISABLE_TRACE_TRACK_END
-#AIOWPS_FORBID_PROXY_COMMENTS_START
-RewriteCond %{REQUEST_METHOD} ^POST
-RewriteCond %{HTTP:VIA} !^$ [OR]
-RewriteCond %{HTTP:FORWARDED} !^$ [OR]
-RewriteCond %{HTTP:USERAGENT_VIA} !^$ [OR]
-RewriteCond %{HTTP:X_FORWARDED_FOR} !^$ [OR]
-RewriteCond %{HTTP:X_FORWARDED_HOST} !^$ [OR]
-RewriteCond %{HTTP:PROXY_CONNECTION} !^$ [OR]
-RewriteCond %{HTTP:XPROXY_CONNECTION} !^$ [OR]
-RewriteCond %{HTTP:HTTP_PC_REMOTE_ADDR} !^$ [OR]
-RewriteCond %{HTTP:HTTP_CLIENT_IP} !^$
-RewriteCond %{REQUEST_URI} !^/[0-9]+\..+\.cpaneldcv$
-RewriteCond %{REQUEST_URI} !^/\.well-known/acme-challenge/[0-9a-zA-Z_-]+$
-RewriteCond %{REQUEST_URI} !^/\.well-known/pki-validation/[A-F0-9]{32}\.txt(?:\ Comodo\ DCV)?$
-RewriteRule wp-comments-post\.php - [F]
-#AIOWPS_FORBID_PROXY_COMMENTS_END
 #AIOWPS_DENY_BAD_QUERY_STRINGS_START
 RewriteCond %{QUERY_STRING} tag=     [NC,OR]
 RewriteCond %{QUERY_STRING} ftp:     [NC,OR]
@@ -236,7 +212,7 @@ RewriteRule ^(.*)?$ https://%{SERVER_NAME}%{REQUEST_URI} [L,R]
   ExpiresActive On
   ExpiresDefault "access plus 1 year"
   # Pages
-  ExpiresByType text/html  "access plus 60 minutes"
+  ExpiresByType text/html  "access plus 120 minutes"
   # RSS feed
   ExpiresByType text/xml  "access plus 240 minutes"
 </IfModule>

--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -11,8 +11,7 @@
   <meta name="theme-color" content="#{{ site.app_theme_color }}">
 
   <!-- Static assets, fonts and CSS includes -->
-  {% for url in site.font_preload_urls %}
-  <link rel="dns-prefetch" href="{{ url }}">
+  {% for url in site.preconnect %}
   <link rel="preconnect" href="{{ url }}">
   {% endfor %}
   {% if site.use_font_loader == false %}


### PR DESCRIPTION
Adds Google Analytics to preload URLs and removes redundant rules from htaccess. Also increases cache time for HTML to 2 hours.

# Motivation
Lighthouse dings you for not having all preload URLs in there. Google Analytics addition will help the score. Additionally, preloading _should_ make the site slightly faster on first load. Increasing cache time should help web speed test too.