### PR TITLE
feat: add a sick-as-hell recursive Section element

### DIFF
--- a/config/gatsby-node.ts
+++ b/config/gatsby-node.ts
@@ -26,11 +26,9 @@ const createPages = async ({
 	const { errors, data }: AllPagesResult = await graphql(`
 		query AllPages {
 			allContentfulPage {
-				edges {
-					node {
-						id
-						slug
-					}
+				nodes {
+					id
+					slug
 				}
 			}
 		}
@@ -40,12 +38,12 @@ const createPages = async ({
 	}
 
 	// Create an actual page for this edge using the given slug - passing the id for later queries
-	data?.allContentfulPage.edges.forEach((edge) => {
+	data?.allContentfulPage.nodes.forEach((node) => {
 		createPage({
-			path: `${edge.node.slug}`,
+			path: `${node.slug}`,
 			component: pageTemplate,
 			context: {
-				id: edge.node.id,
+				id: node.id,
 			},
 		})
 	})

--- a/src/__generated__/gatsby-types.d.ts
+++ b/src/__generated__/gatsby-types.d.ts
@@ -1152,6 +1152,17 @@ type SitePlugin = Node & {
 };
 
 type SitePluginPluginOptions = {
+  readonly accessToken: Maybe<Scalars['String']>;
+  readonly spaceId: Maybe<Scalars['String']>;
+  readonly host: Maybe<Scalars['String']>;
+  readonly useNameForId: Maybe<Scalars['Boolean']>;
+  readonly environment: Maybe<Scalars['String']>;
+  readonly downloadLocal: Maybe<Scalars['Boolean']>;
+  readonly forceFullSync: Maybe<Scalars['Boolean']>;
+  readonly pageLimit: Maybe<Scalars['Int']>;
+  readonly assetDownloadWorkers: Maybe<Scalars['Int']>;
+  readonly token: Maybe<Scalars['String']>;
+  readonly graphQLQuery: Maybe<Scalars['String']>;
   readonly output: Maybe<Scalars['String']>;
   readonly createLinkInHead: Maybe<Scalars['Boolean']>;
   readonly name: Maybe<Scalars['String']>;
@@ -1178,17 +1189,6 @@ type SitePluginPluginOptions = {
   readonly allExtensions: Maybe<Scalars['Boolean']>;
   readonly isTSX: Maybe<Scalars['Boolean']>;
   readonly jsxPragma: Maybe<Scalars['String']>;
-  readonly accessToken: Maybe<Scalars['String']>;
-  readonly spaceId: Maybe<Scalars['String']>;
-  readonly host: Maybe<Scalars['String']>;
-  readonly useNameForId: Maybe<Scalars['Boolean']>;
-  readonly environment: Maybe<Scalars['String']>;
-  readonly downloadLocal: Maybe<Scalars['Boolean']>;
-  readonly forceFullSync: Maybe<Scalars['Boolean']>;
-  readonly pageLimit: Maybe<Scalars['Int']>;
-  readonly assetDownloadWorkers: Maybe<Scalars['Int']>;
-  readonly token: Maybe<Scalars['String']>;
-  readonly graphQLQuery: Maybe<Scalars['String']>;
 };
 
 type SitePluginPackageJson = {
@@ -2605,6 +2605,17 @@ type SitePluginFilterInput = {
 };
 
 type SitePluginPluginOptionsFilterInput = {
+  readonly accessToken: Maybe<StringQueryOperatorInput>;
+  readonly spaceId: Maybe<StringQueryOperatorInput>;
+  readonly host: Maybe<StringQueryOperatorInput>;
+  readonly useNameForId: Maybe<BooleanQueryOperatorInput>;
+  readonly environment: Maybe<StringQueryOperatorInput>;
+  readonly downloadLocal: Maybe<BooleanQueryOperatorInput>;
+  readonly forceFullSync: Maybe<BooleanQueryOperatorInput>;
+  readonly pageLimit: Maybe<IntQueryOperatorInput>;
+  readonly assetDownloadWorkers: Maybe<IntQueryOperatorInput>;
+  readonly token: Maybe<StringQueryOperatorInput>;
+  readonly graphQLQuery: Maybe<StringQueryOperatorInput>;
   readonly output: Maybe<StringQueryOperatorInput>;
   readonly createLinkInHead: Maybe<BooleanQueryOperatorInput>;
   readonly name: Maybe<StringQueryOperatorInput>;
@@ -2631,17 +2642,6 @@ type SitePluginPluginOptionsFilterInput = {
   readonly allExtensions: Maybe<BooleanQueryOperatorInput>;
   readonly isTSX: Maybe<BooleanQueryOperatorInput>;
   readonly jsxPragma: Maybe<StringQueryOperatorInput>;
-  readonly accessToken: Maybe<StringQueryOperatorInput>;
-  readonly spaceId: Maybe<StringQueryOperatorInput>;
-  readonly host: Maybe<StringQueryOperatorInput>;
-  readonly useNameForId: Maybe<BooleanQueryOperatorInput>;
-  readonly environment: Maybe<StringQueryOperatorInput>;
-  readonly downloadLocal: Maybe<BooleanQueryOperatorInput>;
-  readonly forceFullSync: Maybe<BooleanQueryOperatorInput>;
-  readonly pageLimit: Maybe<IntQueryOperatorInput>;
-  readonly assetDownloadWorkers: Maybe<IntQueryOperatorInput>;
-  readonly token: Maybe<StringQueryOperatorInput>;
-  readonly graphQLQuery: Maybe<StringQueryOperatorInput>;
 };
 
 type SitePluginPackageJsonFilterInput = {
@@ -2845,6 +2845,17 @@ type SitePageFieldsEnum =
   | 'pluginCreator.resolve'
   | 'pluginCreator.name'
   | 'pluginCreator.version'
+  | 'pluginCreator.pluginOptions.accessToken'
+  | 'pluginCreator.pluginOptions.spaceId'
+  | 'pluginCreator.pluginOptions.host'
+  | 'pluginCreator.pluginOptions.useNameForId'
+  | 'pluginCreator.pluginOptions.environment'
+  | 'pluginCreator.pluginOptions.downloadLocal'
+  | 'pluginCreator.pluginOptions.forceFullSync'
+  | 'pluginCreator.pluginOptions.pageLimit'
+  | 'pluginCreator.pluginOptions.assetDownloadWorkers'
+  | 'pluginCreator.pluginOptions.token'
+  | 'pluginCreator.pluginOptions.graphQLQuery'
   | 'pluginCreator.pluginOptions.output'
   | 'pluginCreator.pluginOptions.createLinkInHead'
   | 'pluginCreator.pluginOptions.name'
@@ -2871,17 +2882,6 @@ type SitePageFieldsEnum =
   | 'pluginCreator.pluginOptions.allExtensions'
   | 'pluginCreator.pluginOptions.isTSX'
   | 'pluginCreator.pluginOptions.jsxPragma'
-  | 'pluginCreator.pluginOptions.accessToken'
-  | 'pluginCreator.pluginOptions.spaceId'
-  | 'pluginCreator.pluginOptions.host'
-  | 'pluginCreator.pluginOptions.useNameForId'
-  | 'pluginCreator.pluginOptions.environment'
-  | 'pluginCreator.pluginOptions.downloadLocal'
-  | 'pluginCreator.pluginOptions.forceFullSync'
-  | 'pluginCreator.pluginOptions.pageLimit'
-  | 'pluginCreator.pluginOptions.assetDownloadWorkers'
-  | 'pluginCreator.pluginOptions.token'
-  | 'pluginCreator.pluginOptions.graphQLQuery'
   | 'pluginCreator.nodeAPIs'
   | 'pluginCreator.browserAPIs'
   | 'pluginCreator.ssrAPIs'
@@ -6369,6 +6369,17 @@ type SitePluginFieldsEnum =
   | 'resolve'
   | 'name'
   | 'version'
+  | 'pluginOptions.accessToken'
+  | 'pluginOptions.spaceId'
+  | 'pluginOptions.host'
+  | 'pluginOptions.useNameForId'
+  | 'pluginOptions.environment'
+  | 'pluginOptions.downloadLocal'
+  | 'pluginOptions.forceFullSync'
+  | 'pluginOptions.pageLimit'
+  | 'pluginOptions.assetDownloadWorkers'
+  | 'pluginOptions.token'
+  | 'pluginOptions.graphQLQuery'
   | 'pluginOptions.output'
   | 'pluginOptions.createLinkInHead'
   | 'pluginOptions.name'
@@ -6395,17 +6406,6 @@ type SitePluginFieldsEnum =
   | 'pluginOptions.allExtensions'
   | 'pluginOptions.isTSX'
   | 'pluginOptions.jsxPragma'
-  | 'pluginOptions.accessToken'
-  | 'pluginOptions.spaceId'
-  | 'pluginOptions.host'
-  | 'pluginOptions.useNameForId'
-  | 'pluginOptions.environment'
-  | 'pluginOptions.downloadLocal'
-  | 'pluginOptions.forceFullSync'
-  | 'pluginOptions.pageLimit'
-  | 'pluginOptions.assetDownloadWorkers'
-  | 'pluginOptions.token'
-  | 'pluginOptions.graphQLQuery'
   | 'nodeAPIs'
   | 'browserAPIs'
   | 'ssrAPIs'
@@ -6440,13 +6440,43 @@ type SitePluginSortInput = {
   readonly order: Maybe<ReadonlyArray<Maybe<SortOrderEnum>>>;
 };
 
-type SiteVersionQueryVariables = Exact<{ [key: string]: never; }>;
+type SectionFragment = Pick<ContentfulSection, 'id' | 'title'>;
+
+type ProjectFragment = (
+  Pick<ContentfulProject, 'id' | 'title' | 'creationDate' | 'type'>
+  & { readonly description: Maybe<Pick<ContentfulProjectDescription, 'raw'>>, readonly thumbnail: Maybe<Pick<ContentfulAsset, 'id'>> }
+);
+
+type LinkFragment = Pick<ContentfulLink, 'title' | 'url'>;
+
+type TextFragment = (
+  Pick<ContentfulText, 'id' | 'imageType'>
+  & { readonly text: Maybe<Pick<ContentfulTextText, 'raw'>> }
+);
+
+type PageQueryVariables = Exact<{
+  id: Maybe<Scalars['String']>;
+}>;
 
 
-type SiteVersionQuery = { readonly githubData: Maybe<{ readonly data: Maybe<{ readonly repository: Maybe<{ readonly refs: Maybe<{ readonly nodes: Maybe<ReadonlyArray<Maybe<(
-            Pick<GithubDataDataRepositoryRefsNodes, 'name'>
-            & { readonly target: Maybe<Pick<GithubDataDataRepositoryRefsNodesTarget, 'oid'>> }
-          )>>> }> }> }> }> };
+type PageQuery = { readonly contentfulPage: Maybe<(
+    Pick<ContentfulPage, 'title'>
+    & { readonly sections: Maybe<ReadonlyArray<Maybe<(
+      { readonly blocks: Maybe<ReadonlyArray<Maybe<LinkFragment | ProjectFragment | (
+        { readonly blocks: Maybe<ReadonlyArray<Maybe<LinkFragment | ProjectFragment | (
+          { readonly blocks: Maybe<ReadonlyArray<Maybe<LinkFragment | ProjectFragment>>> }
+          & SectionFragment
+        )>>> }
+        & SectionFragment
+      )>>> }
+      & SectionFragment
+    ) | TextFragment>>> }
+  )> };
+
+type PagesQueryQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+type PagesQueryQuery = { readonly allSitePage: { readonly nodes: ReadonlyArray<Pick<SitePage, 'path'>> } };
 
 type FooterQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -6455,11 +6485,6 @@ type FooterQuery = { readonly allContentfulSection: { readonly nodes: ReadonlyAr
           Pick<ContentfulLink, 'url' | 'title'>
           & { readonly icon: Maybe<Pick<contentfulLinkIconTextNode, 'icon'>> }
         )>>> }>>> }> } };
-
-type HeaderQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-type HeaderQuery = { readonly allContentfulSection: { readonly nodes: ReadonlyArray<{ readonly blocks: Maybe<ReadonlyArray<Maybe<Pick<ContentfulLink, 'title' | 'url'>>>> }> } };
 
 type GatsbyContentfulFixedFragment = Pick<ContentfulFixed, 'base64' | 'width' | 'height' | 'src' | 'srcSet'>;
 
@@ -6506,5 +6531,18 @@ type GatsbyImageSharpFluid_withWebp_tracedSVGFragment = Pick<ImageSharpFluid, 't
 type GatsbyImageSharpFluid_noBase64Fragment = Pick<ImageSharpFluid, 'aspectRatio' | 'src' | 'srcSet' | 'sizes'>;
 
 type GatsbyImageSharpFluid_withWebp_noBase64Fragment = Pick<ImageSharpFluid, 'aspectRatio' | 'src' | 'srcSet' | 'srcWebp' | 'srcSetWebp' | 'sizes'>;
+
+type SiteVersionQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+type SiteVersionQuery = { readonly githubData: Maybe<{ readonly data: Maybe<{ readonly repository: Maybe<{ readonly refs: Maybe<{ readonly nodes: Maybe<ReadonlyArray<Maybe<(
+            Pick<GithubDataDataRepositoryRefsNodes, 'name'>
+            & { readonly target: Maybe<Pick<GithubDataDataRepositoryRefsNodesTarget, 'oid'>> }
+          )>>> }> }> }> }> };
+
+type HeaderQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+type HeaderQuery = { readonly allContentfulSection: { readonly nodes: ReadonlyArray<{ readonly blocks: Maybe<ReadonlyArray<Maybe<Pick<ContentfulLink, 'title' | 'url'>>>> }> } };
 
 }

--- a/src/__generated__/gatsby-types.d.ts
+++ b/src/__generated__/gatsby-types.d.ts
@@ -6440,18 +6440,24 @@ type SitePluginSortInput = {
   readonly order: Maybe<ReadonlyArray<Maybe<SortOrderEnum>>>;
 };
 
-type SectionFragment = Pick<ContentfulSection, 'id' | 'title'>;
+type SectionFragment = (
+  Pick<ContentfulSection, 'id' | 'title'>
+  & { readonly internal: Pick<Internal, 'type'> }
+);
 
 type ProjectFragment = (
   Pick<ContentfulProject, 'id' | 'title' | 'creationDate' | 'type'>
-  & { readonly description: Maybe<Pick<ContentfulProjectDescription, 'raw'>>, readonly thumbnail: Maybe<Pick<ContentfulAsset, 'id'>> }
+  & { readonly description: Maybe<Pick<ContentfulProjectDescription, 'raw'>>, readonly thumbnail: Maybe<Pick<ContentfulAsset, 'id'>>, readonly internal: Pick<Internal, 'type'> }
 );
 
-type LinkFragment = Pick<ContentfulLink, 'title' | 'url'>;
+type LinkFragment = (
+  Pick<ContentfulLink, 'id' | 'title' | 'url'>
+  & { readonly internal: Pick<Internal, 'type'> }
+);
 
 type TextFragment = (
   Pick<ContentfulText, 'id' | 'imageType'>
-  & { readonly text: Maybe<Pick<ContentfulTextText, 'raw'>> }
+  & { readonly text: Maybe<Pick<ContentfulTextText, 'raw'>>, readonly internal: Pick<Internal, 'type'> }
 );
 
 type PageQueryVariables = Exact<{
@@ -6485,6 +6491,19 @@ type FooterQuery = { readonly allContentfulSection: { readonly nodes: ReadonlyAr
           Pick<ContentfulLink, 'url' | 'title'>
           & { readonly icon: Maybe<Pick<contentfulLinkIconTextNode, 'icon'>> }
         )>>> }>>> }> } };
+
+type SiteVersionQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+type SiteVersionQuery = { readonly githubData: Maybe<{ readonly data: Maybe<{ readonly repository: Maybe<{ readonly refs: Maybe<{ readonly nodes: Maybe<ReadonlyArray<Maybe<(
+            Pick<GithubDataDataRepositoryRefsNodes, 'name'>
+            & { readonly target: Maybe<Pick<GithubDataDataRepositoryRefsNodesTarget, 'oid'>> }
+          )>>> }> }> }> }> };
+
+type HeaderQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+type HeaderQuery = { readonly allContentfulSection: { readonly nodes: ReadonlyArray<{ readonly blocks: Maybe<ReadonlyArray<Maybe<Pick<ContentfulLink, 'title' | 'url'>>>> }> } };
 
 type GatsbyContentfulFixedFragment = Pick<ContentfulFixed, 'base64' | 'width' | 'height' | 'src' | 'srcSet'>;
 
@@ -6531,18 +6550,5 @@ type GatsbyImageSharpFluid_withWebp_tracedSVGFragment = Pick<ImageSharpFluid, 't
 type GatsbyImageSharpFluid_noBase64Fragment = Pick<ImageSharpFluid, 'aspectRatio' | 'src' | 'srcSet' | 'sizes'>;
 
 type GatsbyImageSharpFluid_withWebp_noBase64Fragment = Pick<ImageSharpFluid, 'aspectRatio' | 'src' | 'srcSet' | 'srcWebp' | 'srcSetWebp' | 'sizes'>;
-
-type SiteVersionQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-type SiteVersionQuery = { readonly githubData: Maybe<{ readonly data: Maybe<{ readonly repository: Maybe<{ readonly refs: Maybe<{ readonly nodes: Maybe<ReadonlyArray<Maybe<(
-            Pick<GithubDataDataRepositoryRefsNodes, 'name'>
-            & { readonly target: Maybe<Pick<GithubDataDataRepositoryRefsNodesTarget, 'oid'>> }
-          )>>> }> }> }> }> };
-
-type HeaderQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-type HeaderQuery = { readonly allContentfulSection: { readonly nodes: ReadonlyArray<{ readonly blocks: Maybe<ReadonlyArray<Maybe<Pick<ContentfulLink, 'title' | 'url'>>>> }> } };
 
 }

--- a/src/__generated__/gatsby-types.d.ts
+++ b/src/__generated__/gatsby-types.d.ts
@@ -257,6 +257,8 @@ type Directory_ctimeArgs = {
 type Site = Node & {
   readonly buildTime: Maybe<Scalars['Date']>;
   readonly siteMetadata: Maybe<SiteSiteMetadata>;
+  readonly port: Maybe<Scalars['Int']>;
+  readonly host: Maybe<Scalars['String']>;
   readonly polyfill: Maybe<Scalars['Boolean']>;
   readonly pathPrefix: Maybe<Scalars['String']>;
   readonly id: Scalars['ID'];
@@ -1360,6 +1362,8 @@ type Query_allDirectoryArgs = {
 type Query_siteArgs = {
   buildTime: Maybe<DateQueryOperatorInput>;
   siteMetadata: Maybe<SiteSiteMetadataFilterInput>;
+  port: Maybe<IntQueryOperatorInput>;
+  host: Maybe<StringQueryOperatorInput>;
   polyfill: Maybe<BooleanQueryOperatorInput>;
   pathPrefix: Maybe<StringQueryOperatorInput>;
   id: Maybe<StringQueryOperatorInput>;
@@ -2462,6 +2466,8 @@ type SiteFieldsEnum =
   | 'siteMetadata.description'
   | 'siteMetadata.author'
   | 'siteMetadata.siteUrl'
+  | 'port'
+  | 'host'
   | 'polyfill'
   | 'pathPrefix'
   | 'id'
@@ -2563,6 +2569,8 @@ type SiteGroupConnection = {
 type SiteFilterInput = {
   readonly buildTime: Maybe<DateQueryOperatorInput>;
   readonly siteMetadata: Maybe<SiteSiteMetadataFilterInput>;
+  readonly port: Maybe<IntQueryOperatorInput>;
+  readonly host: Maybe<StringQueryOperatorInput>;
   readonly polyfill: Maybe<BooleanQueryOperatorInput>;
   readonly pathPrefix: Maybe<StringQueryOperatorInput>;
   readonly id: Maybe<StringQueryOperatorInput>;
@@ -6440,6 +6448,19 @@ type SiteVersionQuery = { readonly githubData: Maybe<{ readonly data: Maybe<{ re
             & { readonly target: Maybe<Pick<GithubDataDataRepositoryRefsNodesTarget, 'oid'>> }
           )>>> }> }> }> }> };
 
+type FooterQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+type FooterQuery = { readonly allContentfulSection: { readonly nodes: ReadonlyArray<{ readonly blocks: Maybe<ReadonlyArray<Maybe<Pick<ContentfulLink, 'title' | 'url'> | { readonly blocks: Maybe<ReadonlyArray<Maybe<(
+          Pick<ContentfulLink, 'url' | 'title'>
+          & { readonly icon: Maybe<Pick<contentfulLinkIconTextNode, 'icon'>> }
+        )>>> }>>> }> } };
+
+type HeaderQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+type HeaderQuery = { readonly allContentfulSection: { readonly nodes: ReadonlyArray<{ readonly blocks: Maybe<ReadonlyArray<Maybe<Pick<ContentfulLink, 'title' | 'url'>>>> }> } };
+
 type GatsbyContentfulFixedFragment = Pick<ContentfulFixed, 'base64' | 'width' | 'height' | 'src' | 'srcSet'>;
 
 type GatsbyContentfulFixed_tracedSVGFragment = Pick<ContentfulFixed, 'tracedSVG' | 'width' | 'height' | 'src' | 'srcSet'>;
@@ -6459,11 +6480,6 @@ type GatsbyContentfulFluid_noBase64Fragment = Pick<ContentfulFluid, 'aspectRatio
 type GatsbyContentfulFluid_withWebpFragment = Pick<ContentfulFluid, 'base64' | 'aspectRatio' | 'src' | 'srcSet' | 'srcWebp' | 'srcSetWebp' | 'sizes'>;
 
 type GatsbyContentfulFluid_withWebp_noBase64Fragment = Pick<ContentfulFluid, 'aspectRatio' | 'src' | 'srcSet' | 'srcWebp' | 'srcSetWebp' | 'sizes'>;
-
-type HeaderQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-type HeaderQuery = { readonly allContentfulSection: { readonly edges: ReadonlyArray<{ readonly node: { readonly blocks: Maybe<ReadonlyArray<Maybe<Pick<ContentfulLink, 'title' | 'url'>>>> } }> } };
 
 type GatsbyImageSharpFixedFragment = Pick<ImageSharpFixed, 'base64' | 'width' | 'height' | 'src' | 'srcSet'>;
 
@@ -6490,13 +6506,5 @@ type GatsbyImageSharpFluid_withWebp_tracedSVGFragment = Pick<ImageSharpFluid, 't
 type GatsbyImageSharpFluid_noBase64Fragment = Pick<ImageSharpFluid, 'aspectRatio' | 'src' | 'srcSet' | 'sizes'>;
 
 type GatsbyImageSharpFluid_withWebp_noBase64Fragment = Pick<ImageSharpFluid, 'aspectRatio' | 'src' | 'srcSet' | 'srcWebp' | 'srcSetWebp' | 'sizes'>;
-
-type FooterQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-type FooterQuery = { readonly allContentfulSection: { readonly edges: ReadonlyArray<{ readonly node: { readonly blocks: Maybe<ReadonlyArray<Maybe<Pick<ContentfulLink, 'title' | 'url'> | { readonly blocks: Maybe<ReadonlyArray<Maybe<(
-            Pick<ContentfulLink, 'url' | 'title'>
-            & { readonly icon: Maybe<Pick<contentfulLinkIconTextNode, 'icon'>> }
-          )>>> }>>> } }> } };
 
 }

--- a/src/hooks/fetchFooter.ts
+++ b/src/hooks/fetchFooter.ts
@@ -1,29 +1,28 @@
 import { graphql, useStaticQuery } from 'gatsby'
 
 /**
- * Fetches header data when needed and returns it as a header query
+ * Fetches the section corresponding to the footer and finds the nodes within it
+ * to transform into sections and links
  *
- * @return  {GatsbyTypes.FooterQuery}  The return value of the header query
+ * @return  {GatsbyTypes.FooterQuery}  nodes with blocks of Links or Sections
  */
 export const fetchFooter = (): GatsbyTypes.FooterQuery =>
 	useStaticQuery<GatsbyTypes.FooterQuery>(graphql`
 		query Footer {
 			allContentfulSection(filter: { title: { eq: "Footer" } }) {
-				edges {
-					node {
-						blocks {
-							... on ContentfulLink {
-								title
-								url
-							}
-							... on ContentfulSection {
-								blocks {
-									... on ContentfulLink {
-										url
-										title
-										icon {
-											icon
-										}
+				nodes {
+					blocks {
+						... on ContentfulLink {
+							title
+							url
+						}
+						... on ContentfulSection {
+							blocks {
+								... on ContentfulLink {
+									url
+									title
+									icon {
+										icon
 									}
 								}
 							}

--- a/src/hooks/fetchHeader.ts
+++ b/src/hooks/fetchHeader.ts
@@ -1,21 +1,20 @@
 import { graphql, useStaticQuery } from 'gatsby'
 
 /**
- * Fetches header data when needed and returns it as a header query
+ * Fetches the section corresponding to the header and finds the nodes within it
+ * to transform into links
  *
- * @return  {GatsbyTypes.HeaderQuery}  The return value of the header query
+ * @return  {GatsbyTypes.HeaderQuery}  nodes with blocks of links
  */
 export const fetchHeader = (): GatsbyTypes.HeaderQuery =>
 	useStaticQuery<GatsbyTypes.HeaderQuery>(graphql`
 		query Header {
 			allContentfulSection(filter: { title: { eq: "Header" } }) {
-				edges {
-					node {
-						blocks {
-							... on ContentfulLink {
-								title
-								url
-							}
+				nodes {
+					blocks {
+						... on ContentfulLink {
+							title
+							url
 						}
 					}
 				}

--- a/src/templates/Page.tsx
+++ b/src/templates/Page.tsx
@@ -1,3 +1,4 @@
+import { graphql } from 'gatsby'
 import * as React from 'react'
 import SiteFooter from './SiteFooter'
 import SiteHeader from './SiteHeader'
@@ -15,13 +16,94 @@ const headingStyles = {
 }
 
 /**
- * All type definitions for a page object (TODO: this component fetches more data)
+ * All type definitions for a page object
  */
 type PageProps = {
 	pageContext: {
 		id: string
 	}
+	data: GatsbyTypes.PageQuery
 }
+
+/**
+ * Fetches data for a page - this fetches section data up to three layers deep.
+ */
+export const query = graphql`
+	fragment Text on ContentfulText {
+		id
+		imageType
+		text {
+			raw
+		}
+	}
+
+	fragment Section on ContentfulSection {
+		id
+		title
+	}
+
+	fragment Project on ContentfulProject {
+		id
+		title
+		creationDate
+		description {
+			raw
+		}
+		type
+		thumbnail {
+			id
+		}
+	}
+
+	fragment Link on ContentfulLink {
+		title
+		url
+	}
+
+	query Page($id: String) {
+		contentfulPage(id: { eq: $id }) {
+			title
+			sections {
+				... on ContentfulSection {
+					...Section
+					blocks {
+						... on ContentfulProject {
+							...Project
+						}
+						... on ContentfulLink {
+							...Link
+						}
+						... on ContentfulSection {
+							...Section
+							blocks {
+								... on ContentfulProject {
+									...Project
+								}
+								... on ContentfulLink {
+									...Link
+								}
+								... on ContentfulSection {
+									...Section
+									blocks {
+										... on ContentfulProject {
+											...Project
+										}
+										... on ContentfulLink {
+											...Link
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+				... on ContentfulText {
+					...Text
+				}
+			}
+		}
+	}
+`
 
 /**
  * A generic render of a page type object, with footer + navigation + content

--- a/src/templates/Page.tsx
+++ b/src/templates/Page.tsx
@@ -1,5 +1,6 @@
 import { graphql } from 'gatsby'
 import * as React from 'react'
+import Section from './Section'
 import SiteFooter from './SiteFooter'
 import SiteHeader from './SiteHeader'
 
@@ -35,11 +36,17 @@ export const query = graphql`
 		text {
 			raw
 		}
+		internal {
+			type
+		}
 	}
 
 	fragment Section on ContentfulSection {
 		id
 		title
+		internal {
+			type
+		}
 	}
 
 	fragment Project on ContentfulProject {
@@ -53,11 +60,18 @@ export const query = graphql`
 		thumbnail {
 			id
 		}
+		internal {
+			type
+		}
 	}
 
 	fragment Link on ContentfulLink {
+		id
 		title
 		url
+		internal {
+			type
+		}
 	}
 
 	query Page($id: String) {
@@ -108,19 +122,25 @@ export const query = graphql`
 /**
  * A generic render of a page type object, with footer + navigation + content
  * @param props An object containing `PageProps`
- * @returns A React.FunctionalComponent for the page itself
+ * @returns An element for the page itself
  */
-const Page = ({ pageContext: { id } }: PageProps): JSX.Element => (
-	<>
-		<header>
-			<title>{id}</title>
-			<SiteHeader />
-		</header>
-		<main style={pageStyles}>
-			<h1 style={headingStyles}>{id}</h1>
-		</main>
-		<SiteFooter />
-	</>
-)
+const Page = ({ data }: PageProps): JSX.Element => {
+	if (!data.contentfulPage?.title) {
+		throw TypeError('Badly formatted page data')
+	}
+	return (
+		<>
+			<header>
+				<title>{data.contentfulPage.title}</title>
+				<SiteHeader />
+			</header>
+			<main style={pageStyles}>
+				<h1 style={headingStyles}>{data.contentfulPage.title}</h1>
+				<Section blocks={data.contentfulPage?.sections} />
+			</main>
+			<SiteFooter />
+		</>
+	)
+}
 
 export default Page

--- a/src/templates/Section.tsx
+++ b/src/templates/Section.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react'
+import Link from './Link'
+
+/**
+ * This is the array of section type that is nested within BlockType
+ */
+type BlockArrayType = GatsbyTypes.Maybe<ReadonlyArray<BlockType>>
+
+/**
+ * This is the "input type" - all section types are possibly of this type, so make it recursive and type-safe!
+ */
+type BlockType = GatsbyTypes.Maybe<
+	| GatsbyTypes.TextFragment
+	| GatsbyTypes.LinkFragment
+	| GatsbyTypes.ProjectFragment
+	| (GatsbyTypes.SectionFragment & {
+			blocks: BlockArrayType
+	  })
+>
+
+/**
+ * Top level page has a list of blocks we pass in to start the recursion
+ */
+type PageProps = {
+	blocks: BlockArrayType
+}
+
+/**
+ * @param item An optional block fragment
+ * @returns The text fragment if it's really text
+ */
+const isTextFragment = (item: BlockType): item is GatsbyTypes.TextFragment =>
+	item?.internal.type === 'ContentfulText'
+
+/**
+ * @param item An optional block fragment
+ * @returns The link fragment if it's really a link
+ */
+const isLinkFragment = (item: BlockType): item is GatsbyTypes.LinkFragment =>
+	item?.internal.type === 'ContentfulLink'
+
+/**
+ * @param item An optional block fragment
+ * @returns The project fragment if it's really a project
+ */
+const isProjectFragment = (
+	item: BlockType
+): item is GatsbyTypes.ProjectFragment =>
+	item?.internal.type === 'ContentfulProject'
+
+/**
+ * Creates an element from one block based on its internal type
+ * @param block A block that may be almost anything
+ * @returns An element to nest somewhere else
+ */
+const generateElement = (block: BlockType): JSX.Element => {
+	if (!block) {
+		throw TypeError("Section wasn't defined")
+	}
+	if (isTextFragment(block)) {
+		return <p key={block.id}>{block.id}</p>
+	} else if (isLinkFragment(block)) {
+		return <Link key={block.id} link={block} />
+	} else if (isProjectFragment(block)) {
+		return <p key={block.id}>{block.title}</p>
+	} else {
+		return <Section key={block.id} blocks={block.blocks} />
+	}
+}
+
+/**
+ * A recursively-defined Section that can have a link, project, text, or another section within it.
+ * @param props An object containing `PageProps`
+ * @returns An element for the section as a list
+ */
+const Section = ({ blocks }: PageProps): JSX.Element => (
+	<ul>
+		{blocks?.map((block) => (
+			<li key={block?.id}>{generateElement(block)}</li>
+		))}
+	</ul>
+)
+
+export default Section

--- a/src/templates/SiteFooter.tsx
+++ b/src/templates/SiteFooter.tsx
@@ -35,8 +35,7 @@ const SiteFooter = (): JSX.Element => {
 	const version = fetchSiteVersion()
 
 	// Separates footer data into text links and icon links
-	const footerData =
-		fetchFooter().allContentfulSection.edges[0]?.node.blocks ?? []
+	const footerData = fetchFooter().allContentfulSection.nodes[0]?.blocks ?? []
 
 	const textLinks = (footerData.filter(
 		(data) => (data as GatsbyTypes.ContentfulLink)?.url !== undefined

--- a/src/templates/SiteHeader.tsx
+++ b/src/templates/SiteHeader.tsx
@@ -16,8 +16,8 @@ const headingStyles = {
  */
 const generateLinkElements = () => {
 	const headerData = fetchHeader()
-	return headerData.allContentfulSection.edges
-		.flatMap((edge) => edge.node.blocks)
+	return headerData.allContentfulSection.nodes
+		.flatMap((node) => node.blocks)
 		.map((link) => <LinkListItem key={link?.title} link={link} />)
 }
 


### PR DESCRIPTION
The Section element knows how to render itself recursively, and can be a text node, link,
project, or another section. This can be expanded really easily to cover even more types.
And it's used in the Page template to show some more basic data.

Also simplifies some other `edges -> node -> x` calls to just be `nodes -> x`

![image](https://user-images.githubusercontent.com/982182/116354873-e0585c00-a7ad-11eb-871a-aac2309a1242.png)
