### PR TITLE
Optimizes goodreads + typekit endpoints

### DIFF
--- a/src/_includes/goodreads.html
+++ b/src/_includes/goodreads.html
@@ -1,6 +1,9 @@
 <div id="gr_grid_widget_1551681975">
   <div class="gr_grid_container">
-    noscript><br/>Share <a rel="nofollow" href="/">book reviews</a> and ratings with Dylan, and even join a <a rel="nofollow" href="/group">book club</a> on Goodreads.</noscript>
+    <div class="gr_grid_book_container"><a title="The Innovators: How a Group of  Hackers, Geniuses and Geeks Created the Digital Revolution" rel="nofollow" href="https://www.goodreads.com/book/show/21856367-the-innovators"><img alt="The Innovators: How a Group of  Hackers, Geniuses and Geeks Created the Digital Revolution" border="0" src="https://images.gr-assets.com/books/1410191571m/21856367.jpg" /></a></div>
+    <div class="gr_grid_book_container"><a title="Becoming" rel="nofollow" href="https://www.goodreads.com/book/show/38746485-becoming"><img alt="Becoming" border="0" src="https://images.gr-assets.com/books/1528206996m/38746485.jpg" /></a></div>
+    <div class="gr_grid_book_container"><a title="Cathedral of the Wild: An African Journey Home" rel="nofollow" href="https://www.goodreads.com/book/show/18050185-cathedral-of-the-wild"><img alt="Cathedral of the Wild: An African Journey Home" border="0" src="https://images.gr-assets.com/books/1377884038m/18050185.jpg" /></a></div>
+    <noscript><br/>Share <a rel="nofollow" href="/">book reviews</a> and ratings with Dylan, and even join a <a rel="nofollow" href="/group">book club</a> on Goodreads.</noscript>
   </div>
 </div>
 <script async src="https://www.goodreads.com/review/grid_widget/92225651.Dylan's%20currently-reading%20book%20montage?cover_size=medium&hide_link=true&hide_title=true&num_books=20&order=a&shelf=currently-reading&sort=date_added&widget_id=1551681975" type="text/javascript" charset="utf-8"></script>

--- a/src/sw.js
+++ b/src/sw.js
@@ -49,11 +49,11 @@ workbox.precaching.precacheAndRoute([]);
 
 /**
  * Routing for different filetypes & endpoints
- * - Force all analytics calls to network only
+ * - Force all goodreads, google analytics calls to network only
  * - Force all p.gif calls (Adobe's check to see if you can use the font) to
  *   network only. If this is cached, the cache grows and grows
  * - Cache the actual font files (use.typekit.net/af) for 120 days
- * - Cache fonts stylesheets for one day
+ * - Force all fonts stylesheets/js to network only for opaque caching probs
  * - Cache js, css, and json for six hours
  * - Cache up to 60 images for 30 days
  */
@@ -73,7 +73,15 @@ const vendorRouteConfiguration = function(hours) {
 };
 
 workbox.routing.registerRoute(
-  /^https?:\/\/www\.google-analytics\.com/,
+  /.*images\.gr-assets\.com/,
+  workbox.strategies.networkOnly()
+);
+workbox.routing.registerRoute(
+  /.*goodreads\.com/,
+  workbox.strategies.networkOnly()
+);
+workbox.routing.registerRoute(
+  /.*google-analytics\.com/,
   workbox.strategies.networkOnly()
 );
 workbox.routing.registerRoute(
@@ -90,7 +98,7 @@ workbox.routing.registerRoute(
 );
 workbox.routing.registerRoute(
   /^https?:\/\/.*.typekit\.net/,
-  workbox.strategies.cacheFirst(vendorRouteConfiguration(24))
+  workbox.strategies.networkOnly()
 );
 workbox.routing.registerRoute(
   /.*\.(?:js|css|json)$/,


### PR DESCRIPTION
# Description of changes
With opaque content, the typekit + Goodreads scripts were forcing the cache to 39MB. That’s bad. This brings it back down to a very nice 600kb (with webp, probably a few MB without webp). Also makes sure that there's fallback Goodreads content offline instead of the ugly noscript gibberish.

## Motivation/Context
Offline goodreads didn't look good and the cache was gigantic. Both things to solve!

## Screenshots/Testing
Chrome devtools

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
