### PR TITLE
Revamps colors to use utility CSS

### DIFF
--- a/src/_assets/components/_footer.scss
+++ b/src/_assets/components/_footer.scss
@@ -7,7 +7,6 @@ footer {
   $height: $icon-size;
   $padding: $height / 2;
 
-  border-top: $border-weight solid $color-primary-dim;
   margin-top: $item-spacing-3;
 
   .copy,
@@ -30,18 +29,10 @@ footer {
     padding: 0 $padding;
   }
 
-  &:hover > path {
-    fill: $color-primary-dim;
-  }
-
   .icon-github {
     display: inline-block;
     height: $icon-size;
     vertical-align: middle;
     width: $icon-size;
-  }
-
-  path {
-    fill: $color-primary-bright;
   }
 }

--- a/src/_assets/components/_nav.scss
+++ b/src/_assets/components/_nav.scss
@@ -15,6 +15,4 @@ nav {
 
 .nav-items {
   @extend %nav-padding;
-
-  background: $color-bg;
 }

--- a/src/_assets/components/_project-card.scss
+++ b/src/_assets/components/_project-card.scss
@@ -11,7 +11,6 @@
   $scale-up-hover: 1.06;
 
   align-content: space-around;
-  color: $color-brightest;
 
   @include for-tablet-up {
     &:nth-child(2) {
@@ -20,14 +19,8 @@
   }
 
   &:hover {
-    color: $color-brightest;
-
     .card-component-on-hover-scale-up {
       transform: scale($scale-up-hover);
-    }
-
-    .card-component-on-hover-pull-right {
-      transform: translateX($item-spacing-3);
     }
   }
 }

--- a/src/_assets/css/_animations.scss
+++ b/src/_assets/css/_animations.scss
@@ -20,7 +20,7 @@ $scale-down-hover: .96;
 }
 
 // Adds support for adding multiple types of transitions, with out-back timing function
-@mixin transition-shadow-transform($properties...) {
+@mixin transition-bouncy($properties...) {
   $final: ();
 
   @each $item in $properties {
@@ -31,11 +31,15 @@ $scale-down-hover: .96;
 }
 
 .transition-shadow-transform {
-  @include transition-shadow-transform(box-shadow, transform);
+  @include transition-bouncy(box-shadow, transform);
+}
+
+.transition-color-shadow-transform {
+  @include transition-bouncy(color, box-shadow, transform);
 }
 
 .transition-color-transform {
-  @include transition-shadow-transform(color, transform);
+  @include transition-bouncy(color, transform);
 }
 
 .transition-quick-shadow {

--- a/src/_assets/css/_colors.scss
+++ b/src/_assets/css/_colors.scss
@@ -1,49 +1,130 @@
 // =====
-// Colors
+// Raw colors
 // =====
 
-// Raw white - black color values
-$color-dim: #000;
-$color-deep: #433d3a;
-$color-muted: lighten($color-deep, 12%);
-$color-bright: #eceff1;
-$color-brightest: #fff;
+// Some of this isn't expressable via pure CSS so
+// there's going to be some SASS variables here
 
-// Colorful raw color values
-$color-green: #16ac7e;
-$color-forest-green: #015500;
-$color-red: #bb2821;
-$color-blue: #237fad;
-
-// Applied color values (primary, bg, border, text)
-$color-primary-bright: $color-green;
-$color-primary-dim: darken($color-primary-bright, 12%);
-
-$color-bg: $color-brightest;
-
-$color-text-dark: $color-deep;
-$color-text-muted: $color-muted;
-$color-text-light: $color-bright;
-$color-text-active: $color-primary-dim;
-
-$color-link: $color-primary-bright;
-$color-link-hover: $color-primary-dim;
-$color-link-focus: $color-blue;
-
-$background-colors: (
-  'red': $color-red,
-  'green': $color-green,
-  'blue': $color-blue,
-  'dim': $color-dim,
-  'forest-green': $color-forest-green
+$colors: (
+  dim: #000,
+  deep: #433d3a,
+  bright: #eceff1,
+  brightest: #fff,
+  aquagreen: #16ac7e,
+  forest: #015500,
+  wine: #bb2821,
+  sky: #237fad
 );
 
-@each $name, $color in $background-colors {
-  .background-#{$name} {
-    background-color: $color;
+:root {
+  @each $name, $color in $colors {
+    --color-#{$name}: #{$color};
+  }
+
+  // These can't be expressable via the map above, so doing it here
+
+  --color-muted: #{lighten(map-get($colors, deep), 12%)};
+  --color-aquagreen-dark: #{darken(map-get($colors, aquagreen), 12%)};
+  --color-aquagreen-light: #{lighten(map-get($colors, aquagreen), 12%)};
+}
+
+// =====
+// Background colors
+// =====
+
+.background-default {
+  background: var(--color-background);
+}
+
+.background-red {
+  background-color: var(--color-wine);
+}
+
+.background-green {
+  background-color: var(--color-aquagreen);
+}
+
+.background-blue {
+  background-color: var(--color-sky);
+}
+
+.background-dim {
+  background-color: var(--color-dim);
+}
+
+.background-forest-green {
+  background-color: var(--color-forest);
+}
+
+// =====
+// Color classes
+// =====
+
+.color-primary-bright {
+  color: var(--color-primary-bright);
+}
+
+.color-link-inverse {
+  color: var(--color-text-inverse);
+
+  &:hover,
+  &:focus {
+    color: var(--color-text-inverse-muted);
   }
 }
 
-.color-primary-bright {
-  color: $color-primary-bright;
+.color-link-reset {
+  color: var(--color-text);
+
+  &:hover,
+  &:focus {
+    color: var(--color-text);
+  }
+}
+
+// =====
+// Main elements
+// =====
+
+html {
+  color: var(--color-text);
+}
+
+a {
+  color: var(--color-primary-bright);
+
+  &:hover {
+    color: var(--color-secondary);
+  }
+
+  &:focus {
+    color: var(--color-tertiary);
+  }
+}
+
+::selection {
+  background: var(--color-secondary);
+  color: var(--color-text-inverse);
+}
+
+.highlight {
+  background-color: var(--color-background-secondary);
+}
+
+// =====
+// Theming classes - associates raw colors with variables
+// =====
+
+.theme-light {
+  @extend .background-default;
+
+  --color-primary-bright: var(--color-aquagreen);
+  --color-secondary: var(--color-aquagreen-dark);
+  --color-tertiary: var(--color-aquagreen-light);
+  --color-background: var(--color-brightest);
+  --color-background-secondary: var(--color-bright);
+  --color-text: var(--color-deep);
+  --color-text-muted: var(--color-muted);
+  --color-text-inverse: var(--color-brightest);
+  --color-text-inverse-muted: var(--color-bright);
 }

--- a/src/_assets/css/_colors.scss
+++ b/src/_assets/css/_colors.scss
@@ -11,7 +11,7 @@ $colors: (
   bright: #eceff1,
   brightest: #fff,
   aquagreen: #16ac7e,
-  forest: #015500,
+  forest: #006331,
   wine: #bb2821,
   sky: #237fad
 );
@@ -36,15 +36,11 @@ $colors: (
   background: var(--color-background);
 }
 
-.background-red {
+.background-wine {
   background-color: var(--color-wine);
 }
 
-.background-green {
-  background-color: var(--color-aquagreen);
-}
-
-.background-blue {
+.background-sky {
   background-color: var(--color-sky);
 }
 
@@ -52,7 +48,7 @@ $colors: (
   background-color: var(--color-dim);
 }
 
-.background-forest-green {
+.background-forest {
   background-color: var(--color-forest);
 }
 

--- a/src/_assets/css/_global.scss
+++ b/src/_assets/css/_global.scss
@@ -3,8 +3,6 @@
 // =====
 
 html {
-  background: $color-bg;
-  color: $color-text-dark;
   overflow-x: hidden;
 }
 
@@ -43,13 +41,4 @@ $tablet-top-padding: $item-spacing-4 + $item-spacing-3;
 
 @include for-desktop-up {
   @include page-body($item-spacing-5, $item-spacing-6);
-}
-
-// =====
-// Selection of anything
-// =====
-
-::selection {
-  background: $color-primary-dim;
-  color: $color-text-light;
 }

--- a/src/_assets/css/_links.scss
+++ b/src/_assets/css/_links.scss
@@ -32,20 +32,15 @@ a {
   background-image: linear-gradient(to bottom, currentColor 0%, currentColor 100%);
   background-position-y: 100%;
   background-repeat: repeat-x;
-  color: $color-link;
   display: inline-block;
   text-decoration: none;
 
   &:hover {
     @extend %link-underline-hovered;
-
-    color: $color-link-hover;
   }
 
   &:focus {
     @extend %link-underline-hovered;
-
-    color: $color-link-focus;
   }
 }
 
@@ -63,16 +58,5 @@ a {
   &:hover,
   &:focus {
     @extend %link-underline-hidden;
-  }
-}
-
-// Will still have translation on hover effect + underline,
-// but the link color will always be $color-text-dark
-
-.link-text-dark {
-  color: $color-text-dark;
-
-  &:hover {
-    color: $color-text-dark;
   }
 }

--- a/src/_assets/css/_shadows.scss
+++ b/src/_assets/css/_shadows.scss
@@ -2,6 +2,9 @@
 // Shadows
 // =====
 
+$strong-shadow-color: rgba(0, 0, 0, .15);
+$weak-shadow-color: rgba(0, 0, 0, .1);
+$spread: $item-spacing-4 + $item-spacing-3;
 $strong-shadow: 0 $item-spacing-3 $spread $strong-shadow-color;
 $weak-shadow: 0 $item-spacing-3 $spread $weak-shadow-color;
 

--- a/src/_assets/css/_syntax.scss
+++ b/src/_assets/css/_syntax.scss
@@ -31,7 +31,6 @@ $color-ffdddd: #fdd;
 $color-fff0f0: #fff0f0;
 
 .highlight {
-  background-color: $color-bright;
   border-radius: 1em;
   max-width: 64rem;
   padding: 1rem;

--- a/src/_assets/css/_utilities.scss
+++ b/src/_assets/css/_utilities.scss
@@ -1,13 +1,5 @@
 // =====
-// Mixins and extensions to be used globally
-// =====
-
-$strong-shadow-color: rgba(0, 0, 0, .15);
-$weak-shadow-color: rgba(0, 0, 0, .1);
-$spread: $item-spacing-4 + $item-spacing-3;
-
-// =====
-// Utility classes
+// Generic utility classes
 // =====
 
 .round-corners {

--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -22,9 +22,9 @@
 // Utility CSS
 @import 'global';
 @import 'grid';
-@import 'mixins';
 @import 'shadows';
 @import 'syntax';
+@import 'utilities';
 
 // Components
 @import 'footer';

--- a/src/_includes/nav.html
+++ b/src/_includes/nav.html
@@ -1,12 +1,12 @@
 <header class="global-nav fixed-header font-weight-bold transition-quick-shadow">
   <nav>
-    <ul class="nav-items grid grid-columns-standard grid-gap-5 grid-gap-3-desktop flush">
+    <ul class="nav-items background-default grid grid-columns-standard grid-gap-5 grid-gap-3-desktop flush">
       <li class="list-block grid-item-align-center font-size-1 flush-bottom"><a class="logo link-no-decoration scale-down-on-hover transition-color-transform" href="{{ site.baseurl }}/" aria-label="Homepage">dg.</a></li>
       {% assign sorted_pages = site.pages | sort:"weight" %}
       {% for nav_page in sorted_pages %}
       
       {% if page.url == nav_page.url %}
-      {% assign nav_class = 'link-no-decoration link-text-dark' %}
+      {% assign nav_class = 'link-no-decoration color-link-reset' %}
       {% else %}
       {% assign nav_class = 'link-underline-on-hover' %}
       {% endif %}

--- a/src/_includes/project-card-two-column.html
+++ b/src/_includes/project-card-two-column.html
@@ -3,7 +3,7 @@
 {% else %}
 {% assign postlink = post.url %}
 {% endif %}
-<a href="{{ postlink }}" class="link-no-decoration grid grid-column-gap-3 grid-span-rows-2-tablet project-card color-link-inverse round-corners shadow-strong shadow-weak-on-hover transition-color-shadow-transform scale-down-on-hover background-{{ post.color }}">
+<a href="{{ postlink }}" class="link-no-decoration grid grid-column-gap-3 grid-span-rows-2-tablet project-card color-link-inverse round-corners shadow-strong shadow-weak-on-hover transition-color-shadow-transform scale-down-on-hover background-{{ post.background }}">
     {% capture thumbnail_section %}
     <section class="transition-shadow-transform card-component-on-hover-scale-up {{ post.thumbnail.container_class }}">
         {% capture alttext %}{{ post.title }} thumbnail{% endcapture %}

--- a/src/_includes/project-card-two-column.html
+++ b/src/_includes/project-card-two-column.html
@@ -3,7 +3,7 @@
 {% else %}
 {% assign postlink = post.url %}
 {% endif %}
-<a href="{{ postlink }}" class="link-no-decoration grid grid-column-gap-3 grid-span-rows-2-tablet project-card round-corners shadow-strong shadow-weak-on-hover transition-shadow-transform scale-down-on-hover background-{{ post.color }}">
+<a href="{{ postlink }}" class="link-no-decoration grid grid-column-gap-3 grid-span-rows-2-tablet project-card color-link-inverse round-corners shadow-strong shadow-weak-on-hover transition-color-shadow-transform scale-down-on-hover background-{{ post.color }}">
     {% capture thumbnail_section %}
     <section class="transition-shadow-transform card-component-on-hover-scale-up {{ post.thumbnail.container_class }}">
         {% capture alttext %}{{ post.title }} thumbnail{% endcapture %}
@@ -15,11 +15,11 @@
 
     {% capture title_content %}
     <h3 class="font-size-9">{{ post.title }}</h3>
-    <h4 class="font-variant-heavy transition-shadow-transform card-component-on-hover-pull-right font-size-1">{{ post.type }}</h4>
+    <h4 class="font-variant-heavy transition-shadow-transform font-size-1">{{ post.type }}</h4>
     {% endcapture %}
 
     {% capture desc_content %}
-    <p class="transition-shadow-transform card-component-on-hover-pull-right">{{ post.description }}</p>
+    <p class="transition-shadow-transform">{{ post.description }}</p>
     {% endcapture %}
 
     {% capture data_section %}

--- a/src/_includes/project-card.html
+++ b/src/_includes/project-card.html
@@ -3,7 +3,7 @@
 {% else %}
 {% assign postlink = post.url %}
 {% endif %}
-<a href="{{ postlink }}" class="project-card color-link-inverse link-no-decoration grid grid-column-gap-3 grid-span-rows-2-tablet round-corners shadow-strong shadow-weak-on-hover transition-color-shadow-transform scale-down-on-hover background-{{ post.color }}">
+<a href="{{ postlink }}" class="project-card color-link-inverse link-no-decoration grid grid-column-gap-3 grid-span-rows-2-tablet round-corners shadow-strong shadow-weak-on-hover transition-color-shadow-transform scale-down-on-hover background-{{ post.background }}">
     <section class="grid grid-columns-2-1-desktop grid-align-center card">
         <h3 class="font-size-9">{{ post.title }}</h3>
         <h4 class="font-variant-heavy flush-top-tablet-down desktop-align-right font-size-1">{{ post.type }}</h4>

--- a/src/_includes/project-card.html
+++ b/src/_includes/project-card.html
@@ -3,12 +3,12 @@
 {% else %}
 {% assign postlink = post.url %}
 {% endif %}
-<a href="{{ postlink }}" class="project-card link-no-decoration grid grid-column-gap-3 grid-span-rows-2-tablet round-corners shadow-strong shadow-weak-on-hover transition-shadow-transform scale-down-on-hover background-{{ post.color }}">
+<a href="{{ postlink }}" class="project-card color-link-inverse link-no-decoration grid grid-column-gap-3 grid-span-rows-2-tablet round-corners shadow-strong shadow-weak-on-hover transition-color-shadow-transform scale-down-on-hover background-{{ post.color }}">
     <section class="grid grid-columns-2-1-desktop grid-align-center card">
         <h3 class="font-size-9">{{ post.title }}</h3>
         <h4 class="font-variant-heavy flush-top-tablet-down desktop-align-right font-size-1">{{ post.type }}</h4>
     </section>
-    <section class="card transition-shadow-transform card-component-on-hover-pull-right">
+    <section class="card transition-shadow-transform">
         <p>{{ post.description }}</p>
     </section>
     {% if post.thumbnail %}

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -3,7 +3,7 @@ layout: compress
 ---
 
 <!DOCTYPE html>
-<html lang="{{ site.lang }}">
+<html lang="{{ site.lang }}" class="theme-light">
 {% include head.html %}
 <body>
 	<!-- Navigation, content, footer -->

--- a/src/_posts/2013-06-18-forest-park-pdx.md
+++ b/src/_posts/2013-06-18-forest-park-pdx.md
@@ -2,7 +2,7 @@
 layout: post
 type: iOS App + Website
 description: Making Portland's great outdoor sights more accessible
-color: forest-green
+background: forest
 link: https://www.forestparkconservancy.org/forest-park/
 sitemap: false
 two_column: mirrored

--- a/src/_posts/2013-07-17-synergy-womens-health-care.md
+++ b/src/_posts/2013-07-17-synergy-womens-health-care.md
@@ -2,7 +2,7 @@
 layout: post
 type: Website + Brand
 description: Streamlining and encouraging access to quality care
-color: blue
+background: sky
 link: https://synergypdx.com
 sitemap: false
 thumbnail:

--- a/src/_posts/2014-09-01-connected-car-citizen.md
+++ b/src/_posts/2014-09-01-connected-car-citizen.md
@@ -2,7 +2,7 @@
 layout: post
 type: Node.js App
 description: Visualizing the future of the connected car ecosystem
-color: dim
+background: dim
 link: https://studio.ey.com/studios/portland/
 sitemap: false
 thumbnail:

--- a/src/_posts/2016-04-18-linkedin-groups.md
+++ b/src/_posts/2016-04-18-linkedin-groups.md
@@ -2,7 +2,7 @@
 layout: post
 type: iOS App
 description: Connecting and empowering the world's professionals
-color: red
+background: wine
 two_column: normal
 thumbnail:
   src: groups-thumb


### PR DESCRIPTION
# Description
Continues #147 with color changes for create utility CSS. Uses SASS maps of all raw colors for clarity, along with some nice changes to theming to make it clearer.
<!--- Describe your changes in detail -->

## Motivation and context
See #147 for more context about why this is useful - this moves all colors to one file, except for the syntax file (tackling that later).
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to the open issue this PR solves -->

## Testing for this change
Made sure all colors show up still
<!--- Please describe in detail how you tested your changes. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply -->

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing
  functionality to change)
