### PR TITLE
Moves 404 file to head of site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -70,7 +70,7 @@ workbox:
     - "assets/*.{js,css,svg,json}"
     - index.html
     - about/index.html
-    - /404/index.html
+    - /404.html
     - /offline/index.html
 
 # Sitemap config - excludes google analytics html file

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,16 +5,16 @@ status = 301
 force = true
 [[redirects]]
 from = "https://dylangattey.com/projects/fppdx/"
-to = "/404/index.html"
+to = "/404.html"
 status = 404
 force = false
 [[redirects]]
 from = "https://dylangattey.com/projects/connected-car-citizen/"
-to = "/404/index.html"
+to = "/404.html"
 status = 404
 force = false
 [[redirects]]
 from = "https://dylangattey.com/projects/synergy-womens-health-care/"
-to = "/404/index.html"
+to = "/404.html"
 status = 404
 force = false

--- a/src/.htaccess
+++ b/src/.htaccess
@@ -258,7 +258,7 @@ Header set Cache-Control "max-age=0, no-cache"
 # https://httpd.apache.org/docs/current/mod/core.html#errordocument
 ####################
 
-ErrorDocument 404 /error-pages/404.html
+ErrorDocument 404 /404.html
 
 # Disable the pattern matching based on filenames.
 #

--- a/src/404.html
+++ b/src/404.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Whoops!
+permalink: 404.html
 ---
 <div class="error">
 	<h1 class="title emphasized">404</h1>


### PR DESCRIPTION
Netlify requires all 404 files to be at 404.html at the head. This commit makes that so in order to get a custom error page across the site. Fixes one task on #27.