### PR TITLE
 Switching to include_cached for Jekyll build speed improvements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,4 +25,5 @@ group :jekyll_plugins do
     # Dev Environment
     gem 'hawkins'               # Live reload
     gem 'kramdown'              # Markdown support
+    gem 'jekyll-include-cache'  # Allows for caching of includes
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
-    autoprefixer-rails (9.4.6)
+    autoprefixer-rails (9.4.7)
       execjs
     colorator (1.1.0)
     concurrent-ruby (1.1.4)
@@ -55,6 +55,8 @@ GEM
       nokogiri (~> 1.8)
       pathutil (~> 0.16)
       sprockets (>= 3.3, < 4.1.beta)
+    jekyll-include-cache (0.1.0)
+      jekyll (~> 3.3)
     jekyll-minifier (0.1.10)
       cssminify2 (~> 2.0)
       htmlcompressor (~> 0.4)
@@ -125,6 +127,7 @@ DEPENDENCIES
   jekyll
   jekyll-analytics
   jekyll-assets
+  jekyll-include-cache
   jekyll-minifier
   jekyll-seo-tag
   jekyll-sitemap

--- a/src/_includes/footer.html
+++ b/src/_includes/footer.html
@@ -6,7 +6,7 @@
     </li>
 
     <li>
-      <a class="icon" href="https://github.com/{{site.github}}" aria-label="Link to Github">{% include icon-github.svg %}</a>
+      <a class="icon" href="https://github.com/{{site.github}}" aria-label="Link to Github">{% include_cached icon-github.svg %}</a>
     </li>
 
     <li>

--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -3,7 +3,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <meta http-equiv="x-ua-compatible" content="ie=edge">
-  {% include content-security.html %}
+  {% include_cached content-security.html %}
   <base href={{ site.url }}>
 
   <!-- PWA/Mobile -->
@@ -19,7 +19,7 @@
   {% endif %}
   <link rel="manifest" href="/manifest.json">
   {% asset main.scss !integrity %}
-  {% include favicons.html %}
+  {% include_cached favicons.html %}
 
   <!-- SEO -->
   {% seo %}

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -11,11 +11,11 @@
 	</div>
 
 	<!-- Footer of page -->
-	{% include footer.html %}
+	{% include_cached footer.html %}
 
 	<!-- Service worker, font loader, & sticky header -->
-	{% include service-worker.html %}
-	{% include font-loader.html %}
+	{% include_cached service-worker.html %}
+	{% include_cached font-loader.html %}
 	{% asset sticky-header.js async %}
 </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -3,5 +3,5 @@ layout: default
 title: Projects
 weight: 0
 ---
-{% include intro.html %}
-{% include proj-grid.html %}
+{% include_cached intro.html %}
+{% include_cached proj-grid.html %}


### PR DESCRIPTION
Installed a new plugin that lets us cache built `{ % include x.html %}` templates. To use, we can specify `{% include_cached x.html %}` instead, and it'll reuse it everywhere. Can't use on `head.html` or `nav.html` since those are dynamic based on the page. Keep that in mind when using it.