### PR TITLE
Disables liveserve (incompatible with service worker)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ source 'https://rubygems.org'
 
 group :jekyll_plugins do
   gem 'autoprefixer-rails'      # Autoprefixes css
-  gem 'hawkins'                 # Live reload
   gem 'jekyll'                  # This one's obvious
   gem 'jekyll-analytics'        # Google Analytics built in
   gem 'jekyll-assets'           # Asset management

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,9 +23,6 @@ GEM
     fastimage (2.1.5)
     ffi (1.10.0)
     forwardable-extended (2.6.0)
-    hawkins (2.0.5)
-      em-websocket (~> 0.5)
-      jekyll (~> 3.1)
     htmlcompressor (0.4.0)
     http_parser.rb (0.6.0)
     i18n (0.9.5)
@@ -125,7 +122,6 @@ PLATFORMS
 
 DEPENDENCIES
   autoprefixer-rails
-  hawkins
   jekyll
   jekyll-analytics
   jekyll-assets

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ to install the following:
 1. Install the necessary gems with `bundle install`
 1. Build & serve the site with `bundle exec jekyll serve`
 
-If you want autoreload, use `bundle exec jekyll liveserve`. The site files will
-live in `build` and be served on `http://localhost:4000/`.
+The site files will live in `build` and be served on
+`http://localhost:4000/`.
 
 ### Adding a new dependency
 


### PR DESCRIPTION
# Description
Disables Hawkins (liveserve library) since it wasn't working correctly with `jekyll-assets` + service worker. 
<!--- Describe your changes in detail -->

## Motivation and context
Livereload doesn't work right with Hawkins, so I'm removing it totally
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to the open issue this PR solves -->

## Testing for this change
Yea, manual
<!--- Please describe in detail how you tested your changes. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply -->

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [x] Breaking change (fix or feature that would cause existing
  functionality to change)
