### PR TITLE
Background cover images element size respected again

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -55,7 +55,7 @@
 	Referrer-Policy = "no-referrer"
 
 	# Feature policies
-	Feature-Policy = "unsized-media 'none'; sync-xhr 'none'; unoptimized-images 'none'"
+	Feature-Policy = "sync-xhr 'none'; unoptimized-images 'none'"
 
 	# Expect-CT to report uri
 	Expect-CT = "max-age=0, report-uri=\"https://dgattey.report-uri.com/r/d/ct/reportOnly\""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Oops, adding the Feature-Policy of `unsized-media 'none';` meant that the intro image was totally off. Squished in Chrome when experimental flags was on. Undoing that policy.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See above!

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Kept the feature flag on and tried to see what the image looked like.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
