### PR TITLE
Adds cache control headers for TypeKit and Google Analytics

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -50,6 +50,23 @@
 	[headers.values]
 		Cache-Control = "no-cache"
 
+# Cache Typekit CSS for 1 day, fonts for 120 days
+[[headers]]
+	for = "https://use.typekit.net/*.css"
+	[headers.values]
+		Cache-Control = "max-age=86400, public"
+[[headers]]
+	for = "https://use.typekit.net/af/*"
+	[headers.values]
+		Cache-Control = "max-age=10368000, public"
+
+# Cache Google Analytics for 1 day
+[[headers]]
+	for = "https://www.google-analytics.com/*"
+	[headers.values]
+		Cache-Control = "max-age=86400, public"
+
+# Everything else
 [[headers]]
 	for = "/*"
 	[headers.values]

--- a/src/sw.js
+++ b/src/sw.js
@@ -56,14 +56,14 @@ workbox.precaching.precacheAndRoute([]);
  * - Cache up to 60 images for 30 days
  */
 
-const vendorRouteConfiguration = {
+const vendorRouteConfiguration = function(hours) {
 	cacheName: vendorCacheName,
 	plugins: [
 		new workbox.cacheableResponse.Plugin({
 			statuses: [0, 200],
 		}),
 		new workbox.expiration.Plugin({
-			maxAgeSeconds: 60 * 60 * 24 * 120,
+			maxAgeSeconds: 60 * hours,
 		}),
 	],
 };
@@ -82,11 +82,11 @@ workbox.routing.registerRoute(
 );
 workbox.routing.registerRoute(
 	/^https?:\/\/.*.typekit\.net\/af/,
-	workbox.strategies.cacheFirst(vendorRouteConfiguration)
+	workbox.strategies.cacheFirst(vendorRouteConfiguration(60 * 120))
 );
 workbox.routing.registerRoute(
 	/^https?:\/\/.*.typekit\.net/,
-	workbox.strategies.cacheFirst(vendorRouteConfiguration)
+	workbox.strategies.cacheFirst(vendorRouteConfiguration(60))
 );
 workbox.routing.registerRoute(
 	/.*\.(?:js|css|json)$/,


### PR DESCRIPTION
# Description
Adds Cache-Control headers for Typekit (120 days for fonts, 1 day for CSS) and Google Analytics (1 day). Fixes #20.
<!--- Describe your changes in detail -->

## Motivation and context
Lighthouse reported on this - need longer cache headers to solve. Better for the user too!
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to the open issue this PR solves -->

## Testing for this change
Will do on deploy preview & webpagetest
<!--- Please describe in detail how you tested your changes. -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply -->

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing
  functionality to change)
