### PR TITLE
Blocks all projects from being visible

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,3 +3,18 @@ from = "https://dgattey.netlify.com/*"
 to = "https://dylangattey.com/:splat"
 status = 301
 force = true
+[[redirects]]
+from = "https://dylangattey.com/projects/fppdx/"
+to = "/404/index.html"
+status = 404
+force = false
+[[redirects]]
+from = "https://dylangattey.com/projects/connected-car-citizen/"
+to = "/404/index.html"
+status = 404
+force = false
+[[redirects]]
+from = "https://dylangattey.com/projects/synergy-womens-health-care/"
+to = "/404/index.html"
+status = 404
+force = false


### PR DESCRIPTION
Uses Netlify redirect file to block access to all the project files except Groups so that you can't stumble across them by accident.