### PR TITLE
chore(commits): add feat and fix explicitly to commit analyzer

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,14 @@
             {
               "type": "ci",
               "release": "patch"
+            },
+            {
+              "type": "fix",
+              "release": "patch"
+            },
+            {
+              "type": "feat",
+              "release": "minor"
             }
           ],
           "parserOpts": {


### PR DESCRIPTION
Need to add fix and feat manually because feat wasn't getting picked up as a `minor` change for `semantic-release`