### PR TITLE
Removes hardcoded front-matter titles in favor of Markdown # headings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,17 +4,19 @@
 source 'https://rubygems.org'
 
 group :jekyll_plugins do
-  gem 'autoprefixer-rails'      # Autoprefixes css
-  gem 'jekyll'                  # This one's obvious
-  gem 'jekyll-analytics'        # Google Analytics built in
-  gem 'jekyll-assets'           # Asset management
-  gem 'jekyll-last-modified-at' # Better last modified date
-  gem 'jekyll-minifier'         # Minifies JS
-  gem 'jekyll-seo-tag'          # Generated SEO (title, canonical url, etc)
-  gem 'jekyll-sitemap'          # Generated Sitemap
-  gem 'jekyll-workbox-plugin'   # Google Workbox service worker
-  gem 'kramdown'                # Markdown support
-  gem 'mini_magick'             # Image conversion
-  gem 'normalize-scss'          # Normalizes the scss
-  gem 'rouge'                   # Highlighter of code
+  gem 'autoprefixer-rails'            # Autoprefixes css
+  gem 'jekyll'                        # Gotta have it!
+  gem 'jekyll-analytics'              # Integrates Google Analytics
+  gem 'jekyll-assets'                 # Asset + cache pipeline
+  gem 'jekyll-last-modified-at'       # Smarter last modified date
+  gem 'jekyll-minifier'               # Minifies JS/JSON/etc
+  gem 'jekyll-optional-front-matter'  # Doesn't force you to include FM
+  gem 'jekyll-seo-tag'                # Generates SEO <head> content
+  gem 'jekyll-sitemap'                # Generates Sitemap XML
+  gem 'jekyll-titles-from-headings'   # Infers title from heading
+  gem 'jekyll-workbox-plugin'         # Google Workbox service worker
+  gem 'kramdown'                      # Translates Markdown to HTML
+  gem 'mini_magick'                   # Automated image conversion
+  gem 'normalize-scss'                # Port of normalize.css to SCSS
+  gem 'rouge'                         # Highlights code in HTML
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,8 @@ GEM
       jekyll (~> 3.3)
     jekyll-sitemap (1.2.0)
       jekyll (~> 3.3)
+    jekyll-titles-from-headings (0.5.1)
+      jekyll (~> 3.3)
     jekyll-watch (2.1.2)
       listen (~> 3.0)
     jekyll-workbox-plugin (0.0.2)
@@ -129,6 +131,7 @@ DEPENDENCIES
   jekyll-minifier
   jekyll-seo-tag
   jekyll-sitemap
+  jekyll-titles-from-headings
   jekyll-workbox-plugin
   kramdown
   mini_magick

--- a/_config.yml
+++ b/_config.yml
@@ -71,6 +71,11 @@ workbox:
     - /offline.html
     - favicon.ico
 
+# For auto-inferring post titles
+titles_from_headings:
+  strip_title: true
+  collections: true
+
 # Compression settings for the HTML
 compress_html:
   clippings: all

--- a/src/_posts/2013-06-18-forest-park-pdx.md
+++ b/src/_posts/2013-06-18-forest-park-pdx.md
@@ -1,9 +1,10 @@
 ---
 layout: post
-title: Forest Park PDX
 type: iOS App + Website
 description: Making Portland's great outdoor sights more accessible
 color: green
 link: https://www.forestparkconservancy.org/forest-park/
 sitemap: false
 ---
+
+# Forest Park PDX

--- a/src/_posts/2013-07-17-synergy-womens-health-care.md
+++ b/src/_posts/2013-07-17-synergy-womens-health-care.md
@@ -1,9 +1,10 @@
 ---
 layout: post
-title: Synergy Women's Health Care
 type: Website + Brand
 description: Streamlining and encouraging access to quality care
 color: blue
 link: https://synergypdx.com
 sitemap: false
 ---
+
+# Synergy Women's Health Care

--- a/src/_posts/2014-09-01-connected-car-citizen.md
+++ b/src/_posts/2014-09-01-connected-car-citizen.md
@@ -1,9 +1,10 @@
 ---
 layout: post
-title: Connected
 type: Node.js App
 description: Visualizing the future of the connected car ecosystem
 color: muted
 link: https://studio.ey.com/studios/portland/
 sitemap: false
 ---
+
+# Connected

--- a/src/_posts/2016-04-18-linkedin-groups.md
+++ b/src/_posts/2016-04-18-linkedin-groups.md
@@ -1,10 +1,12 @@
 ---
 layout: post
-title: LinkedIn Groups
 type: iOS App
 description: Connecting and empowering the world's professionals
 color: red
 ---
+
+# LinkedIn Groups
+
 <section>
 <p class="emphasized">As an intern at LinkedIn, I helped craft LinkedIn Groups
 2.0 for iOS. Interface "delights" to make Groups smooth and attractive were

--- a/src/about.md
+++ b/src/about.md
@@ -1,7 +1,8 @@
 ---
 layout: page
-title: About
-permalink: /about/
 weight: 2
 ---
+
+# About
+
 Find me on [LinkedIn](https://www.linkedin.com/in/dgattey/)! More coming soon.


### PR DESCRIPTION
# Description
Adds `jekyll-optional-front-matter` and `jekyll-titles-from-headings` to make the title tag in front-matter totally optional & for Jekyll to use the # heading from the page itself.
<!--- Describe your changes in detail -->

## Motivation and context
Fixes #121 
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to the open issue this PR solves -->

## Testing for this change
Manually confirmed no pages are different
<!--- Please describe in detail how you tested your changes. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply -->

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing
  functionality to change)
