### PR TITLE
Allows self in connect-src for CSP

### DIFF
--- a/src/_data/content-security.yml
+++ b/src/_data/content-security.yml
@@ -1,13 +1,13 @@
 default-src:
   - &self "'self'"
-  - &netlify-cdn https://d33wubrfki0l68.cloudfront.net/
   - &netlify https://dgattey.netlify.com/
+  - &netlify-cdn https://d33wubrfki0l68.cloudfront.net/
 img-src:
   - *self
   - *netlify
   - *netlify-cdn
-  - &google-analytics https://www.google-analytics.com
-  - https://google-analytics.com
+  - &google-analytics https://google-analytics.com
+  - &google-analytics-www https://www.google-analytics.com
   - https://www.google.com/ads/
   - https://stats.g.doubleclick.net/
 script-src:
@@ -15,26 +15,28 @@ script-src:
   - *netlify
   - *netlify-cdn
   - *google-analytics
-  - https://google-analytics.com
+  - *google-analytics-www
   - "'sha256-AP5dd2QsbU3QOEJPw+ytEwxizO0kXXheCb4T/H9jz4I='"
   - "'sha256-E0EZj2xhUMF2eiGjBZ7EEtOpOdVx9Ia2ykjanm799ww='"
   # If async google fonts is on, this is it
   #- "'sha256-xXkeCOd4qqYaG8F+aZPKXacPfCWyAHihzqN9OqgGAds='"
 connect-src:
+  - *self
   - *netlify
   - *netlify-cdn
-  - https://www.google-analytics.com
+  - *google-analytics
+  - *google-analytics-www
 style-src:
   - *self
   - *netlify
   - *netlify-cdn
-  - https://use.typekit.net/
+  - &typekit https://use.typekit.net/
   - https://p.typekit.net/
 font-src:
   - *self
   - *netlify
   - *netlify-cdn
-  - https://use.typekit.net/
+  - *typekit
 manifest-src:
   - *self
   - *netlify

--- a/src/robots.txt
+++ b/src/robots.txt
@@ -1,3 +1,2 @@
 User-agent: *
 Disallow:
-Sitemap: /sitemap.xml


### PR DESCRIPTION
robots.txt was inaccessible to Lighthouse since `connect-src` for Content Security Policy didn't include `self`. It now does! Also reorganized the file a bit & removed an invalid sitemap declaration from robots.txt itself. Only Google and Bing supported it, and they already know the site.

Fixes #13 :tada: