### PR TITLE
Reduces served CSS from 16KB to 9.61KB

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,5 @@ group :jekyll_plugins do
   gem 'jekyll_version_plugin'         # Grabs version from Github tags
   gem 'kramdown'                      # Translates Markdown to HTML
   gem 'mini_magick'                   # Automated image conversion
-  gem 'normalize-scss'                # Port of normalize.css to SCSS
   gem 'rouge'                         # Highlights code in HTML
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,8 +99,6 @@ GEM
     minitest (5.11.3)
     nokogiri (1.10.1)
       mini_portile2 (~> 2.4.0)
-    normalize-scss (7.0.1)
-      sass (~> 3.3)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     posix-spawn (0.3.13)
@@ -146,7 +144,6 @@ DEPENDENCIES
   jekyll_version_plugin
   kramdown
   mini_magick
-  normalize-scss
   rouge
 
 BUNDLED WITH

--- a/src/_assets/components/_goodreads.scss
+++ b/src/_assets/components/_goodreads.scss
@@ -2,15 +2,11 @@
 // For styling the goodreads widget for the about page
 // =====
 
+.gr_grid_container {
+  @extend .flex;
+}
+
 .gr_grid_book_container {
-  @extend .padding-2;
-
-  float: left;
-  height: 150px;
-  overflow: hidden;
-  width: 98px;
-
-  a {
-    @extend .link-no-decoration;
-  }
+  @extend .margin-right-4;
+  @extend .margin-bottom-4;
 }

--- a/src/_assets/css/_animations.scss
+++ b/src/_assets/css/_animations.scss
@@ -2,60 +2,39 @@
 // Animation & transition support as mixins and includes
 // =====
 
-// Constants for animations and transitions
-$quick-animation-duration: 167ms;
-$animation-duration: 334ms;
-$ease-out-back: cubic-bezier(.175, .885, .32, 1.275);
-$scale-down-hover: .96;
-
-// Adds support for adding multiple types of transitions
-@mixin transition-quick($properties...) {
+// Adds support for expanding properties and animation types out to the full string
+@function transition($speed, $properties) {
   $final: ();
 
-  @each $item in $properties {
-    $final: append($final, ($item $quick-animation-duration ease-in-out unquote(',')));
+  @for $i from 1 through length($properties) - 1 {
+    $item: nth($properties, $i);
+    $final: append($final, (#{$item} #{$speed}unquote(',')));
   }
+  $last-item: nth($properties, length($properties));
+  $final: append($final, (#{$last-item} #{$speed}));
 
-  transition: $final;
+  @return $final;
 }
 
-// Adds support for adding multiple types of transitions, with out-back timing function
-@mixin transition-bouncy($properties...) {
-  $final: ();
+// =====
+// Provides data through css var
+// =====
 
-  @each $item in $properties {
-    $final: append($final, ($item $animation-duration $ease-out-back unquote(',')));
-  }
-
-  transition: $final;
+:root {
+  --animate-default: #{transition(334ms cubic-bezier(.175, .885, .32, 1.275), (color, box-shadow, transform, font-weight))};
+  --animate-quick: #{transition(167ms 'ease-in-out', (box-shadow, fill, transform))};
 }
 
-.transition-shadow-transform {
-  @include transition-bouncy(box-shadow, transform);
+.transition-default {
+  transition: var(--animate-default);
 }
 
-.transition-color-shadow-transform {
-  @include transition-bouncy(color, box-shadow, transform);
-}
-
-.transition-color-transform {
-  @include transition-bouncy(color, transform);
-}
-
-.transition-color-transform-font-weight {
-  @include transition-bouncy(color, transform, font-weight);
-}
-
-.transition-fill-transform {
-  @include transition-quick(fill, transform);
-}
-
-.transition-quick-shadow {
-  @include transition-quick(box-shadow);
+.transition-quick {
+  transition: var(--animate-quick);
 }
 
 .scale-down-on-hover {
   &:hover {
-    transform: scale($scale-down-hover);
+    transform: scale(.96);
   }
 }

--- a/src/_assets/css/_colors.scss
+++ b/src/_assets/css/_colors.scss
@@ -152,16 +152,16 @@ $colors: (
 // =====
 
 .theme-light {
-  --color-primary: #{color(teal5)};
-  --color-secondary: #{color(teal7)};
-  --color-tertiary: #{color(teal8)};
-  --color-background: #{color(lightest)};
-  --color-background-translucent: #{color(lightest-translucent)};
-  --color-text: #{color(gray5)};
-  --color-text-muted: #{color(gray3)};
-  --color-text-inverse: #{color(gray0)};
-  --color-text-inverse-muted: #{color(gray1)};
-  --color-title: #{color(teal7)};
+  --c-primary: #{color(teal5)};
+  --c-secondary: #{color(teal7)};
+  --c-tertiary: #{color(teal8)};
+  --c-background: #{color(lightest)};
+  --c-glass: #{color(lightest-translucent)};
+  --c-text: #{color(gray5)};
+  --c-text-muted: #{color(gray3)};
+  --c-text-inverse: #{color(gray0)};
+  --c-text-inverse-muted: #{color(gray1)};
+  --c-title: #{color(teal7)};
 }
 
 // =====
@@ -179,11 +179,11 @@ $colors: (
 }
 
 .background-default {
-  background-color: var(--color-background);
+  background-color: var(--c-background);
 }
 
 @mixin background-translucent {
-  background-color: var(--color-background-translucent);
+  background-color: var(--c-glass);
 }
 
 // =====
@@ -191,34 +191,34 @@ $colors: (
 // =====
 
 .fill-primary {
-  fill: var(--color-primary);
+  fill: var(--c-primary);
 }
 
 .fill-secondary {
   &:hover {
-    fill: var(--color-secondary);
+    fill: var(--c-secondary);
   }
 }
 
 .color-primary {
-  color: var(--color-primary);
+  color: var(--c-primary);
 }
 
 .color-link-inverse {
-  color: var(--color-text-inverse);
+  color: var(--c-text-inverse);
 
   &:hover,
   &:focus {
-    color: var(--color-text-inverse-muted);
+    color: var(--c-text-inverse-muted);
   }
 }
 
 .color-link-reset {
-  color: var(--color-text);
+  color: var(--c-text);
 
   &:hover,
   &:focus {
-    color: var(--color-text);
+    color: var(--c-text);
   }
 }
 
@@ -227,31 +227,31 @@ $colors: (
 // =====
 
 html {
-  background-color: var(--color-background);
-  color: var(--color-text);
+  background-color: var(--c-background);
+  color: var(--c-text);
 }
 
 h1 {
-  color: var(--color-title);
+  color: var(--c-title);
 }
 
 a {
-  color: var(--color-primary);
+  color: var(--c-primary);
 
   &:hover {
-    color: var(--color-secondary);
+    color: var(--c-secondary);
   }
 
   &:focus {
-    color: var(--color-tertiary);
+    color: var(--c-tertiary);
   }
 }
 
 ::selection {
-  background: var(--color-secondary);
-  color: var(--color-text-inverse);
+  background: var(--c-secondary);
+  color: var(--c-text-inverse);
 }
 
 .highlight {
-  background-color: var(--color-background-secondary);
+  background-color: var(--c-background-secondary);
 }

--- a/src/_assets/css/_flex.scss
+++ b/src/_assets/css/_flex.scss
@@ -1,0 +1,12 @@
+// =====
+// Flexbox-related content
+// =====
+
+.flex {
+  display: flex;
+  flex-wrap: wrap;
+
+  @include for-phone-only {
+    justify-content: center;
+  }
+}

--- a/src/_assets/css/_font-levels.scss
+++ b/src/_assets/css/_font-levels.scss
@@ -3,6 +3,12 @@
 // =====
 
 // =====
+// Constants
+// =====
+$font-size-proportion: 1.09;
+$line-height-proportion: 1.08;
+
+// =====
 // Raises a number to a power
 // =====
 @function pow($number, $power) {
@@ -23,39 +29,40 @@
 // larger than normal the font should be.
 // =====
 @mixin generate-font-level-content($level) {
-  // Base variables
-  $base-font-size: 1.26rem;
-  $base-line-height-proportion: 1.58;
-  $base-margin-bottom: 2.5rem;
+  // Proportions used in calculation
+  $font-size-modifier: pow($font-size-proportion, $level);
+  $line-height-modifier: pow($line-height-proportion, $level);
 
-  // Proportions used in calculation.
-  $font-size-proportion: 1.09;
-  $line-height-proportion: 1.08;
-
-  // Calculation
-  $base-line-height: $base-font-size * $base-line-height-proportion;
-
-  font-size: $base-font-size * pow($font-size-proportion, $level);
-  line-height: $base-line-height * pow($line-height-proportion, $level);
-  margin-bottom: $base-margin-bottom;
+  font-size: calc(var(--font-base) * #{$font-size-modifier});
+  line-height: calc(var(--line-height-base) * #{$line-height-modifier});
 }
 
 // =====
-// Includes the generated font body on font-size-$level with a particular level
+// Sets the base size for the generate to work right
 // =====
-@mixin generate-font-level($level) {
-  .font-size-#{$level} {
-    @include for-phone-up {
-      @include generate-font-level-content($level);
-    }
+:root {
+  $base-font-size: 1.26rem;
+  $base-line-height: 1.58;
 
-    @include for-tablet-up {
-      @include generate-font-level-content($level + 1);
-    }
+  @include for-phone-up {
+    $size: $base-font-size;
 
-    @include for-desktop-up {
-      @include generate-font-level-content($level + 2);
-    }
+    --font-base: #{$size};
+    --line-height-base: #{$size * $base-line-height};
+  }
+
+  @include for-tablet-up {
+    $size: $base-font-size * $font-size-proportion;
+
+    --font-base: #{$size};
+    --line-height-base: #{$size * $base-line-height};
+  }
+
+  @include for-desktop-up {
+    $size: $base-font-size * $font-size-proportion * $font-size-proportion;
+
+    --font-base: #{$size};
+    --line-height-base: #{$size * $base-line-height};
   }
 }
 
@@ -64,5 +71,7 @@
 // =====
 
 @for $level from 0 through 20 {
-  @include generate-font-level($level);
+  .font-size-#{$level} {
+    @include generate-font-level-content($level);
+  }
 }

--- a/src/_assets/css/_font-levels.scss
+++ b/src/_assets/css/_font-levels.scss
@@ -20,7 +20,7 @@ $line-height-proportion: 1.08;
     }
   }
 
-  @return $value;
+  @return round($value * 1000) / 1000;
 }
 
 // =====
@@ -33,8 +33,8 @@ $line-height-proportion: 1.08;
   $font-size-modifier: pow($font-size-proportion, $level);
   $line-height-modifier: pow($line-height-proportion, $level);
 
-  font-size: calc(var(--font-base) * #{$font-size-modifier});
-  line-height: calc(var(--line-height-base) * #{$line-height-modifier});
+  font-size: calc(var(--fs) * #{$font-size-modifier});
+  line-height: calc(var(--lh) * #{$line-height-modifier});
 }
 
 // =====
@@ -47,22 +47,22 @@ $line-height-proportion: 1.08;
   @include for-phone-up {
     $size: $base-font-size;
 
-    --font-base: #{$size};
-    --line-height-base: #{$size * $base-line-height};
+    --fs: #{$size};
+    --lh: #{$size * $base-line-height};
   }
 
   @include for-tablet-up {
     $size: $base-font-size * $font-size-proportion;
 
-    --font-base: #{$size};
-    --line-height-base: #{$size * $base-line-height};
+    --fs: #{$size};
+    --lh: #{$size * $base-line-height};
   }
 
   @include for-desktop-up {
     $size: $base-font-size * $font-size-proportion * $font-size-proportion;
 
-    --font-base: #{$size};
-    --line-height-base: #{$size * $base-line-height};
+    --fs: #{$size};
+    --lh: #{$size * $base-line-height};
   }
 }
 

--- a/src/_assets/css/_fonts.scss
+++ b/src/_assets/css/_fonts.scss
@@ -3,18 +3,6 @@
 // =====
 
 :root {
-  // Families
-  --font-family-body: lft-etica, Arial, sans-serif;
-  --font-family-code: roboto-mono, Monaco, monospace;
-
-  // Weights
-  --font-weight-normal: 400;
-  --font-weight-medium: 500;
-  --font-weight-semibold: 600;
-  --font-weight-bold: 700;
-  --font-weight-black: 800;
-
-  // Sizes
   --font-base-size: 10px;
 
   // For when fonts are un-loaded
@@ -40,7 +28,7 @@ html {
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
   // sass-lint:enable no-vendor-prefixes
-  font-family: var(--font-family-body);
+  font-family: lft-etica, Arial, sans-serif;
   font-size: var(--font-base-size);
   font-feature-settings: 'kern' 1;
   font-kerning: normal;
@@ -52,7 +40,8 @@ html {
 // =====
 
 .font-family-code {
-  font-family: var(--font-family-code);
+  font-family: roboto-mono, Monaco, monospace;
+  font-weight: 500;
 }
 
 // =====
@@ -60,19 +49,19 @@ html {
 // =====
 
 .font-weight-normal {
-  font-weight: var(--font-weight-normal);
+  font-weight: 400;
 }
 
 .font-weight-bold {
-  font-weight: var(--font-weight-bold);
+  font-weight: 700;
 }
 
 .font-weight-semibold {
-  font-weight: var(--font-weight-semibold);
+  font-weight: 600;
 }
 
 .font-weight-black {
-  font-weight: var(--font-weight-black);
+  font-weight: 800;
 }
 
 .font-variant-heavy {
@@ -84,34 +73,44 @@ html {
 // Header styling
 // =====
 
+%font-margin {
+  margin-bottom: 2.5rem;
+}
+
 h1 {
   @extend .font-weight-semibold;
   @extend .font-size-17;
+  @extend %font-margin;
 }
 
 h2 {
   @extend .font-weight-semibold;
   @extend .font-size-12;
+  @extend %font-margin;
 }
 
 h3 {
   @extend .font-weight-semibold;
   @extend .font-size-9;
+  @extend %font-margin;
 }
 
 h4 {
   @extend .font-weight-black;
   @extend .font-size-6;
+  @extend %font-margin;
 }
 
 h5 {
   @extend .font-weight-black;
   @extend .font-size-4;
+  @extend %font-margin;
 }
 
 h6 {
   @extend .font-weight-black;
   @extend .font-size-2;
+  @extend %font-margin;
 }
 
 // =====
@@ -122,6 +121,7 @@ p {
   max-width: 36em;
 
   @extend .font-size-2;
+  @extend %font-margin;
 }
 
 input,
@@ -131,6 +131,7 @@ textarea,
 ul,
 ol {
   @extend .font-size-2;
+  @extend %font-margin;
 }
 
 // =====
@@ -140,8 +141,8 @@ ol {
 code {
   @extend .font-family-code;
   @extend .font-size-0;
+  @extend %font-margin;
 
-  font-weight: var(--font-weight-medium);
   overflow: auto;
 
   @include for-phone-only {

--- a/src/_assets/css/_fonts.scss
+++ b/src/_assets/css/_fonts.scss
@@ -3,7 +3,7 @@
 // =====
 
 :root {
-  --font-base-size: 10px;
+  --fs-base: 10px;
 
   // For when fonts are un-loaded
   letter-spacing: -.002em;
@@ -29,7 +29,7 @@ html {
   -webkit-font-smoothing: antialiased;
   // sass-lint:enable no-vendor-prefixes
   font-family: lft-etica, Arial, sans-serif;
-  font-size: var(--font-base-size);
+  font-size: var(--fs-base);
   font-feature-settings: 'kern' 1;
   font-kerning: normal;
   text-size-adjust: 100%;

--- a/src/_assets/css/_fonts.scss
+++ b/src/_assets/css/_fonts.scss
@@ -32,6 +32,7 @@ html {
   font-size: var(--fs-base);
   font-feature-settings: 'kern' 1;
   font-kerning: normal;
+  line-height: 1.15;
   text-size-adjust: 100%;
 }
 
@@ -52,12 +53,15 @@ html {
   font-weight: 400;
 }
 
-.font-weight-bold {
-  font-weight: 700;
-}
-
 .font-weight-semibold {
   font-weight: 600;
+}
+
+// Add the correct font weight in Chrome, Edge, and Safari.
+b,
+strong,
+.font-weight-bold {
+  font-weight: 700;
 }
 
 .font-weight-black {
@@ -139,11 +143,17 @@ ol {
 // =====
 
 code {
-  @extend .font-family-code;
-  @extend .font-size-0;
   @extend %font-margin;
 
   overflow: auto;
+
+  // 1. Correct the inheritance and scaling of font size in all browsers.
+  // 2. Correct the odd `em` font sizing in all browsers.
+  pre,
+  & {
+    @extend .font-family-code;
+    @extend .font-size-0;
+  }
 
   @include for-phone-only {
     word-break: break-all;

--- a/src/_assets/css/_grid.scss
+++ b/src/_assets/css/_grid.scss
@@ -85,10 +85,6 @@ $grid-columns-double-standard: 2 * ($grid-columns-standard - 1);
   align-self: center;
 }
 
-.grid-autoflow-dense {
-  grid-auto-flow: dense;
-}
-
 // Grid gaps
 
 @each $form, $suffix in $form-factors {

--- a/src/_assets/css/_links.scss
+++ b/src/_assets/css/_links.scss
@@ -18,20 +18,18 @@ p a {
 
   display: inline;
 
-  &:hover,
-  &:focus {
+  &:hover {
     @extend .font-weight-black;
   }
 }
 
 a {
-  @extend .transition-color-transform-font-weight;
+  @extend .transition-default;
 
   display: inline-block;
   text-decoration: underline;
 
-  &:hover,
-  &:focus {
+  &:hover {
     text-decoration: underline;
     transform: translateY(-.3rem);
   }
@@ -48,8 +46,7 @@ a {
 .link-no-decoration {
   @extend %link-underline-hidden;
 
-  &:hover,
-  &:focus {
+  &:hover {
     @extend %link-underline-hidden;
   }
 }

--- a/src/_assets/css/_normalize.scss
+++ b/src/_assets/css/_normalize.scss
@@ -1,0 +1,18 @@
+// =====
+// Normalize CSS resets, customized for dg
+// =====
+
+html {
+  box-sizing: border-box;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: inherit;
+}
+
+// Remove margin in all browsers
+body {
+  margin: 0;
+}

--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -21,6 +21,7 @@
 
 // Utility CSS
 @import 'borders';
+@import 'flex';
 @import 'grid';
 @import 'shadows';
 @import 'syntax';

--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -5,8 +5,8 @@
 @charset "UTF-8";
 // sass-lint:enable quotes
 
-// Normalizes css
-@import 'normalize/import-now';
+// Imports my normalize css (based on normalize.css)
+@import 'normalize';
 
 // Base utility CSS
 @import 'animations';

--- a/src/_includes/footer.html
+++ b/src/_includes/footer.html
@@ -4,19 +4,19 @@
   <p class="grid-span-col-full grid-span-col-8-tablet margin-vertical-3 margin-vertical-6-tablet">&copy; {{ site.time | date: '%Y' }} {{ site.title }} | {{ version }} | <a href="/privacy-policy/">Privacy Policy</a></p>
   <ul class="grid-span-col-full grid-span-col-start-8-tablet padding-horizontal-0 margin-vertical-5 margin-vertical-6-tablet grid-item-align-right-tablet">
     <li class="padding-left-4 list-block">
-      <a class="link-no-decoration font-size-1 fill-primary fill-secondary transition-fill-transform margin-0" href="mailto:{{ site.email | encode_email }}" aria-label="Email me">{% include icon-email.svg %}</a>
+      <a class="link-no-decoration font-size-1 fill-primary fill-secondary transition-quick margin-0" href="mailto:{{ site.email | encode_email }}" aria-label="Email me">{% include icon-email.svg %}</a>
     </li>
 
     <li class="padding-left-4 list-block">
-      <a class="link-no-decoration font-size-1 fill-primary fill-secondary transition-fill-transform margin-0" href="https://github.com/{{site.github}}" aria-label="Link to Github">{% include icon-github.svg %}</a>
+      <a class="link-no-decoration font-size-1 fill-primary fill-secondary transition-quick margin-0" href="https://github.com/{{site.github}}" aria-label="Link to Github">{% include icon-github.svg %}</a>
     </li>
 
     <li class="padding-left-4 list-block">
-      <a class="link-no-decoration font-size-1 fill-primary fill-secondary transition-fill-transform margin-0" href="https://www.linkedin.com/in/{{site.linkedin}}" aria-label="Dylan's LinkedIn">{% include icon-linkedin.svg %}</a>
+      <a class="link-no-decoration font-size-1 fill-primary fill-secondary transition-quick margin-0" href="https://www.linkedin.com/in/{{site.linkedin}}" aria-label="Dylan's LinkedIn">{% include icon-linkedin.svg %}</a>
     </li>
 
     <li class="padding-left-4 list-block">
-      <a class="link-no-decoration font-size-1 fill-primary fill-secondary transition-fill-transform margin-0" href="{{ site.baseurl }}/about" aria-label="About me">{% include icon-question.svg %}</a>
+      <a class="link-no-decoration font-size-1 fill-primary fill-secondary transition-quick margin-0" href="{{ site.baseurl }}/about" aria-label="About me">{% include icon-question.svg %}</a>
     </li>
   </ul>
 </footer>

--- a/src/_includes/nav.html
+++ b/src/_includes/nav.html
@@ -1,7 +1,7 @@
-<header id="global-nav" class="fixed-header depth-4 font-weight-bold transition-quick-shadow background-default translucent-header">
+<header id="global-nav" class="fixed-header depth-4 font-weight-bold transition-quick background-default translucent-header">
   <nav class="margin-horizontal-auto max-width-max width-full">
     <ul class="grid grid-columns-standard grid-gap-6 grid-gap-4-desktop margin-0 padding-vertical-4 padding-horizontal-5 padding-horizontal-6-desktop">
-      <li class="list-block grid-item-align-center font-size-2 margin-bottom-0"><a class="logo link-no-decoration scale-down-on-hover transition-color-transform" href="{{ site.baseurl }}/" aria-label="Homepage">dg.</a></li>
+      <li class="list-block grid-item-align-center font-size-2 margin-bottom-0"><a class="logo link-no-decoration scale-down-on-hover transition-default" href="{{ site.baseurl }}/" aria-label="Homepage">dg.</a></li>
       {% assign sorted_pages = site.pages | sort:"weight" %}
       {% for nav_page in sorted_pages %}
       

--- a/src/_includes/project-card-full.html
+++ b/src/_includes/project-card-full.html
@@ -2,7 +2,7 @@
     <h3 class="font-size-10 margin-top-5 margin-bottom-2">{{ post.title }}</h3>
     <h4 class="font-variant-heavy margin-top-5 margin-bottom-2 margin-vertical-3-tablet-down desktop-align-right font-size-2">{{ post.type }}</h4>
 </section>
-<section class="padding-horizontal-5 transition-shadow-transform">
+<section class="padding-horizontal-5 transition-default">
     <p>{{ post.description }}</p>
 </section>
 {% include project-card-section-thumb.html %}

--- a/src/_includes/project-card-section-thumb.html
+++ b/src/_includes/project-card-section-thumb.html
@@ -1,4 +1,4 @@
-<section class="transition-shadow-transform card-component-on-hover-scale-up {{ post.thumbnail.container_class }}">
+<section class="transition-default card-component-on-hover-scale-up {{ post.thumbnail.container_class }}">
     {% capture alttext %}{{ post.title }} thumbnail{% endcapture %}
     {% include picture.html src=post.thumbnail.src alt=alttext filetype=post.thumbnail.filetype class=post.thumbnail.class %}
 </section>

--- a/src/_includes/project-card-vertical.html
+++ b/src/_includes/project-card-vertical.html
@@ -5,6 +5,6 @@
           <h3 class="font-size-10 margin-top-5 margin-bottom-2">{{ post.title }}</h3>
           <h4 class="font-variant-heavy margin-top-5 margin-bottom-2 margin-vertical-3-tablet-down font-size-2">{{ post.type }}</h4>
         </div>
-        <p class="transition-shadow-transform">{{ post.description }}</p>
+        <p class="transition-default">{{ post.description }}</p>
     </section>
 </div>

--- a/src/_includes/project-card.html
+++ b/src/_includes/project-card.html
@@ -3,7 +3,7 @@
 {% else %}
 {% assign postlink = post.url %}
 {% endif %}
-<a href="{{ postlink }}" class="color-link-inverse corners-2 grid grid-column-gap-4 grid-span-rows-2-tablet link-no-decoration project-card scale-down-on-hover shadow-strong shadow-weak-on-hover transition-color-shadow-transform {{ post.class }}">
+<a href="{{ postlink }}" class="color-link-inverse corners-2 grid grid-column-gap-4 grid-span-rows-2-tablet link-no-decoration project-card scale-down-on-hover shadow-strong shadow-weak-on-hover transition-default {{ post.class }}">
     {% if post.project_layout == 'vertical' %}
       {% include project-card-vertical.html %}
     {% else %}

--- a/src/_includes/socials.html
+++ b/src/_includes/socials.html
@@ -1,17 +1,17 @@
 <ul class="padding-0 margin-bottom-5 margin-bottom-6-tablet">
   <li class="padding-2 list-block">
-    <a class="link-no-decoration font-size-1 fill-primary fill-secondary transition-fill-transform margin-0" href="mailto:{{ site.email | encode_email }}" aria-label="Email me">{% include icon-email.svg class="height-6 width-6" %}</a>
+    <a class="link-no-decoration font-size-1 fill-primary fill-secondary transition-quick margin-0" href="mailto:{{ site.email | encode_email }}" aria-label="Email me">{% include icon-email.svg class="height-6 width-6" %}</a>
   </li>
   <li class="padding-2 list-block">
-    <a class="link-no-decoration font-size-1 fill-darkest fill-secondary transition-fill-transform margin-0" href="https://github.com/{{site.github}}" aria-label="Link to Github">{% include icon-github.svg class="height-6 width-6" %}</a>
+    <a class="link-no-decoration font-size-1 fill-darkest fill-secondary transition-quick margin-0" href="https://github.com/{{site.github}}" aria-label="Link to Github">{% include icon-github.svg class="height-6 width-6" %}</a>
   </li>
   <li class="padding-2 list-block">
-    <a class="link-no-decoration font-size-1 fill-pink5 fill-secondary transition-fill-transform margin-0" href="https://www.instagram.com/{{site.instagram}}" aria-label="Link to Instagram">{% include icon-instagram.svg class="height-6 width-6" %}</a>
+    <a class="link-no-decoration font-size-1 fill-pink5 fill-secondary transition-quick margin-0" href="https://www.instagram.com/{{site.instagram}}" aria-label="Link to Instagram">{% include icon-instagram.svg class="height-6 width-6" %}</a>
   </li>
   <li class="padding-2 list-block">
-    <a class="link-no-decoration font-size-1 fill-blue5 fill-secondary transition-fill-transform margin-0" href="https://www.linkedin.com/in/{{site.linkedin}}" aria-label="Dylan's LinkedIn">{% include icon-linkedin.svg class="height-6 width-6" %}</a>
+    <a class="link-no-decoration font-size-1 fill-blue5 fill-secondary transition-quick margin-0" href="https://www.linkedin.com/in/{{site.linkedin}}" aria-label="Dylan's LinkedIn">{% include icon-linkedin.svg class="height-6 width-6" %}</a>
   </li>
   <li class="padding-2 list-block">
-    <a class="link-no-decoration font-size-1 fill-lime5 fill-secondary transition-fill-transform margin-0" href="https://open.spotify.com/user/{{site.spotify}}?si=yXvHMsSLR9au8bTjdjJsUA" aria-label="Dylan's Spotify">{% include icon-spotify.svg class="height-6 width-6" %}</a>
+    <a class="link-no-decoration font-size-1 fill-lime5 fill-secondary transition-quick margin-0" href="https://open.spotify.com/user/{{site.spotify}}?si=yXvHMsSLR9au8bTjdjJsUA" aria-label="Dylan's Spotify">{% include icon-spotify.svg class="height-6 width-6" %}</a>
   </li>
 </ul>

--- a/src/_includes/socials.html
+++ b/src/_includes/socials.html
@@ -1,17 +1,17 @@
-<ul class="padding-0 margin-bottom-5 margin-bottom-6-tablet">
-  <li class="padding-2 list-block">
-    <a class="link-no-decoration font-size-1 fill-primary fill-secondary transition-quick margin-0" href="mailto:{{ site.email | encode_email }}" aria-label="Email me">{% include icon-email.svg class="height-6 width-6" %}</a>
+<ul class="flex font-size-1 padding-0 margin-bottom-5 margin-bottom-6-tablet">
+  <li class="margin-right-5 margin-vertical-4 margin-right-6-tablet list-block">
+    <a class="link-no-decoration fill-primary fill-secondary transition-quick margin-0" href="mailto:{{ site.email | encode_email }}" aria-label="Email me">{% include icon-email.svg class="height-6 width-6" %}</a>
   </li>
-  <li class="padding-2 list-block">
-    <a class="link-no-decoration font-size-1 fill-darkest fill-secondary transition-quick margin-0" href="https://github.com/{{site.github}}" aria-label="Link to Github">{% include icon-github.svg class="height-6 width-6" %}</a>
+  <li class="margin-right-5 margin-vertical-4 margin-right-6-tablet list-block">
+    <a class="link-no-decoration fill-darkest fill-secondary transition-quick margin-0" href="https://github.com/{{site.github}}" aria-label="Link to Github">{% include icon-github.svg class="height-6 width-6" %}</a>
   </li>
-  <li class="padding-2 list-block">
-    <a class="link-no-decoration font-size-1 fill-pink5 fill-secondary transition-quick margin-0" href="https://www.instagram.com/{{site.instagram}}" aria-label="Link to Instagram">{% include icon-instagram.svg class="height-6 width-6" %}</a>
+  <li class="margin-right-5 margin-vertical-4 margin-right-6-tablet list-block">
+    <a class="link-no-decoration fill-pink5 fill-secondary transition-quick margin-0" href="https://www.instagram.com/{{site.instagram}}" aria-label="Link to Instagram">{% include icon-instagram.svg class="height-6 width-6" %}</a>
   </li>
-  <li class="padding-2 list-block">
-    <a class="link-no-decoration font-size-1 fill-blue5 fill-secondary transition-quick margin-0" href="https://www.linkedin.com/in/{{site.linkedin}}" aria-label="Dylan's LinkedIn">{% include icon-linkedin.svg class="height-6 width-6" %}</a>
+  <li class="margin-right-5 margin-vertical-4 margin-right-6-tablet list-block">
+    <a class="link-no-decoration fill-blue5 fill-secondary transition-quick margin-0" href="https://www.linkedin.com/in/{{site.linkedin}}" aria-label="Dylan's LinkedIn">{% include icon-linkedin.svg class="height-6 width-6" %}</a>
   </li>
-  <li class="padding-2 list-block">
-    <a class="link-no-decoration font-size-1 fill-lime5 fill-secondary transition-quick margin-0" href="https://open.spotify.com/user/{{site.spotify}}?si=yXvHMsSLR9au8bTjdjJsUA" aria-label="Dylan's Spotify">{% include icon-spotify.svg class="height-6 width-6" %}</a>
+  <li class="margin-right-5 margin-vertical-4 margin-right-6-tablet list-block">
+    <a class="link-no-decoration fill-lime5 fill-secondary transition-quick margin-0" href="https://open.spotify.com/user/{{site.spotify}}?si=yXvHMsSLR9au8bTjdjJsUA" aria-label="Dylan's Spotify">{% include icon-spotify.svg class="height-6 width-6" %}</a>
   </li>
 </ul>

--- a/src/about.html
+++ b/src/about.html
@@ -7,7 +7,7 @@ weight: 1
 {% capture about_me %}{% include about_me.md %}{% endcapture %}
 {% capture skills %}{% include skills.md %}{% endcapture %}
 {% capture reading_list %}{% include reading-list.md %}{% endcapture %}
-<div itemprop="text" class="grid grid-columns-standard grid-column-gap-4 grid-autoflow-dense">
+<div itemprop="text" class="grid grid-columns-standard grid-column-gap-4">
   <section class="grid-span-col-full grid-span-col-8-tablet">
     {{ about_me | markdownify }}
   </section>


### PR DESCRIPTION
# Description of changes
Almost halved my CSS! Most of the work was around reducing long names and duplicated strings, but removing a bunch of redundant normalize resets helped too.

- Simplifies transitions + links (15KB)
- Rewrites how font levels are calculated (11.5KB)
- Reduces css variable length (11KB)
- Reduces size of font css to 11.07KB
- Removes normalize css for custom overrides (9.85KB)
- Uses flex to consolidate social/goodreads (9.61KB)

## Motivation/Context
Fixes #103 and drastically improves sitespeed.

## Screenshots/Testing
<img width="426" alt="image" src="https://user-images.githubusercontent.com/982182/54338303-b86a0680-45ee-11e9-9f49-352fc7896cc6.png">
<img width="353" alt="image" src="https://user-images.githubusercontent.com/982182/54338307-ba33ca00-45ee-11e9-9700-8bb7260e09c8.png">
<img width="835" alt="image" src="https://user-images.githubusercontent.com/982182/54338309-bc962400-45ee-11e9-9d71-31f0b8e6fe6d.png">
<img width="608" alt="image" src="https://user-images.githubusercontent.com/982182/54338312-be5fe780-45ee-11e9-9c50-104fc01b3239.png">

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
