### PR TITLE
Bugfixes for centering the privacy policy

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -72,6 +72,7 @@ workbox:
   precache_glob_patterns:
     - 'index.html': /
     - 'about/index.html': /about/
+    - 'projects/index.html': /projects/
     - 500.html
     - 503.html
     - favicon.ico

--- a/src/_layouts/page.html
+++ b/src/_layouts/page.html
@@ -1,6 +1,14 @@
 ---
 layout: default
+centered: false
 ---
 <article class="margin-horizontal-5 margin-horizontal-6-desktop margin-top-7 margin-top-8-tablet" itemscope itemtype="http://schema.org/WebPage" role="main">
-  {{ content }}
+  {% unless page.no_header %}
+    {% include page-header.html title=page.header %}
+  {% endunless %}
+  {% if page.centered %}
+    <div class="centered-content">{{ content }}</div>
+  {% else %}
+    {{ content }}
+  {% endif %}
 </article>

--- a/src/about.html
+++ b/src/about.html
@@ -2,13 +2,13 @@
 layout: page
 title: About Me
 nav_title: <b>03</b> about
+header: Hey there!
 weight: 2
 ---
 {% capture about_me %}{% include about_me.md %}{% endcapture %}
 {% capture technologies %}{% include technologies.md %}{% endcapture %}
 {% capture reading %}{% include reading.md %}{% endcapture %}
 {% capture offline %}{% include offline.md %}{% endcapture %}
-{% include page-header.html title="Hey there!" %}
 <div itemprop="text">
   <div class="grid grid-columns-standard grid-rows-2 grid-column-gap-4">
     <section class="centered-content grid-span-col-full grid-span-col-9-tablet align-item-center">

--- a/src/index.html
+++ b/src/index.html
@@ -2,6 +2,7 @@
 layout: page
 title: Home
 nav_title: <b>01</b> home
+no_header: true
 weight: 0
 ---
 {% include intro.html %}

--- a/src/privacy-policy.md
+++ b/src/privacy-policy.md
@@ -1,10 +1,9 @@
 ---
 layout: page
 title: Privacy Policy
+centered: true
 permalink: /privacy-policy/
 ---
-# Privacy Policy
-
 **Effective date:** March 1, 2019
 
 {{ site.title }} ("us", "we", or "our") operates the <{{ site.url }}> website

--- a/src/projects.html
+++ b/src/projects.html
@@ -4,7 +4,6 @@ title: Projects
 nav_title: <b>02</b> projects
 weight: 1
 ---
-{% include page-header.html %}
 <section class="grid grid-gap-5 grid-columns-2-tablet grid-gap-6-tablet margin-top-7">
   <p class="font-size-4">Here are a few big things I've worked on recently. <a href="https://github.com/dgattey">Check out my Github</a> for even more.</p>
   {% for post in site.posts %}

--- a/src/sw.js
+++ b/src/sw.js
@@ -17,7 +17,7 @@ const staticCacheName = "static",
 workbox.core.setCacheNameDetails({
   precache: "pre",
   prefix: "dg",
-  suffix: "v1"
+  suffix: "v2"
 });
 workbox.skipWaiting();
 workbox.clientsClaim();


### PR DESCRIPTION
# Description of changes
Automatically adds page headers based on frontmatter. Now there's a solution to align the whole page by default, and an option to automatically add the page header.

## Motivation/Context
#181 was a little busted. Privacy policy was still left aligned.

## Screenshots/Testing
Manual.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
