### PR TITLE
chore: remove assets from semantic release github plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,14 +35,7 @@
       "main"
     ],
     "plugins": [
-      [
-        "@semantic-release/github",
-        {
-          "assets": [
-            "public/**"
-          ]
-        }
-      ],
+      "@semantic-release/github",
       "@semantic-release/git",
       "@semantic-release/changelog"
     ]


### PR DESCRIPTION
Don't need assets from `semantic-release/@github` plugin