### PR TITLE
Optimizes service worker & more aggressively uses cache

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ group :jekyll_plugins do
   gem 'jekyll-analytics'        # Google Analytics built in
   gem 'jekyll-assets'           # Asset management
   gem 'jekyll-last-modified-at' # Better last modified date
-  gem 'jekyll-minifier'         # Minifies everything
   gem 'jekyll-seo-tag'          # Generated SEO (title, canonical url, etc)
   gem 'jekyll-sitemap'          # Generated Sitemap
   gem 'jekyll-workbox-plugin'   # Google Workbox service worker

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,6 @@ GEM
       execjs
     colorator (1.1.0)
     concurrent-ruby (1.1.4)
-    cssminify2 (2.0.1)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
@@ -26,7 +25,6 @@ GEM
     hawkins (2.0.5)
       em-websocket (~> 0.5)
       jekyll (~> 3.1)
-    htmlcompressor (0.4.0)
     http_parser.rb (0.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
@@ -58,12 +56,6 @@ GEM
     jekyll-last-modified-at (1.0.1)
       jekyll (~> 3.3)
       posix-spawn (~> 0.3.9)
-    jekyll-minifier (0.1.10)
-      cssminify2 (~> 2.0)
-      htmlcompressor (~> 0.4)
-      jekyll (>= 3.5)
-      json-minify (~> 0.0.3)
-      uglifier (~> 4.1)
     jekyll-sanity (1.2.0)
       jekyll (~> 3.1)
     jekyll-sass-converter (1.5.2)
@@ -75,9 +67,6 @@ GEM
     jekyll-watch (2.1.2)
       listen (~> 3.0)
     jekyll-workbox-plugin (0.0.2)
-    json (2.1.0)
-    json-minify (0.0.3)
-      json (> 0)
     kramdown (1.17.0)
     liquid (4.0.1)
     liquid-tag-parser (1.9.0)
@@ -117,8 +106,6 @@ GEM
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    uglifier (4.1.20)
-      execjs (>= 0.3.0, < 3)
 
 PLATFORMS
   ruby
@@ -130,7 +117,6 @@ DEPENDENCIES
   jekyll-analytics
   jekyll-assets
   jekyll-last-modified-at
-  jekyll-minifier
   jekyll-seo-tag
   jekyll-sitemap
   jekyll-workbox-plugin
@@ -140,4 +126,4 @@ DEPENDENCIES
   rouge
 
 BUNDLED WITH
-   1.17.3
+   1.16.6

--- a/_config.yml
+++ b/_config.yml
@@ -61,11 +61,6 @@ favicons:
   ios: [120, 152, 180]
   windows: [144]
   thumbnail: [152]
-jekyll-minifier:
-  # Because Google Analytics is already minified, we
-  # must disable Uglify cause it doesn't play well
-  # with an already minified script :(
-  compress_javascript: false
 
 # Workbox settings for Service worker
 workbox:
@@ -90,7 +85,6 @@ sass:
 
 # Plugins
 plugins:
-  - jekyll-minifier
   - jekyll-sitemap
   - jekyll-analytics
   - jekyll-seo-tag

--- a/_config.yml
+++ b/_config.yml
@@ -71,10 +71,9 @@ jekyll-minifier:
 workbox:
   precache_glob_directory: /
   precache_glob_patterns:
-    - 'index.html': ['/', 'projects/']
-    - 'about/index.html': about/
-    - /404.html
+    - 'index.html': '/'
     - /offline.html
+    - favicon.ico
 
 # Build settings
 markdown: kramdown

--- a/src/sw.js
+++ b/src/sw.js
@@ -10,7 +10,6 @@
  */
 const staticCacheName = "static",
 	imageCacheName = "images",
-	analyticsCacheName = "google-analytics",
 	offlinePage = "/offline.html";
 
 workbox.core.setCacheNameDetails({
@@ -38,14 +37,6 @@ self.addEventListener("controllerchange", refreshWindow);
  * Enables navigation preload which we use in our default handler
  */
 workbox.navigationPreload.enable();
-
-/**
- * Google Analytics
- * - Now available while offline! It'll send when back online
- */
-workbox.googleAnalytics.initialize({
-	cacheName: analyticsCacheName
-});
 
 /**
  * Precaching all the things!

--- a/src/sw.js
+++ b/src/sw.js
@@ -55,6 +55,19 @@ workbox.precaching.precacheAndRoute([]);
  * - Cache js, css, and json for an hour
  * - Cache up to 60 images for 30 days
  */
+
+const vendorRouteConfiguration = {
+	cacheName: vendorCacheName,
+	plugins: [
+		new workbox.cacheableResponse.Plugin({
+			statuses: [0, 200],
+		}),
+		new workbox.expiration.Plugin({
+			maxAgeSeconds: 60 * 60 * 24 * 120,
+		}),
+	],
+};
+
 workbox.routing.registerRoute(
 	/404.html/,
 	workbox.strategies.networkOnly()
@@ -69,32 +82,11 @@ workbox.routing.registerRoute(
 );
 workbox.routing.registerRoute(
 	/^https?:\/\/.*.typekit\.net\/af/,
-	workbox.strategies.cacheFirst({
-		cacheName: vendorCacheName,
-		plugins: [
-			new workbox.cacheableResponse.Plugin({
-				statuses: [0, 200],
-			}),
-			new workbox.expiration.Plugin({
-				maxAgeSeconds: 60 * 60 * 24 * 120,
-			}),
-		],
-	})
+	workbox.strategies.cacheFirst(vendorRouteConfiguration)
 );
 workbox.routing.registerRoute(
 	/^https?:\/\/.*.typekit\.net/,
-	workbox.strategies.cacheFirst({
-		cacheName: vendorCacheName,
-		plugins: [
-			new workbox.cacheableResponse.Plugin({
-				statuses: [0, 200],
-			}),
-			new workbox.expiration.Plugin({
-				maxAgeSeconds: 60 * 60,
-			}),
-
-		],
-	})
+	workbox.strategies.cacheFirst(vendorRouteConfiguration)
 );
 workbox.routing.registerRoute(
 	/.*\.(?:js|css|json)$/,

--- a/src/sw.js
+++ b/src/sw.js
@@ -51,8 +51,8 @@ workbox.precaching.precacheAndRoute([]);
  * - Force 404 page to network only since we don't need it offline
  * - Force all analytics calls to network only
  * - Cache the actual font files (use.typekit.net/af) for 120 days
- * - State while revalidate for fonts stylesheets
- * - Stale while revalidate for js, css, and json
+ * - Cache fonts stylesheets for an hour
+ * - Cache js, css, and json for an hour
  * - Cache up to 60 images for 30 days
  */
 workbox.routing.registerRoute(
@@ -83,23 +83,32 @@ workbox.routing.registerRoute(
 );
 workbox.routing.registerRoute(
 	/^https?:\/\/.*.typekit\.net/,
-	workbox.strategies.staleWhileRevalidate({
+	workbox.strategies.cacheFirst({
 		cacheName: vendorCacheName,
 		plugins: [
 			new workbox.cacheableResponse.Plugin({
 				statuses: [0, 200],
 			}),
+			new workbox.expiration.Plugin({
+				maxAgeSeconds: 60 * 60,
+			}),
+
 		],
 	})
 );
 workbox.routing.registerRoute(
 	/.*\.(?:js|css|json)$/,
-	workbox.strategies.staleWhileRevalidate({
-		cacheName: staticCacheName
+	workbox.strategies.cacheFirst({
+		cacheName: staticCacheName,
+		plugins: [
+			new workbox.expiration.Plugin({
+				maxAgeSeconds: 60 * 60,
+			}),
+		]
 	})
 );
 workbox.routing.registerRoute(
-	/\.(?:png|gif|jpg|jpeg|svg|webp)$/,
+	/\.(?:png|gif|jpg|jpeg|svg|webp|ico)$/,
 	workbox.strategies.cacheFirst({
 		cacheName: imageCacheName,
 		plugins: [


### PR DESCRIPTION
# Description
This pull request finally fixes the infinitely growing cache issue, while adding more conservative caching techniques, saving the user some bandwidth and making subsequent page loads faster.
- Makes sure we don't cache ANYTHING Google Analytics: fixes #12 !
- Switches to cacheFirst with 1 hour timeouts for all js/css/etc to save user bandwidth and fixes #89
- Separated fonts to a vendor cache
- Never caches the 404 page since we don't need that offline and fixes #90
- Kills jekyll-minifier since it's not doing anything useful with all the minification from Netlify and fixes #83 
- Removes dead Google Analytics service worker init code since we're doing everything online
<!--- Describe your changes in detail -->

## Motivation and context
It makes sure that 
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to the open issue this PR solves -->

## Testing for this change

<!--- Please describe in detail how you tested your changes. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply -->

- [x] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing
  functionality to change)
