### PR TITLE
fix: uses version matching commit instead of latest

### DIFF
--- a/codegen.yml
+++ b/codegen.yml
@@ -1,8 +1,4 @@
 overwrite: true
-config:
-  namingConvention:
-    typeNames: change-case-all#pascalCase
-    transformUnderscore: true
 hooks:
   afterAllFileWrite:
     - prettier --write
@@ -75,7 +71,7 @@ generates:
         Base64String: string
         Date: string
         DateTime: string
-        GitObjectId: string
+        GitObjectID: string
         GitSSHRemote: string
         GitTimestamp: string
         HTML: string

--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,14 @@
  * */
 const nextConfig = {
   reactStrictMode: true,
+  webpack: (config, { isServer }) => {
+    if (!isServer) {
+      const copy = { ...config };
+      copy.resolve.fallback = { fs: false, path: false, child_process: false, util: false };
+      return copy;
+    }
+    return config;
+  },
   experimental: {
     // Enables the styled-components SWC transform
     styledComponents: true,

--- a/next.config.js
+++ b/next.config.js
@@ -3,14 +3,6 @@
  * */
 const nextConfig = {
   reactStrictMode: true,
-  webpack: (config, { isServer }) => {
-    if (!isServer) {
-      const copy = { ...config };
-      copy.resolve.fallback = { fs: false, path: false, child_process: false, util: false };
-      return copy;
-    }
-    return config;
-  },
   experimental: {
     // Enables the styled-components SWC transform
     styledComponents: true,

--- a/src/api/contentful/fetchSiteFooter.ts
+++ b/src/api/contentful/fetchSiteFooter.ts
@@ -56,7 +56,6 @@ const fetchSiteFooter = async (): Promise<SiteFooter> => {
   const data = await fetchContentfulData<SiteFooterQuery>(QUERY);
   const items =
     data?.sectionCollection?.items.flatMap((item) => item?.blocksCollection?.items ?? []) ?? [];
-  console.log(items);
   const iconLinks = items
     .filter(isSection)
     .flatMap((section) => section.blocksCollection)

--- a/src/api/github/fetchRepoVersion.ts
+++ b/src/api/github/fetchRepoVersion.ts
@@ -24,7 +24,7 @@ const QUERY = gql`
  * to run on client, but it'll gracefully fallback to the fallback.
  */
 const fetchRepoVersion = async () => {
-  const commitSha = process.env.VERCEL_GIT_COMMIT_SHA;
+  const commitSha = process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA;
   if (!commitSha && !process.env.NODE_ENV) {
     // Fallback for browser only
     return undefined;

--- a/src/api/github/fetchRepoVersion.ts
+++ b/src/api/github/fetchRepoVersion.ts
@@ -5,19 +5,37 @@ import { DgRepoLatestReleaseQuery } from './generated/fetchRepoVersion.generated
 const QUERY = gql`
   query DgRepoLatestRelease {
     repository(name: "dg", owner: "dgattey") {
-      latestRelease {
-        name
+      releases(last: 100) {
+        nodes {
+          name
+          tagCommit {
+            oid
+          }
+        }
       }
     }
   }
 `;
 
 /**
- * Grabs latest version of the repo from Github
+ * Grabs the last 100 versions from Github, and our HEAD commit SHA from
+ * the filesystem. Compare the releases' `oid`s to the current HEAD to
+ * see which one matches. If any do, the first is returned. Won't be able
+ * to run on client, but it'll gracefully fallback to the fallback.
  */
 const fetchRepoVersion = async () => {
   const data = await fetchGithubData<DgRepoLatestReleaseQuery>(QUERY);
-  return data?.repository?.latestRelease?.name;
+  const releases = data?.repository?.releases?.nodes;
+  try {
+    const { promisify } = await import('util');
+    const exec = promisify((await import('child_process')).exec);
+    const { stdout: commitSha } = await exec('git rev-parse HEAD');
+    const filteredReleases =
+      releases?.filter((release) => release?.tagCommit?.oid === commitSha.trim()) ?? [];
+    return filteredReleases[0]?.name ?? null;
+  } catch {
+    return undefined;
+  }
 };
 
 export default fetchRepoVersion;

--- a/src/api/github/fetchRepoVersion.ts
+++ b/src/api/github/fetchRepoVersion.ts
@@ -32,7 +32,9 @@ const fetchRepoVersion = async () => {
     const { stdout: commitSha } = await exec('git rev-parse HEAD');
     const filteredReleases =
       releases?.filter((release) => release?.tagCommit?.oid === commitSha.trim()) ?? [];
-    return filteredReleases[0]?.name ?? null;
+    // If we have a release that matched, return it, otherwise the last release
+    const fallbackValue = `${releases?.[(releases?.length ?? 0) - 1]?.name}-ra2d71g12339`;
+    return filteredReleases[0]?.name ?? fallbackValue;
   } catch {
     return undefined;
   }

--- a/src/api/github/generated/api.generated.ts
+++ b/src/api/github/generated/api.generated.ts
@@ -17,7 +17,7 @@ export type Scalars = {
   /** An ISO-8601 encoded UTC date string. */
   DateTime: string;
   /** A Git object ID. */
-  GitObjectID: unknown;
+  GitObjectID: string;
   /** Git SSH string */
   GitSSHRemote: string;
   /** An ISO-8601 encoded date string. Unlike the DateTime type, GitTimestamp is not converted in UTC. */

--- a/src/api/github/generated/fetchRepoVersion.generated.ts
+++ b/src/api/github/generated/fetchRepoVersion.generated.ts
@@ -4,6 +4,18 @@ export type DgRepoLatestReleaseQueryVariables = Types.Exact<{ [key: string]: nev
 
 export type DgRepoLatestReleaseQuery = {
   readonly repository:
-    | { readonly latestRelease: { readonly name: string | undefined } | undefined }
+    | {
+        readonly releases: {
+          readonly nodes:
+            | ReadonlyArray<
+                | {
+                    readonly name: string | undefined;
+                    readonly tagCommit: { readonly oid: any } | undefined;
+                  }
+                | undefined
+              >
+            | undefined;
+        };
+      }
     | undefined;
 };


### PR DESCRIPTION
# Description of changes

So before, I was just fetching the latest release from Github. This obviously fails if I ever have to rollback/etc. Instead, I fetch all versions with their tagCommit's oids, then compare those against the HEAD from local git. Obviously it has to exist, but it should be able to find the matching commit easily. Let's see if it works on Vercel.

Only thing - not sure why oid is `any` in the generated Query 🤔 