### PR TITLE
Vastly improves the purgecss plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Caches
 .sass-cache
 .jekyll-cache
-.tmp
+.purgecss
 
 # Temporary files
 *.swp

--- a/src/_plugins/hooks/purgecss.rb
+++ b/src/_plugins/hooks/purgecss.rb
@@ -1,29 +1,119 @@
 # frozen_string_literal: true
 
-@config_file = '.tmp/purgecss.js'
-@build_directory = '_site'
-@temp_directory = '.tmp'
+# Jekyll Assets runs async, so on post_write from standard
+# Jekyll hooks, we can't be sure that our assets are done writing.
+# We want to run purgecss on our CSS files only after they're
+# written out entirely. This plugin accomplishes that by hooking
+# into JekyllAssets:env:after_init and JekyllAssets:env:after_write
+# 
+# I've written an optimization to make sure we don't re-run purgecss
+# on files that are already done. It makes use of temporary files
+# that have a hash of the css file contents in it to compute whether
+# it needs to get changed or not. It'll run for all CSS files
+# independently since you may create multiple when Jekyll Assets
+# writes a new version of the file. It prints to console too to
+# show what's happening.
 
-Jekyll::Hooks.register(:site, :post_write) do |_site|
-  # Only run on production
-  if Jekyll.env == 'production'
-    # Create temp directory if it's missing
-    FileUtils.mkdir(@temp_directory) unless Dir.exist?(@temp_directory)
+# Simply exposes the constants because they can't be truly global
+def export_constants()
+  @build_folder = '_site'
+  @temporary_folder = '.purgecss'
+  @hash_suffix = '.pcss'
+  @config_file = @temporary_folder + '/config.js'
+  @output_folder = @build_folder + '/assets'
+  @html_glob = @build_folder + '/**/*.html'
+  @css_glob = @build_folder + '/**/*.css'
+  @temporary_files = @temporary_folder + '/*' + @hash_suffix
+  @leading_space = '                    '
 
-    # Make sure we delete the config file
-    File.delete(@config_file) if File.exist?(@config_file)
+  # These are the selectors that are JS added and can't be inferred
+  @selector_whitelist = [
+    'wf-active',
+    'wf-inactive'
+  ]
+end
 
-    # Configuration JS to write to the file. (Docs: https://www.purgecss.com/configuration)
-    config_text = ''"module.exports = #{{
-      content: [@build_directory + '/**/*.html'],
-      css: [Dir.glob(@build_directory + '/assets/*.css').first],
-      whitelist: %w[overhang-parent-top-4-tablet overhang-parent-bottom-4-tablet
-                    flush-left-4 round-corners underline-on-hover link-no-hover
-                    shadow-weak wf-active wf-inactive]
-    }.stringify_keys.to_json}"''
+# Computes a hashed filepath in the temp folder from a filename
+def get_temporary_filepath(name)
+  hashed_name = Digest::MD5.hexdigest name
+  return @temporary_folder + '/' + hashed_name + @hash_suffix
+end
 
-    # Write configuration file & run command
-    File.open(@config_file, 'w+') { |f| f.write(config_text) }
-    system("purgecss --config #{@config_file} --out #{@build_directory}/assets")
+# Runs PurgeCSS on a file
+def run_purge_on_file(filename)
+  # Print out which file we're purging in-place
+  print @leading_space
+  print 'purging CSS: '
+  puts filename
+
+  # JS config (Docs: https://www.purgecss.com/configuration)
+  config_text = ''"module.exports = #{{
+    content: [@html_glob],
+    css: [filename],
+    whitelist: @selector_whitelist
+  }.stringify_keys.to_json}"''
+
+  # Write configuration file for purgecss, run command, and delete it
+  File.open(@config_file, 'w') do |file|
+    file.write(config_text)
+  end
+  system("purgecss --config #{@config_file} --out #{@output_folder}")
+  File.delete(@config_file)
+end
+
+# Recreates an empty temp folder on init
+Jekyll::Assets::Hook.register :env, :after_init do
+  export_constants
+
+  # Create the temp dir if it doesn't exist
+  FileUtils.mkdir(@temporary_folder) unless Dir.exist?(@temporary_folder)
+
+  # Delete any files from last time
+  Dir.glob(@temporary_files).each do |file|
+    print @leading_space
+    print 'deleting stale file '
+    puts file
+    File.delete(file)
+  end
+end
+
+# Runs PurgeCSS if necessary
+Jekyll::Assets::Hook.register :env, :after_write do
+  export_constants
+
+  # Save a list of all the hash files we've used
+  processed_files = Hash.new(0)
+
+  # Loop over all CSS files
+  Dir.glob(@css_glob).each do |css_file|
+    # Get temporary filepath and save that we're processing this one
+    temp_filepath = get_temporary_filepath css_file
+    processed_files[temp_filepath] = 1
+  
+    # Contents of the CSS file we'll be using, hashed, for comparison
+    contents = Digest::SHA512.file css_file
+
+    # Compare the saved contents from last time to the current
+    # contents - if they're the same, no purging is needed
+    needs_purge = true
+    File.open(temp_filepath, 'a+') do |file|
+      needs_purge = contents != file.read
+    end
+    next unless needs_purge
+
+    # Run purge on the file
+    run_purge_on_file css_file
+
+    # Write the hashed contents of the css file now for next time
+    purged_contents = Digest::SHA512.file css_file
+    File.open(temp_filepath, 'w') do |file|
+      file.write(purged_contents)
+    end
+  end
+
+  # There may be extra files laying around for stuff that got deleted
+  # so let's delete everything else we didn't process in this run
+  Dir.glob(@temporary_files).each do |file|
+    File.delete(file) if processed_files[file] == 0
   end
 end

--- a/src/_plugins/hooks/purgecss.rb
+++ b/src/_plugins/hooks/purgecss.rb
@@ -33,6 +33,13 @@ def export_constants()
   ]
 end
 
+# Prints a filesize in KB for a given file
+def print_filesize(filename, message)
+  filesize = '%.2f' % (File.size(filename).to_f / 1000 )
+  print @leading_space
+  puts "  [#{filesize}KB] #{message}"
+end
+
 # Computes a hashed filepath in the temp folder from a filename
 def get_temporary_filepath(name)
   hashed_name = Digest::MD5.hexdigest name
@@ -43,8 +50,10 @@ end
 def run_purge_on_file(filename)
   # Print out which file we're purging in-place
   print @leading_space
-  print 'purging CSS: '
-  puts filename
+  puts 'purging unused css from: '
+  print @leading_space
+  puts '  ' + filename
+  print_filesize(filename, 'before purging')
 
   # JS config (Docs: https://www.purgecss.com/configuration)
   config_text = ''"module.exports = #{{
@@ -59,6 +68,9 @@ def run_purge_on_file(filename)
   end
   system("purgecss --config #{@config_file} --out #{@output_folder}")
   File.delete(@config_file)
+
+  # Show progress
+  print_filesize(filename, 'after purging')
 end
 
 # Recreates an empty temp folder on init


### PR DESCRIPTION
# Description
Jekyll Assets runs async, so on post_write from standard
Jekyll hooks, we can't be sure that our assets are done writing.
We want to run purgecss on our CSS files only after they're
written out entirely. This plugin accomplishes that by hooking
into JekyllAssets:env:after_init and JekyllAssets:env:after_write
I've written an optimization to make sure we don't re-run purgecss
on files that are already done. It makes use of temporary files
that have a hash of the css file contents in it to compute whether
it needs to get changed or not. It'll run for all CSS files
independently since you may create multiple when Jekyll Assets
writes a new version of the file. It prints to console too to
show what's happening.
<!--- Describe your changes in detail -->

## Motivation and context
Fixes #153 and helps pave the way for #17 
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to the open issue this PR solves -->

## Testing for this change
LOTS of it manually locally
<!--- Please describe in detail how you tested your changes. -->

## Screenshots (if appropriate)
<img width="472" alt="image" src="https://user-images.githubusercontent.com/982182/53483864-54b0dc80-3a37-11e9-93b5-82c40e439f9d.png">

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply -->

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing
  functionality to change)
