### PR TITLE
feat: fetch real project data + add thumbnails on home page

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -7,6 +7,9 @@ const nextConfig = {
     // Enables the styled-components SWC transform
     styledComponents: true,
   },
+  images: {
+    domains: ['images.ctfassets.net'],
+  },
 };
 
 module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "next": "12.0.7",
     "react": "17.0.2",
     "react-dom": "17.0.2",
+    "react-icons": "4.3.1",
     "react-is": "17.0.2",
     "styled-components": "5.3.3",
     "swr": "1.1.2-beta.0"

--- a/src/api/contentful/fetchProjects.ts
+++ b/src/api/contentful/fetchProjects.ts
@@ -1,0 +1,45 @@
+import { gql } from 'graphql-request';
+import fetchGraphQLData from '../fetchGraphQLData';
+import { Project } from './generated/api.generated';
+import { ProjectsQuery } from './generated/fetchProjects.generated';
+import { isProject } from './typeguards';
+
+type Projects = Array<Project>;
+
+/**
+ * Grabs all projects to display
+ */
+const QUERY = gql`
+  query Projects {
+    projectCollection(order: creationDate_DESC) {
+      items {
+        title
+        creationDate
+        type
+        link {
+          url
+        }
+        layout
+        thumbnail {
+          url
+          width
+          height
+        }
+        description {
+          json
+        }
+      }
+    }
+  }
+`;
+
+/**
+ * Fetches the section corresponding to the projects and finds the nodes within it
+ * to transform into Projects
+ */
+const fetchProjects = async (): Promise<Projects> => {
+  const data = await fetchGraphQLData<ProjectsQuery>('/api/content', QUERY);
+  return data?.projectCollection?.items.filter(isProject) ?? [];
+};
+
+export default fetchProjects;

--- a/src/api/contentful/generated/api.generated.ts
+++ b/src/api/contentful/generated/api.generated.ts
@@ -129,8 +129,16 @@ export type AssetFilter = {
 };
 
 export type AssetLinkingCollections = {
+  readonly bookCollection: Maybe<BookCollection>;
   readonly entryCollection: Maybe<EntryCollection>;
   readonly projectCollection: Maybe<ProjectCollection>;
+};
+
+export type AssetLinkingCollectionsBookCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']>;
+  locale: InputMaybe<Scalars['String']>;
+  preview: InputMaybe<Scalars['Boolean']>;
+  skip?: InputMaybe<Scalars['Int']>;
 };
 
 export type AssetLinkingCollectionsEntryCollectionArgs = {
@@ -173,9 +181,10 @@ export type AssetOrder =
 export type Book = Entry & {
   readonly author: Maybe<Scalars['String']>;
   readonly contentfulMetadata: ContentfulMetadata;
-  readonly coverImageUrl: Maybe<Scalars['String']>;
+  readonly coverImage: Maybe<Asset>;
   readonly description: Maybe<BookDescription>;
   readonly linkedFrom: Maybe<BookLinkingCollections>;
+  readonly readDate: Maybe<Scalars['DateTime']>;
   readonly sys: Sys;
   readonly title: Maybe<Scalars['String']>;
 };
@@ -186,8 +195,9 @@ export type BookAuthorArgs = {
 };
 
 /** All data describing a recent book I've read. [See type definition](https://app.contentful.com/spaces/nb3rzo39eupw/content_types/book) */
-export type BookCoverImageUrlArgs = {
+export type BookCoverImageArgs = {
   locale: InputMaybe<Scalars['String']>;
+  preview: InputMaybe<Scalars['Boolean']>;
 };
 
 /** All data describing a recent book I've read. [See type definition](https://app.contentful.com/spaces/nb3rzo39eupw/content_types/book) */
@@ -198,6 +208,11 @@ export type BookDescriptionArgs = {
 /** All data describing a recent book I've read. [See type definition](https://app.contentful.com/spaces/nb3rzo39eupw/content_types/book) */
 export type BookLinkedFromArgs = {
   allowedLocales: InputMaybe<ReadonlyArray<InputMaybe<Scalars['String']>>>;
+};
+
+/** All data describing a recent book I've read. [See type definition](https://app.contentful.com/spaces/nb3rzo39eupw/content_types/book) */
+export type BookReadDateArgs = {
+  locale: InputMaybe<Scalars['String']>;
 };
 
 /** All data describing a recent book I've read. [See type definition](https://app.contentful.com/spaces/nb3rzo39eupw/content_types/book) */
@@ -244,16 +259,19 @@ export type BookFilter = {
   readonly author_not_contains: InputMaybe<Scalars['String']>;
   readonly author_not_in: InputMaybe<ReadonlyArray<InputMaybe<Scalars['String']>>>;
   readonly contentfulMetadata: InputMaybe<ContentfulMetadataFilter>;
-  readonly coverImageUrl: InputMaybe<Scalars['String']>;
-  readonly coverImageUrl_contains: InputMaybe<Scalars['String']>;
-  readonly coverImageUrl_exists: InputMaybe<Scalars['Boolean']>;
-  readonly coverImageUrl_in: InputMaybe<ReadonlyArray<InputMaybe<Scalars['String']>>>;
-  readonly coverImageUrl_not: InputMaybe<Scalars['String']>;
-  readonly coverImageUrl_not_contains: InputMaybe<Scalars['String']>;
-  readonly coverImageUrl_not_in: InputMaybe<ReadonlyArray<InputMaybe<Scalars['String']>>>;
+  readonly coverImage_exists: InputMaybe<Scalars['Boolean']>;
   readonly description_contains: InputMaybe<Scalars['String']>;
   readonly description_exists: InputMaybe<Scalars['Boolean']>;
   readonly description_not_contains: InputMaybe<Scalars['String']>;
+  readonly readDate: InputMaybe<Scalars['DateTime']>;
+  readonly readDate_exists: InputMaybe<Scalars['Boolean']>;
+  readonly readDate_gt: InputMaybe<Scalars['DateTime']>;
+  readonly readDate_gte: InputMaybe<Scalars['DateTime']>;
+  readonly readDate_in: InputMaybe<ReadonlyArray<InputMaybe<Scalars['DateTime']>>>;
+  readonly readDate_lt: InputMaybe<Scalars['DateTime']>;
+  readonly readDate_lte: InputMaybe<Scalars['DateTime']>;
+  readonly readDate_not: InputMaybe<Scalars['DateTime']>;
+  readonly readDate_not_in: InputMaybe<ReadonlyArray<InputMaybe<Scalars['DateTime']>>>;
   readonly sys: InputMaybe<SysFilter>;
   readonly title: InputMaybe<Scalars['String']>;
   readonly title_contains: InputMaybe<Scalars['String']>;
@@ -286,8 +304,8 @@ export type BookLinkingCollectionsSectionCollectionArgs = {
 export type BookOrder =
   | 'author_ASC'
   | 'author_DESC'
-  | 'coverImageUrl_ASC'
-  | 'coverImageUrl_DESC'
+  | 'readDate_ASC'
+  | 'readDate_DESC'
   | 'sys_firstPublishedAt_ASC'
   | 'sys_firstPublishedAt_DESC'
   | 'sys_id_ASC'
@@ -555,6 +573,7 @@ export type Project = Entry & {
   readonly contentfulMetadata: ContentfulMetadata;
   readonly creationDate: Maybe<Scalars['DateTime']>;
   readonly description: Maybe<ProjectDescription>;
+  readonly layout: Maybe<Scalars['String']>;
   readonly link: Maybe<Link>;
   readonly linkedFrom: Maybe<ProjectLinkingCollections>;
   readonly sys: Sys;
@@ -570,6 +589,11 @@ export type ProjectCreationDateArgs = {
 
 /** Website, app, other code-based project, or graphics created for something. [See type definition](https://app.contentful.com/spaces/nb3rzo39eupw/content_types/project) */
 export type ProjectDescriptionArgs = {
+  locale: InputMaybe<Scalars['String']>;
+};
+
+/** Website, app, other code-based project, or graphics created for something. [See type definition](https://app.contentful.com/spaces/nb3rzo39eupw/content_types/project) */
+export type ProjectLayoutArgs = {
   locale: InputMaybe<Scalars['String']>;
 };
 
@@ -644,6 +668,13 @@ export type ProjectFilter = {
   readonly description_contains: InputMaybe<Scalars['String']>;
   readonly description_exists: InputMaybe<Scalars['Boolean']>;
   readonly description_not_contains: InputMaybe<Scalars['String']>;
+  readonly layout: InputMaybe<Scalars['String']>;
+  readonly layout_contains: InputMaybe<Scalars['String']>;
+  readonly layout_exists: InputMaybe<Scalars['Boolean']>;
+  readonly layout_in: InputMaybe<ReadonlyArray<InputMaybe<Scalars['String']>>>;
+  readonly layout_not: InputMaybe<Scalars['String']>;
+  readonly layout_not_contains: InputMaybe<Scalars['String']>;
+  readonly layout_not_in: InputMaybe<ReadonlyArray<InputMaybe<Scalars['String']>>>;
   readonly link: InputMaybe<CfLinkNestedFilter>;
   readonly link_exists: InputMaybe<Scalars['Boolean']>;
   readonly sys: InputMaybe<SysFilter>;
@@ -683,6 +714,8 @@ export type ProjectLinkingCollectionsSectionCollectionArgs = {
 export type ProjectOrder =
   | 'creationDate_ASC'
   | 'creationDate_DESC'
+  | 'layout_ASC'
+  | 'layout_DESC'
   | 'sys_firstPublishedAt_ASC'
   | 'sys_firstPublishedAt_DESC'
   | 'sys_id_ASC'
@@ -792,7 +825,7 @@ export type QuerySectionCollectionArgs = {
   where: InputMaybe<SectionFilter>;
 };
 
-/** A section containing references to other blocks. Based on the content of the section, may appear differently on different pages. [See type definition](https://app.contentful.com/spaces/nb3rzo39eupw/content_types/section) */
+/** A collection of references to other nodes [See type definition](https://app.contentful.com/spaces/nb3rzo39eupw/content_types/section) */
 export type Section = Entry & {
   readonly blocksCollection: Maybe<SectionBlocksCollection>;
   readonly contentfulMetadata: ContentfulMetadata;
@@ -801,7 +834,7 @@ export type Section = Entry & {
   readonly title: Maybe<Scalars['String']>;
 };
 
-/** A section containing references to other blocks. Based on the content of the section, may appear differently on different pages. [See type definition](https://app.contentful.com/spaces/nb3rzo39eupw/content_types/section) */
+/** A collection of references to other nodes [See type definition](https://app.contentful.com/spaces/nb3rzo39eupw/content_types/section) */
 export type SectionBlocksCollectionArgs = {
   limit?: InputMaybe<Scalars['Int']>;
   locale: InputMaybe<Scalars['String']>;
@@ -809,12 +842,12 @@ export type SectionBlocksCollectionArgs = {
   skip?: InputMaybe<Scalars['Int']>;
 };
 
-/** A section containing references to other blocks. Based on the content of the section, may appear differently on different pages. [See type definition](https://app.contentful.com/spaces/nb3rzo39eupw/content_types/section) */
+/** A collection of references to other nodes [See type definition](https://app.contentful.com/spaces/nb3rzo39eupw/content_types/section) */
 export type SectionLinkedFromArgs = {
   allowedLocales: InputMaybe<ReadonlyArray<InputMaybe<Scalars['String']>>>;
 };
 
-/** A section containing references to other blocks. Based on the content of the section, may appear differently on different pages. [See type definition](https://app.contentful.com/spaces/nb3rzo39eupw/content_types/section) */
+/** A collection of references to other nodes [See type definition](https://app.contentful.com/spaces/nb3rzo39eupw/content_types/section) */
 export type SectionTitleArgs = {
   locale: InputMaybe<Scalars['String']>;
 };
@@ -826,7 +859,7 @@ export type SectionBlocksCollection = {
   readonly total: Scalars['Int'];
 };
 
-export type SectionBlocksItem = Book | Link | Project | Section;
+export type SectionBlocksItem = Book | Link | Project;
 
 export type SectionCollection = {
   readonly items: ReadonlyArray<Maybe<Section>>;
@@ -852,17 +885,9 @@ export type SectionFilter = {
 
 export type SectionLinkingCollections = {
   readonly entryCollection: Maybe<EntryCollection>;
-  readonly sectionCollection: Maybe<SectionCollection>;
 };
 
 export type SectionLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']>;
-  locale: InputMaybe<Scalars['String']>;
-  preview: InputMaybe<Scalars['Boolean']>;
-  skip?: InputMaybe<Scalars['Int']>;
-};
-
-export type SectionLinkingCollectionsSectionCollectionArgs = {
   limit?: InputMaybe<Scalars['Int']>;
   locale: InputMaybe<Scalars['String']>;
   preview: InputMaybe<Scalars['Boolean']>;

--- a/src/api/contentful/generated/fetchProjects.generated.ts
+++ b/src/api/contentful/generated/fetchProjects.generated.ts
@@ -1,0 +1,28 @@
+import type * as Types from './api.generated';
+
+export type ProjectsQueryVariables = Types.Exact<{ [key: string]: never }>;
+
+export type ProjectsQuery = {
+  readonly projectCollection:
+    | {
+        readonly items: ReadonlyArray<
+          | {
+              readonly title: string | undefined;
+              readonly creationDate: any | undefined;
+              readonly type: ReadonlyArray<string | undefined> | undefined;
+              readonly layout: string | undefined;
+              readonly link: { readonly url: string | undefined } | undefined;
+              readonly thumbnail:
+                | {
+                    readonly url: string | undefined;
+                    readonly width: number | undefined;
+                    readonly height: number | undefined;
+                  }
+                | undefined;
+              readonly description: { readonly json: any } | undefined;
+            }
+          | undefined
+        >;
+      }
+    | undefined;
+};

--- a/src/api/contentful/generated/fetchSiteFooter.generated.ts
+++ b/src/api/contentful/generated/fetchSiteFooter.generated.ts
@@ -15,21 +15,6 @@ export type SiteFooterQuery = {
                           readonly url: string | undefined;
                           readonly icon: string | undefined;
                         }
-                      | {
-                          readonly blocksCollection:
-                            | {
-                                readonly items: ReadonlyArray<
-                                  | {
-                                      readonly title: string | undefined;
-                                      readonly url: string | undefined;
-                                      readonly icon: string | undefined;
-                                    }
-                                  | {}
-                                  | undefined
-                                >;
-                              }
-                            | undefined;
-                        }
                       | {}
                       | undefined
                     >;

--- a/src/api/contentful/typeguards.ts
+++ b/src/api/contentful/typeguards.ts
@@ -1,4 +1,4 @@
-import type { Link } from './generated/api.generated';
+import type { Link, Project } from './generated/api.generated';
 
 /**
  * Type guard to get a link out
@@ -6,6 +6,13 @@ import type { Link } from './generated/api.generated';
 export const isLink = (item: Link | undefined | Record<string, unknown>): item is Link =>
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   !!(item as Link)?.title;
+
+/**
+ * Type guard to get a project out
+ */
+export const isProject = (item: Project | undefined | Record<string, unknown>): item is Project =>
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  !!(item as Project)?.creationDate && !!(item as Project)?.thumbnail;
 
 /**
  * Type guard to filter out null or undefined items

--- a/src/api/useData.ts
+++ b/src/api/useData.ts
@@ -1,4 +1,5 @@
 import useSWR from 'swr';
+import fetchProjects from './contentful/fetchProjects';
 import fetchSiteFooter from './contentful/fetchSiteFooter';
 import fetchSiteHeader from './contentful/fetchSiteHeader';
 import fetchRepoVersion from './github/fetchRepoVersion';
@@ -40,6 +41,11 @@ const fetchers = {
    * Text links for the full site header
    */
   siteHeader: fetchSiteHeader,
+
+  /**
+   * All projects to list on home page
+   */
+  projects: fetchProjects,
 } as const;
 
 /**

--- a/src/components/AppStyle.tsx
+++ b/src/components/AppStyle.tsx
@@ -1,5 +1,5 @@
 import '@picocss/pico/css/pico.min.css';
-import { createGlobalStyle } from 'styled-components';
+import { createGlobalStyle, css } from 'styled-components';
 
 const CONTENT_GRID_DIMENSION = 17;
 const CONTENT_GRID_GAP = 2.5;
@@ -9,6 +9,24 @@ const CONTENT_GRID_GAP = 2.5;
  */
 export const cardSizeInEm = (span = 1) =>
   CONTENT_GRID_DIMENSION * span + (span - 1) * CONTENT_GRID_GAP;
+
+/**
+ * Variables specific to dark mode. Anything that appears here needs to have
+ * something defined in `lightModeVariables` and vice versa.
+ */
+const darkModeVariables = css`
+  --contrast-overlay: var(--contrast-inverse);
+  --contrast-overlay-inverse: var(--contrast);
+`;
+
+/**
+ * Variables specific to light mode. Anything that appears here needs to have
+ * something defined in `darkModeVariables` and vice versa.
+ */
+const lightModeVariables = css`
+  --contrast-overlay: var(--secondary);
+  --contrast-overlay-inverse: var(--secondary-inverse);
+`;
 
 /**
  * Applies styles to the full app
@@ -21,6 +39,24 @@ const AppStyle = createGlobalStyle`
       /* Below here are new variables */
       --content-grid-dimension-em: ${CONTENT_GRID_DIMENSION}em;
       --content-grid-gap-em: ${CONTENT_GRID_GAP}em;
+  }
+
+  // When a page/component is set to light or the root has no dark theme applied
+  [data-theme='light'],
+  :root:not([data-theme='dark']) {
+    ${lightModeVariables};
+  }
+
+  // When a page/component is set to dark
+  [data-theme='dark'] {
+    ${darkModeVariables};
+  }
+
+  // When dark mode is on and the root isn't set to light
+  @media only screen and (prefers-color-scheme: dark) {
+    :root:not([data-theme='light']) {
+      ${darkModeVariables};
+    }
   }
 `;
 

--- a/src/components/AppStyle.tsx
+++ b/src/components/AppStyle.tsx
@@ -1,8 +1,8 @@
 import '@picocss/pico/css/pico.min.css';
 import { createGlobalStyle } from 'styled-components';
 
-const CONTENT_GRID_DIMENSION = 13;
-const CONTENT_GRID_GAP = 1.5;
+const CONTENT_GRID_DIMENSION = 17;
+const CONTENT_GRID_GAP = 2.5;
 
 /**
  * Creates a card size in em from a span

--- a/src/components/AppStyle.tsx
+++ b/src/components/AppStyle.tsx
@@ -5,6 +5,12 @@ const CONTENT_GRID_DIMENSION = 13;
 const CONTENT_GRID_GAP = 1.5;
 
 /**
+ * Creates a card size in em from a span
+ */
+export const cardSizeInEm = (span = 1) =>
+  CONTENT_GRID_DIMENSION * span + (span - 1) * CONTENT_GRID_GAP;
+
+/**
  * Applies styles to the full app
  */
 const AppStyle = createGlobalStyle`
@@ -13,9 +19,7 @@ const AppStyle = createGlobalStyle`
       --border-radius: 1rem;
       
       /* Below here are new variables */
-      --content-grid-dimension: ${CONTENT_GRID_DIMENSION};
       --content-grid-dimension-em: ${CONTENT_GRID_DIMENSION}em;
-      --content-grid-gap: ${CONTENT_GRID_GAP};
       --content-grid-gap-em: ${CONTENT_GRID_GAP}em;
   }
 `;

--- a/src/components/ContentCard.tsx
+++ b/src/components/ContentCard.tsx
@@ -41,7 +41,6 @@ interface CardProps {
 const Card = styled.article<CardProps>`
   position: relative;
   border: var(--border-width) solid var(--secondary-focus);
-  overflow: hidden;
   margin: inherit;
   padding: 0;
   ${({ $isClickable }) =>
@@ -73,8 +72,14 @@ const ContentCard = ({
   verticalSpan,
   isClickable,
   children,
-}: Pick<React.ComponentProps<'article'>, 'children'> & Props) => (
-  <Card $hSpan={horizontalSpan ?? 1} $vSpan={verticalSpan ?? 1} $isClickable={isClickable ?? false}>
+  className,
+}: Pick<React.ComponentProps<'article'>, 'children' | 'className'> & Props) => (
+  <Card
+    className={className}
+    $hSpan={horizontalSpan ?? 1}
+    $vSpan={verticalSpan ?? 1}
+    $isClickable={isClickable ?? false}
+  >
     {children}
   </Card>
 );

--- a/src/components/ContentCard.tsx
+++ b/src/components/ContentCard.tsx
@@ -1,4 +1,5 @@
 import styled, { css } from 'styled-components';
+import { cardSizeInEm } from './AppStyle';
 
 interface Props {
   /**
@@ -38,13 +39,16 @@ interface CardProps {
 
 // Card component that spans an arbitrary number of rows/cols
 const Card = styled.article<CardProps>`
+  position: relative;
   border: var(--border-width) solid var(--secondary-focus);
   overflow: hidden;
   margin: inherit;
+  padding: 0;
   ${({ $isClickable }) =>
     $isClickable &&
     css`
       cursor: pointer;
+      -webkit-transform-style: preserve-3d;
       transition: transform var(--transition);
       &:hover {
         transform: scale(1.02);
@@ -56,9 +60,7 @@ const Card = styled.article<CardProps>`
   `};
   ${({ $vSpan }) =>
     css`
-      height: calc(
-        var(--content-grid-dimension-em) * ${$vSpan} + ${$vSpan - 1} * var(--content-grid-gap-em)
-      );
+      height: ${cardSizeInEm($vSpan)}em;
       grid-row-start: span ${$vSpan};
     `}
 `;

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -1,0 +1,40 @@
+import { Project } from 'api/contentful/generated/api.generated';
+import Image from 'next/image';
+import Link from 'next/link';
+import styled from 'styled-components';
+import ContentCard from './ContentCard';
+
+type Props = Project;
+
+const Title = styled.a`
+  position: absolute;
+  bottom: 10px;
+  left: 10px;
+  background: black;
+`;
+
+/**
+ * Uses the `ContentCard` to show a project's details
+ */
+const ProjectCard = ({ title, layout, link, thumbnail }: Props) => {
+  const verticalSpan = layout === 'tall' ? 2 : 1;
+  const horizontalSpan = layout === 'wide' ? 2 : 1;
+  return (
+    <ContentCard verticalSpan={verticalSpan} horizontalSpan={horizontalSpan} isClickable={!!link}>
+      <Image
+        src={thumbnail?.url}
+        alt={title}
+        layout="responsive"
+        width={thumbnail?.width}
+        height={thumbnail?.height}
+      />
+      {link?.url && (
+        <Link passHref href={link.url}>
+          <Title>{title}</Title>
+        </Link>
+      )}
+    </ContentCard>
+  );
+};
+
+export default ProjectCard;

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -6,11 +6,25 @@ import ContentCard from './ContentCard';
 
 type Props = Project;
 
-const Title = styled.a`
+const Title = styled.strong`
   position: absolute;
-  bottom: 10px;
-  left: 10px;
-  background: black;
+  bottom: 0.5em;
+  left: 0.5em;
+  transition: transform var(--transition);
+  transform: translateY(150%);
+  background: var(--primary);
+  color: var(--primary-inverse);
+  padding: 0.5em 1em;
+  border-radius: 2em;
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.1), 0 0 8px rgba(0, 0, 0, 0.16);
+`;
+
+const Card = styled(ContentCard)`
+  :hover {
+    ${Title} {
+      transform: initial;
+    }
+  }
 `;
 
 /**
@@ -19,21 +33,24 @@ const Title = styled.a`
 const ProjectCard = ({ title, layout, link, thumbnail }: Props) => {
   const verticalSpan = layout === 'tall' ? 2 : 1;
   const horizontalSpan = layout === 'wide' ? 2 : 1;
+  if (!link?.url) {
+    return null;
+  }
   return (
-    <ContentCard verticalSpan={verticalSpan} horizontalSpan={horizontalSpan} isClickable={!!link}>
-      <Image
-        src={thumbnail?.url}
-        alt={title}
-        layout="responsive"
-        width={thumbnail?.width}
-        height={thumbnail?.height}
-      />
-      {link?.url && (
-        <Link passHref href={link.url}>
+    <Link passHref href={link.url}>
+      <Card verticalSpan={verticalSpan} horizontalSpan={horizontalSpan} isClickable={!!link}>
+        <a href={link.url}>
+          <Image
+            src={thumbnail?.url}
+            alt={title}
+            layout="responsive"
+            width={thumbnail?.width}
+            height={thumbnail?.height}
+          />
           <Title>{title}</Title>
-        </Link>
-      )}
-    </ContentCard>
+        </a>
+      </Card>
+    </Link>
   );
 };
 

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -3,36 +3,61 @@ import Image from 'next/image';
 import Link from 'next/link';
 import styled from 'styled-components';
 import ContentCard from './ContentCard';
+import ProjectIcon from './ProjectIcon';
+import Stack from './Stack';
 
 type Props = Project;
 
-const Title = styled.strong`
+// A stack for the title + icon, that animates in from slightly offscreen left when hovered
+const TitleStack = styled(Stack).attrs({ $alignItems: 'center', $gap: '8px' })`
+  overflow: hidden;
   position: absolute;
   bottom: 0.5em;
   left: 0.5em;
-  transition: transform var(--transition);
-  transform: translateY(150%);
-  background: var(--primary);
-  color: var(--primary-inverse);
-  padding: 0.5em 1em;
+  background: var(--contrast-overlay);
+  color: var(--contrast-overlay-inverse);
+  padding: 0.5em 0.75em;
   border-radius: 2em;
   box-shadow: 0 0 4px rgba(0, 0, 0, 0.1), 0 0 8px rgba(0, 0, 0, 0.16);
+
+  transition: transform var(--transition);
+  transform: translateX(calc(2em - 100%));
+`;
+
+// Animates "from right" and fully opaque when hovered - as it's in the stack, it appears to not move since both animate
+const TitleText = styled.strong`
+  white-space: nowrap;
+  transition: opacity var(--transition), transform var(--transition);
+  opacity: 0;
+  transform-origin: right;
+  transform: translateX(100%);
 `;
 
 const Card = styled(ContentCard)`
   :hover {
-    ${Title} {
+    ${TitleStack} {
+      transform: initial;
+    }
+    ${TitleText} {
+      opacity: 1;
       transform: initial;
     }
   }
 `;
 
+// Adds a background and moves it to its own layer so it covers the text as it animates
+const ProjectIconWithBackground = styled(ProjectIcon)`
+  background: var(--contrast-overlay);
+  z-index: 1;
+`;
+
 /**
  * Uses the `ContentCard` to show a project's details
  */
-const ProjectCard = ({ title, layout, link, thumbnail }: Props) => {
+const ProjectCard = ({ title, layout, link, thumbnail, type }: Props) => {
   const verticalSpan = layout === 'tall' ? 2 : 1;
   const horizontalSpan = layout === 'wide' ? 2 : 1;
+
   if (!link?.url) {
     return null;
   }
@@ -40,14 +65,19 @@ const ProjectCard = ({ title, layout, link, thumbnail }: Props) => {
     <Link passHref href={link.url}>
       <Card verticalSpan={verticalSpan} horizontalSpan={horizontalSpan} isClickable={!!link}>
         <a href={link.url}>
-          <Image
-            src={thumbnail?.url}
-            alt={title}
-            layout="responsive"
-            width={thumbnail?.width}
-            height={thumbnail?.height}
-          />
-          <Title>{title}</Title>
+          {thumbnail && (
+            <Image
+              src={thumbnail?.url}
+              alt={title}
+              layout="responsive"
+              width={thumbnail?.width}
+              height={thumbnail?.height}
+            />
+          )}
+          <TitleStack>
+            <TitleText>{title}</TitleText>
+            <ProjectIconWithBackground type={type} />
+          </TitleStack>
         </a>
       </Card>
     </Link>

--- a/src/components/ProjectGrid.tsx
+++ b/src/components/ProjectGrid.tsx
@@ -1,0 +1,20 @@
+import useData from 'api/useData';
+import React from 'react';
+import ContentGrid from './ContentGrid';
+import ProjectCard from './ProjectCard';
+
+/**
+ * Puts all projects into a grid using `projects` data
+ */
+const ProjectGrid = () => {
+  const { data: projects } = useData('projects');
+  return (
+    <ContentGrid>
+      {projects?.map((project) => (
+        <ProjectCard key={project.title} {...project} />
+      ))}
+    </ContentGrid>
+  );
+};
+
+export default ProjectGrid;

--- a/src/components/ProjectIcon.tsx
+++ b/src/components/ProjectIcon.tsx
@@ -1,0 +1,28 @@
+import { Project } from 'api/contentful/generated/api.generated';
+import { FiGlobe, FiMonitor, FiSmartphone } from 'react-icons/fi';
+
+type Props = Pick<Project, 'type'>;
+
+/**
+ * Returns a Feather icon matching a project type or null
+ */
+const ProjectIcon = ({
+  type,
+  className,
+}: Props & Pick<React.ComponentProps<'div'>, 'className'>) => {
+  if (!type?.[0]) {
+    throw new TypeError('Invalid type for project');
+  }
+  switch (type[0]) {
+    case 'Website':
+      return <FiGlobe className={className} />;
+    case 'iOS App':
+      return <FiSmartphone className={className} />;
+    case 'macOS App':
+      return <FiMonitor className={className} />;
+    default:
+      return null;
+  }
+};
+
+export default ProjectIcon;

--- a/src/components/Stack.tsx
+++ b/src/components/Stack.tsx
@@ -1,0 +1,35 @@
+import styled, { css, CSSProperties } from 'styled-components';
+
+/**
+ * Stacks content - has a few properities built in as props for convenience
+ */
+const Stack = styled.div<{
+  $isVertical?: boolean;
+  $gap?: string;
+  $alignItems?: CSSProperties['alignItems'];
+  $justifyContent?: CSSProperties['justifyContent'];
+}>`
+  display: flex;
+  ${({ $isVertical }) =>
+    $isVertical &&
+    css`
+      flex-direction: column;
+    `};
+  ${({ $alignItems }) =>
+    $alignItems &&
+    css`
+      align-items: ${$alignItems};
+    `};
+  ${({ $justifyContent }) =>
+    $justifyContent &&
+    css`
+      justify-content: ${$justifyContent};
+    `};
+  ${({ $gap }) =>
+    $gap &&
+    css`
+      gap: ${$gap};
+    `};
+`;
+
+export default Stack;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,8 +1,7 @@
-import useData, { Fallback, fetchData } from 'api/useData';
-import ContentGrid from 'components/ContentGrid';
+import { Fallback, fetchData } from 'api/useData';
 import Layout from 'components/Layout';
 import Meta from 'components/Meta';
-import ProjectCard from 'components/ProjectCard';
+import ProjectGrid from 'components/ProjectGrid';
 import { GetStaticProps, InferGetStaticPropsType } from 'next/types';
 import React from 'react';
 import { SWRConfig } from 'swr';
@@ -40,23 +39,16 @@ export const getStaticProps: GetStaticProps<Props> = async () => {
 /**
  * Homepage, shows projects + other cards in a grid
  */
-const Home = ({ fallback }: InferGetStaticPropsType<typeof getStaticProps>) => {
-  const { data: projects } = useData('projects');
-  return (
-    <SWRConfig value={{ fallback }}>
-      <Meta
-        title="Engineer, Human"
-        description="I'm Dylan, an engineer focused on building top-notch user experiences. I'm interested in React, Product Design, Sustainability, Startups, Music, and Cycling."
-      />
-      <Layout>
-        <ContentGrid>
-          {projects?.map((project) => (
-            <ProjectCard key={project.title} {...project} />
-          ))}
-        </ContentGrid>
-      </Layout>
-    </SWRConfig>
-  );
-};
+const Home = ({ fallback }: InferGetStaticPropsType<typeof getStaticProps>) => (
+  <SWRConfig value={{ fallback }}>
+    <Meta
+      title="Engineer, Human"
+      description="I'm Dylan, an engineer focused on building top-notch user experiences. I'm interested in React, Product Design, Sustainability, Startups, Music, and Cycling."
+    />
+    <Layout>
+      <ProjectGrid />
+    </Layout>
+  </SWRConfig>
+);
 
 export default Home;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,8 +1,8 @@
-import { Fallback, fetchData } from 'api/useData';
-import ContentCard from 'components/ContentCard';
+import useData, { Fallback, fetchData } from 'api/useData';
 import ContentGrid from 'components/ContentGrid';
 import Layout from 'components/Layout';
 import Meta from 'components/Meta';
+import ProjectCard from 'components/ProjectCard';
 import { GetStaticProps, InferGetStaticPropsType } from 'next/types';
 import React from 'react';
 import { SWRConfig } from 'swr';
@@ -11,7 +11,7 @@ interface Props {
   /**
    * Provides SWR with fallback version data
    */
-  fallback: Fallback<'version' | 'siteFooter' | 'siteHeader'>;
+  fallback: Fallback<'version' | 'siteFooter' | 'siteHeader' | 'projects'>;
 }
 
 /**
@@ -19,10 +19,11 @@ interface Props {
  * provide a fallback for the server side rendering done elsewhere.
  */
 export const getStaticProps: GetStaticProps<Props> = async () => {
-  const [version, siteFooter, siteHeader] = await Promise.all([
+  const [version, siteFooter, siteHeader, projects] = await Promise.all([
     fetchData('version'),
     fetchData('siteFooter'),
     fetchData('siteHeader'),
+    fetchData('projects'),
   ]);
   return {
     props: {
@@ -30,36 +31,32 @@ export const getStaticProps: GetStaticProps<Props> = async () => {
         version,
         siteFooter,
         siteHeader,
+        projects,
       },
     },
   };
 };
 
 /**
- * Homepage, shows dummy data for now, with real data in footer
+ * Homepage, shows projects + other cards in a grid
  */
-const Home = ({ fallback }: InferGetStaticPropsType<typeof getStaticProps>) => (
-  <SWRConfig value={{ fallback }}>
-    <Meta
-      title="Engineer, Human"
-      description="I'm Dylan, an engineer focused on building top-notch user experiences. I'm interested in React, Product Design, Sustainability, Startups, Music, and Cycling."
-    />
-    <Layout>
-      <ContentGrid>
-        <ContentCard>Hi</ContentCard>
-        <ContentCard verticalSpan={2}>Spans wide</ContentCard>
-        <ContentCard horizontalSpan={2}>Spans tall</ContentCard>
-        <ContentCard>I&apos;m regular</ContentCard>
-        <ContentCard isClickable>Here is card 5</ContentCard>
-        <ContentCard verticalSpan={2}>Sixth element</ContentCard>
-        <ContentCard>Third to last (7)</ContentCard>
-        <ContentCard horizontalSpan={2} isClickable>
-          8
-        </ContentCard>
-        <ContentCard>Ninth and last</ContentCard>
-      </ContentGrid>
-    </Layout>
-  </SWRConfig>
-);
+const Home = ({ fallback }: InferGetStaticPropsType<typeof getStaticProps>) => {
+  const { data: projects } = useData('projects');
+  return (
+    <SWRConfig value={{ fallback }}>
+      <Meta
+        title="Engineer, Human"
+        description="I'm Dylan, an engineer focused on building top-notch user experiences. I'm interested in React, Product Design, Sustainability, Startups, Music, and Cycling."
+      />
+      <Layout>
+        <ContentGrid>
+          {projects?.map((project) => (
+            <ProjectCard key={project.title} {...project} />
+          ))}
+        </ContentGrid>
+      </Layout>
+    </SWRConfig>
+  );
+};
 
 export default Home;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7375,6 +7375,11 @@ react-dom@17.0.2:
     object-assign "^4.1.1"
     scheduler "^0.20.2"
 
+react-icons@4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.3.1.tgz#2fa92aebbbc71f43d2db2ed1aed07361124e91ca"
+  integrity sha512-cB10MXLTs3gVuXimblAdI71jrJx8njrJZmNMEMC+sQu5B/BIOmlsAjskdqpn81y8UBVEGuHODd7/ci5DvoSzTQ==
+
 react-is@17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"


### PR DESCRIPTION
# Description of changes

Gets rid of the cards that were already there and adds real data!
1. Shows a card for each project with support for wide/tall cards
2. Each card has a title + icon overlay for the type of project, animates in on hover
3. Adds `react-icons` for icon use
4. Project cards get bigger because they look better 3 abreast instead of 4
5. Support for light/dark mode CSS variables (only at a global level right now, gotta figure out how to do that on component level in future)

<img width="1210" alt="image" src="https://user-images.githubusercontent.com/982182/149444518-3cc2ba12-85ab-4516-8bbc-a525b8636e4a.png">
<img width="427" alt="image" src="https://user-images.githubusercontent.com/982182/149444541-fa2c654d-ebde-4698-a12f-9842e34118a8.png">
<img width="1418" alt="Screen Shot 2022-01-13 at 7 05 03 PM" src="https://user-images.githubusercontent.com/982182/149444656-68554802-620c-443d-a58d-47ae1bd21c58.png">

