### PR TITLE
Properly applies sticky header (regression)

### DIFF
--- a/src/_assets/javascript/sticky-header.js
+++ b/src/_assets/javascript/sticky-header.js
@@ -10,5 +10,5 @@ var addOrRemoveClass = function() {
 	}
 }
 // On scroll and load, add the class specified
-window.addEventListener('scroll', addOrRemoveClass());
-window.addEventListener('load', addOrRemoveClass());
+window.addEventListener('scroll', addOrRemoveClass);
+window.addEventListener('load', addOrRemoveClass);


### PR DESCRIPTION
Somehow, sticky header wasn't getting added properly - the functions were called rather than simply referenced. Now called correctly. Fixes #42 and adds to #6.