### PR TITLE
Improving sitemap generation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,9 @@ source "https://rubygems.org"
 
 group :jekyll_plugins do
     # Experience
-    gem 'jekyll'                # This one's obvious
-    gem 'rouge'                 # Highlighter of code
+    gem 'jekyll'                    # This one's obvious
+    gem 'rouge'                     # Highlighter of code
+    gem 'jekyll-last-modified-at'   # Better last modified date
 
     # Services & Integrations
     gem 'jekyll-analytics'      # Google Analytics built in

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,6 +55,9 @@ GEM
       nokogiri (~> 1.8)
       pathutil (~> 0.16)
       sprockets (>= 3.3, < 4.1.beta)
+    jekyll-last-modified-at (1.0.1)
+      jekyll (~> 3.3)
+      posix-spawn (~> 0.3.9)
     jekyll-minifier (0.1.10)
       cssminify2 (~> 2.0)
       htmlcompressor (~> 0.4)
@@ -94,6 +97,7 @@ GEM
       sass (~> 3.3)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
+    posix-spawn (0.3.13)
     public_suffix (3.0.3)
     rack (2.0.6)
     rb-fsevent (0.10.3)
@@ -125,6 +129,7 @@ DEPENDENCIES
   jekyll
   jekyll-analytics
   jekyll-assets
+  jekyll-last-modified-at
   jekyll-minifier
   jekyll-seo-tag
   jekyll-sitemap

--- a/_config.yml
+++ b/_config.yml
@@ -76,14 +76,6 @@ workbox:
     - /404.html
     - /offline/index.html
 
-# Sitemap config - excludes google analytics html file
-defaults:
-  -
-    scope:
-      path: "google*.html"
-    values:
-      sitemap:  false
-
 # Build settings
 markdown: kramdown
 source: src

--- a/src/404.html
+++ b/src/404.html
@@ -2,6 +2,7 @@
 layout: default
 title: Whoops!
 permalink: 404.html
+sitemap: false
 ---
 <div class="error">
 	<h1 class="title emphasized">404</h1>

--- a/src/_posts/2013-06-18-fppdx.markdown
+++ b/src/_posts/2013-06-18-fppdx.markdown
@@ -5,5 +5,6 @@ identifier: fppdx
 type: "iOS App"
 description: "An iOS app for exploring the great outdoors of Portland"
 link: https://www.forestparkconservancy.org/forest-park/
+sitemap: false
 ---
 

--- a/src/_posts/2013-07-17-synergy-womens-health-care.markdown
+++ b/src/_posts/2013-07-17-synergy-womens-health-care.markdown
@@ -4,6 +4,6 @@ title:  "Synergy Women's Health Care"
 identifier: swhc
 type: "Website + Brand"
 description: "A new office for women's health needs a clean, welcoming website"
-thumb: synergy.jpg
 link: https://synergypdx.com
+sitemap: false
 ---

--- a/src/_posts/2014-09-01-connected-car-citizen.markdown
+++ b/src/_posts/2014-09-01-connected-car-citizen.markdown
@@ -5,4 +5,5 @@ identifier: "connected"
 type: "Javascript App"
 description: "A visualization of the future of the connected car"
 link: https://studio.ey.com/studios/portland/
+sitemap: false
 ---

--- a/src/googlefca82d08613257ba.html
+++ b/src/googlefca82d08613257ba.html
@@ -1,1 +1,5 @@
+---
+sitemap: false
+permalink: googlefca82d08613257ba.html
+---
 google-site-verification: googlefca82d08613257ba.html

--- a/src/offline.html
+++ b/src/offline.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Offline
+sitemap: false
 ---
 <div class="offline">
 	<h1 class="title emphasized">You're offline!</h1>


### PR DESCRIPTION
Fixes #47 by hiding the non-visible posts from the sitemap. Additional fixes:

- Improves the last modified date for the files themselves by adding a new plugin
- Removes need for globbing by moving sitemap annotations to front matter of a page (cleans up build logs!)
- Also hides 404 and offline pages from sitemap