### PR TITLE
build(semantic-release): add all types of commit messages to semantic release

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,36 @@
       "main"
     ],
     "plugins": [
+      [
+        "@semantic-release/commit-analyzer",
+        {
+          "preset": "angular",
+          "releaseRules": [
+            {
+              "type": "chore",
+              "release": "patch"
+            },
+            {
+              "type": "build",
+              "release": "patch"
+            },
+            {
+              "type": "test",
+              "release": "patch"
+            },
+            {
+              "type": "ci",
+              "release": "patch"
+            }
+          ],
+          "parserOpts": {
+            "noteKeywords": [
+              "BREAKING CHANGE",
+              "BREAKING CHANGES"
+            ]
+          }
+        }
+      ],
       "@semantic-release/github",
       "@semantic-release/git",
       "@semantic-release/changelog"


### PR DESCRIPTION
Adds new type of commit messages to semantic release! Because looks like only fix/feat/perf are supported right now.