### PR TITLE
Improves styling on mobile

### DIFF
--- a/src/_assets/css/_breakpoints.scss
+++ b/src/_assets/css/_breakpoints.scss
@@ -9,6 +9,7 @@ $breakpoint-max-width: 1200px;
 
 $form-factors: (
   phone: '',
+  phone-only: '-phone-only',
   tablet: '-tablet',
   tablet-down: '-tablet-down',
   desktop: '-desktop'
@@ -16,7 +17,15 @@ $form-factors: (
 
 @mixin breakpoint($form) {
   @if $form == 'phone' {
-    @content;
+    @include for-phone-up {
+      @content;
+    }
+  }
+
+  @else if $form == 'phone-only' {
+    @include for-phone-only {
+      @content;
+    }
   }
 
   @else if $form == 'tablet' {

--- a/src/_includes/intro.html
+++ b/src/_includes/intro.html
@@ -1,5 +1,5 @@
 <section class="intro grid grid-columns-standard grid-rows-2 grid-column-gap-4">
-  <h1 class="margin-bottom-0 title grid-span-col-full grid-span-col-8-tablet align-item-bottom">I develop, design, teach, and learn.</h1>
+  <h1 class="margin-bottom-0 margin-top-0-phone-only title grid-span-col-full grid-span-col-8-tablet align-item-bottom">I develop, design, teach, and learn.</h1>
 	<p class="font-size-6 detail grid-span-col-full grid-span-col-8-tablet">I'm Dylan, a full-stack software engineer + technical lead at LinkedIn, passionate about well-designed interfaces, clean code, and social impact.</p>
 	{% include picture.html src="dg-portrait" filetype="png" alt="Portrait of Dylan Gattey" container_class="portrait fill-parent grid-span-col-full grid-span-col-start-8-tablet" class="fill-parent fit-within-parent" %}
 </section>

--- a/src/_layouts/error-page.html
+++ b/src/_layouts/error-page.html
@@ -6,7 +6,7 @@ no_header: true
     <h3 itemprop="name headline" class="grid-span-row-1 grid-span-col-full font-size-5 font-weight-black">&lt;error&gt;</h3>
     <div itemprop="text" class="grid-span-row-1 grid-span-col-full grid-span-col-offset">
         {{ content }}
-        <p class="font-size-2 font-family-code">? page {{ page.verb }}</p>
+        <p class="font-size-2 font-family-code">unknown page {{ page.verb }}</p>
     </div>
     <h3 class="grid-span-row-1 grid-span-col-full align-item-right font-size-5 font-weight-black">&lt;/error&gt;</h3>
 

--- a/src/projects.html
+++ b/src/projects.html
@@ -4,7 +4,7 @@ title: Projects
 nav_title: <b>02</b> projects
 weight: 1
 ---
-<section class="grid grid-gap-5 grid-columns-2-tablet grid-gap-6-tablet margin-top-7">
+<section class="grid grid-gap-5 grid-columns-2-tablet grid-gap-6-tablet margin-top-7-tablet">
   <p class="font-size-4">Here are a few big things I've worked on recently. <a href="https://github.com/dgattey">Check out my Github</a> for even more.</p>
   {% for post in site.posts %}
     {% include project-card.html %}

--- a/src/sw.js
+++ b/src/sw.js
@@ -8,16 +8,18 @@
  * - Skip waiting and claim clients so we take over from any old workers
  * - Also make sure that if we are an old worker, we force reload the page to get freshest stuff
  */
-const staticCacheName = "static",
-  vendorCacheName = "vendor-static",
-  imageCacheName = "images",
+const version = "v1.18.3",
+  cachePrefix = "dg",
+  staticCacheName = cachePrefix + "-static-" + version,
+  vendorCacheName = cachePrefix + "-vendor-" + version,
+  imageCacheName = cachePrefix + "-images-" + version,
   offlinePage = "/503.html",
   genericErrorPage = "/500.html";
 
 workbox.core.setCacheNameDetails({
   precache: "pre",
-  prefix: "dg",
-  suffix: "v2"
+  prefix: cachePrefix,
+  suffix: version
 });
 workbox.skipWaiting();
 workbox.clientsClaim();
@@ -151,7 +153,7 @@ const offlinePageForURL = async(pageURL) => {
 /**
  * Takes an existing response and replaces some error content. Specifically:
  * - Replaces "<error>"" or "</error>" with the actual status code
- * - Replaces "? page" with the actual pageURL
+ * - Replaces "unknown page" with the actual pageURL
  *
  * Note that the status code falls back to the response's status if not defined.
  */
@@ -171,7 +173,7 @@ function responseWithReplacedErrorContent(existingResponse, pageURL, status) {
     const left = "&lt;";
     const right = status + "&gt;";
 
-    var newContent = body.replace(/\? page/, pageURL);
+    var newContent = body.replace(/\unknown page/, pageURL);
     newContent = newContent.replace(/&lt;error&gt;/, left + right);
     newContent = newContent.replace(/&lt;\/error&gt;/, left + "/" + right);
 


### PR DESCRIPTION
# Description of changes
Just some quick fixes to mobile styles - headers are now aligned on every page. Also updates the error page string so Firefox iOS (no service workers 😢) and browers without service workers look nicer. Also aligns all service worker cache names with the version in which `sw.js` was last changed. Not super automated but it's better than `v1`, `v2`, etc like I had before.

## Motivation/Context
Inconsistent spacing on mobile. Nothing big.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
