### PR TITLE
Fixes incorrect status for the default uncached offline page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -70,7 +70,8 @@ favicons:
 workbox:
   precache_glob_directory: /
   precache_glob_patterns:
-    - 'index.html': '/'
+    - 'index.html': /
+    - 'about/index.html': /about/
     - 500.html
     - 503.html
     - favicon.ico

--- a/src/sw.js
+++ b/src/sw.js
@@ -161,7 +161,7 @@ function responseWithReplacedErrorContent(existingResponse, pageURL, status) {
   }
 
   const constructedResponse = {
-    status: status,
+    status: status === 503 ? 200 : status,
     statusText: existingResponse.statusText,
     headers: existingResponse.headers
   };

--- a/src/sw.js
+++ b/src/sw.js
@@ -15,10 +15,9 @@ const staticCacheName = "static",
   genericErrorPage = "/500.html";
 
 workbox.core.setCacheNameDetails({
-  precache: "precache",
+  precache: "pre",
   prefix: "dg",
-  suffix: "prod",
-  runtime: "site"
+  suffix: "v1"
 });
 workbox.skipWaiting();
 workbox.clientsClaim();


### PR DESCRIPTION
# Description of changes
Fixes the Lighthouse error that the about page wasn't responding with a 200. It was responding with a 503, so that's been fixed. Also caches the about page by default and changes the cache naming convention to clean up existing caches.

## Motivation/Context
Fixes #168 

## Screenshots/Testing
Lighthouse in Chrome devtools

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
