### PR TITLE
feat: RichText + intro cards

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "codegen": "DOTENV_CONFIG_PATH='.env.development.local' graphql-codegen --require dotenv/config --config codegen.yml"
   },
   "dependencies": {
+    "@contentful/rich-text-react-renderer": "15.11.1",
+    "@contentful/rich-text-types": "15.11.1",
     "@picocss/pico": "1.4.2",
     "graphql": "16.2.0",
     "graphql-request": "3.7.0",

--- a/src/api/contentful/fetchIntroBlock.ts
+++ b/src/api/contentful/fetchIntroBlock.ts
@@ -1,0 +1,78 @@
+import { gql } from 'graphql-request';
+import fetchGraphQLData from '../fetchGraphQLData';
+import { Asset, TextBlock } from './generated/api.generated';
+import { IntroBlockQuery } from './generated/fetchIntroBlock.generated';
+import { isTextBlock } from './typeguards';
+
+type IntroBlock = {
+  textBlock: TextBlock;
+  image: Pick<Asset, 'url' | 'width' | 'height' | 'title'>;
+} | null;
+
+/**
+ * Grabs the contentful sections with the title of header. Should
+ * be only one.
+ */
+const QUERY = gql`
+  query IntroBlock {
+    asset(id: "1P5peDFKfzDHjWd6mcytc8") {
+      url
+      width
+      height
+      title
+    }
+    textBlockCollection(limit: 1, where: { slug: "intro" }) {
+      items {
+        content {
+          json
+          links {
+            entries {
+              inline {
+                ... on Link {
+                  title
+                  url
+                  icon
+                }
+              }
+              block {
+                ... on Link {
+                  title
+                  url
+                  icon
+                }
+              }
+            }
+            assets {
+              block {
+                sys {
+                  id
+                }
+                url
+                title
+                width
+                height
+                description
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+/**
+ * Fetches the text block corresponding to the introduction rich text
+ * for the home page.
+ */
+const fetchIntroBlock = async (): Promise<IntroBlock> => {
+  const data = await fetchGraphQLData<IntroBlockQuery>('/api/content', QUERY);
+  const textBlock = data?.textBlockCollection?.items?.filter(isTextBlock)?.[0];
+  const image = data?.asset;
+  if (textBlock && image) {
+    return { textBlock, image };
+  }
+  return null;
+};
+
+export default fetchIntroBlock;

--- a/src/api/contentful/fetchSiteHeader.ts
+++ b/src/api/contentful/fetchSiteHeader.ts
@@ -4,12 +4,7 @@ import { Link } from './generated/api.generated';
 import { SiteHeaderQuery } from './generated/fetchSiteHeader.generated';
 import { isLink } from './typeguards';
 
-interface SiteHeader {
-  /**
-   * An array of text links to show
-   */
-  links: Array<Link>;
-}
+type SiteHeader = Array<Link>;
 
 /**
  * Grabs the contentful sections with the title of header. Should
@@ -38,13 +33,11 @@ const QUERY = gql`
  */
 const fetchSiteHeader = async (): Promise<SiteHeader> => {
   const data = await fetchGraphQLData<SiteHeaderQuery>('/api/content', QUERY);
-  const links =
+  return (
     data?.sectionCollection?.items?.flatMap(
       (item) => item?.blocksCollection?.items?.filter(isLink) ?? [],
-    ) ?? [];
-  return {
-    links,
-  };
+    ) ?? []
+  );
 };
 
 export default fetchSiteHeader;

--- a/src/api/contentful/generated/api.generated.ts
+++ b/src/api/contentful/generated/api.generated.ts
@@ -43,13 +43,49 @@ export type Asset = {
 };
 
 /** Represents a binary file in a space. An asset can be any file type. */
+export type AssetContentTypeArgs = {
+  locale: InputMaybe<Scalars['String']>;
+};
+
+/** Represents a binary file in a space. An asset can be any file type. */
+export type AssetDescriptionArgs = {
+  locale: InputMaybe<Scalars['String']>;
+};
+
+/** Represents a binary file in a space. An asset can be any file type. */
+export type AssetFileNameArgs = {
+  locale: InputMaybe<Scalars['String']>;
+};
+
+/** Represents a binary file in a space. An asset can be any file type. */
+export type AssetHeightArgs = {
+  locale: InputMaybe<Scalars['String']>;
+};
+
+/** Represents a binary file in a space. An asset can be any file type. */
 export type AssetLinkedFromArgs = {
   allowedLocales: InputMaybe<ReadonlyArray<InputMaybe<Scalars['String']>>>;
 };
 
 /** Represents a binary file in a space. An asset can be any file type. */
+export type AssetSizeArgs = {
+  locale: InputMaybe<Scalars['String']>;
+};
+
+/** Represents a binary file in a space. An asset can be any file type. */
+export type AssetTitleArgs = {
+  locale: InputMaybe<Scalars['String']>;
+};
+
+/** Represents a binary file in a space. An asset can be any file type. */
 export type AssetUrlArgs = {
+  locale: InputMaybe<Scalars['String']>;
   transform: InputMaybe<ImageTransformOptions>;
+};
+
+/** Represents a binary file in a space. An asset can be any file type. */
+export type AssetWidthArgs = {
+  locale: InputMaybe<Scalars['String']>;
 };
 
 export type AssetCollection = {
@@ -739,6 +775,8 @@ export type Query = {
   readonly projectCollection: Maybe<ProjectCollection>;
   readonly section: Maybe<Section>;
   readonly sectionCollection: Maybe<SectionCollection>;
+  readonly textBlock: Maybe<TextBlock>;
+  readonly textBlockCollection: Maybe<TextBlockCollection>;
 };
 
 export type QueryAssetArgs = {
@@ -825,13 +863,28 @@ export type QuerySectionCollectionArgs = {
   where: InputMaybe<SectionFilter>;
 };
 
+export type QueryTextBlockArgs = {
+  id: Scalars['String'];
+  locale: InputMaybe<Scalars['String']>;
+  preview: InputMaybe<Scalars['Boolean']>;
+};
+
+export type QueryTextBlockCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']>;
+  locale: InputMaybe<Scalars['String']>;
+  order: InputMaybe<ReadonlyArray<InputMaybe<TextBlockOrder>>>;
+  preview: InputMaybe<Scalars['Boolean']>;
+  skip?: InputMaybe<Scalars['Int']>;
+  where: InputMaybe<TextBlockFilter>;
+};
+
 /** A collection of references to other nodes [See type definition](https://app.contentful.com/spaces/nb3rzo39eupw/content_types/section) */
 export type Section = Entry & {
   readonly blocksCollection: Maybe<SectionBlocksCollection>;
   readonly contentfulMetadata: ContentfulMetadata;
   readonly linkedFrom: Maybe<SectionLinkingCollections>;
+  readonly slug: Maybe<Scalars['String']>;
   readonly sys: Sys;
-  readonly title: Maybe<Scalars['String']>;
 };
 
 /** A collection of references to other nodes [See type definition](https://app.contentful.com/spaces/nb3rzo39eupw/content_types/section) */
@@ -848,7 +901,7 @@ export type SectionLinkedFromArgs = {
 };
 
 /** A collection of references to other nodes [See type definition](https://app.contentful.com/spaces/nb3rzo39eupw/content_types/section) */
-export type SectionTitleArgs = {
+export type SectionSlugArgs = {
   locale: InputMaybe<Scalars['String']>;
 };
 
@@ -873,14 +926,14 @@ export type SectionFilter = {
   readonly OR: InputMaybe<ReadonlyArray<InputMaybe<SectionFilter>>>;
   readonly blocksCollection_exists: InputMaybe<Scalars['Boolean']>;
   readonly contentfulMetadata: InputMaybe<ContentfulMetadataFilter>;
+  readonly slug: InputMaybe<Scalars['String']>;
+  readonly slug_contains: InputMaybe<Scalars['String']>;
+  readonly slug_exists: InputMaybe<Scalars['Boolean']>;
+  readonly slug_in: InputMaybe<ReadonlyArray<InputMaybe<Scalars['String']>>>;
+  readonly slug_not: InputMaybe<Scalars['String']>;
+  readonly slug_not_contains: InputMaybe<Scalars['String']>;
+  readonly slug_not_in: InputMaybe<ReadonlyArray<InputMaybe<Scalars['String']>>>;
   readonly sys: InputMaybe<SysFilter>;
-  readonly title: InputMaybe<Scalars['String']>;
-  readonly title_contains: InputMaybe<Scalars['String']>;
-  readonly title_exists: InputMaybe<Scalars['Boolean']>;
-  readonly title_in: InputMaybe<ReadonlyArray<InputMaybe<Scalars['String']>>>;
-  readonly title_not: InputMaybe<Scalars['String']>;
-  readonly title_not_contains: InputMaybe<Scalars['String']>;
-  readonly title_not_in: InputMaybe<ReadonlyArray<InputMaybe<Scalars['String']>>>;
 };
 
 export type SectionLinkingCollections = {
@@ -895,6 +948,8 @@ export type SectionLinkingCollectionsEntryCollectionArgs = {
 };
 
 export type SectionOrder =
+  | 'slug_ASC'
+  | 'slug_DESC'
   | 'sys_firstPublishedAt_ASC'
   | 'sys_firstPublishedAt_DESC'
   | 'sys_id_ASC'
@@ -902,9 +957,7 @@ export type SectionOrder =
   | 'sys_publishedAt_ASC'
   | 'sys_publishedAt_DESC'
   | 'sys_publishedVersion_ASC'
-  | 'sys_publishedVersion_DESC'
-  | 'title_ASC'
-  | 'title_DESC';
+  | 'sys_publishedVersion_DESC';
 
 export type Sys = {
   readonly environmentId: Scalars['String'];
@@ -951,6 +1004,98 @@ export type SysFilter = {
   readonly publishedVersion_not: InputMaybe<Scalars['Float']>;
   readonly publishedVersion_not_in: InputMaybe<ReadonlyArray<InputMaybe<Scalars['Float']>>>;
 };
+
+/** A block of rich text, for use with things like Privacy Policy/introduction paragraph/etc [See type definition](https://app.contentful.com/spaces/nb3rzo39eupw/content_types/textBlock) */
+export type TextBlock = Entry & {
+  readonly content: Maybe<TextBlockContent>;
+  readonly contentfulMetadata: ContentfulMetadata;
+  readonly linkedFrom: Maybe<TextBlockLinkingCollections>;
+  readonly slug: Maybe<Scalars['String']>;
+  readonly sys: Sys;
+};
+
+/** A block of rich text, for use with things like Privacy Policy/introduction paragraph/etc [See type definition](https://app.contentful.com/spaces/nb3rzo39eupw/content_types/textBlock) */
+export type TextBlockContentArgs = {
+  locale: InputMaybe<Scalars['String']>;
+};
+
+/** A block of rich text, for use with things like Privacy Policy/introduction paragraph/etc [See type definition](https://app.contentful.com/spaces/nb3rzo39eupw/content_types/textBlock) */
+export type TextBlockLinkedFromArgs = {
+  allowedLocales: InputMaybe<ReadonlyArray<InputMaybe<Scalars['String']>>>;
+};
+
+/** A block of rich text, for use with things like Privacy Policy/introduction paragraph/etc [See type definition](https://app.contentful.com/spaces/nb3rzo39eupw/content_types/textBlock) */
+export type TextBlockSlugArgs = {
+  locale: InputMaybe<Scalars['String']>;
+};
+
+export type TextBlockCollection = {
+  readonly items: ReadonlyArray<Maybe<TextBlock>>;
+  readonly limit: Scalars['Int'];
+  readonly skip: Scalars['Int'];
+  readonly total: Scalars['Int'];
+};
+
+export type TextBlockContent = {
+  readonly json: Scalars['JSON'];
+  readonly links: TextBlockContentLinks;
+};
+
+export type TextBlockContentAssets = {
+  readonly block: ReadonlyArray<Maybe<Asset>>;
+  readonly hyperlink: ReadonlyArray<Maybe<Asset>>;
+};
+
+export type TextBlockContentEntries = {
+  readonly block: ReadonlyArray<Maybe<Entry>>;
+  readonly hyperlink: ReadonlyArray<Maybe<Entry>>;
+  readonly inline: ReadonlyArray<Maybe<Entry>>;
+};
+
+export type TextBlockContentLinks = {
+  readonly assets: TextBlockContentAssets;
+  readonly entries: TextBlockContentEntries;
+};
+
+export type TextBlockFilter = {
+  readonly AND: InputMaybe<ReadonlyArray<InputMaybe<TextBlockFilter>>>;
+  readonly OR: InputMaybe<ReadonlyArray<InputMaybe<TextBlockFilter>>>;
+  readonly content_contains: InputMaybe<Scalars['String']>;
+  readonly content_exists: InputMaybe<Scalars['Boolean']>;
+  readonly content_not_contains: InputMaybe<Scalars['String']>;
+  readonly contentfulMetadata: InputMaybe<ContentfulMetadataFilter>;
+  readonly slug: InputMaybe<Scalars['String']>;
+  readonly slug_contains: InputMaybe<Scalars['String']>;
+  readonly slug_exists: InputMaybe<Scalars['Boolean']>;
+  readonly slug_in: InputMaybe<ReadonlyArray<InputMaybe<Scalars['String']>>>;
+  readonly slug_not: InputMaybe<Scalars['String']>;
+  readonly slug_not_contains: InputMaybe<Scalars['String']>;
+  readonly slug_not_in: InputMaybe<ReadonlyArray<InputMaybe<Scalars['String']>>>;
+  readonly sys: InputMaybe<SysFilter>;
+};
+
+export type TextBlockLinkingCollections = {
+  readonly entryCollection: Maybe<EntryCollection>;
+};
+
+export type TextBlockLinkingCollectionsEntryCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']>;
+  locale: InputMaybe<Scalars['String']>;
+  preview: InputMaybe<Scalars['Boolean']>;
+  skip?: InputMaybe<Scalars['Int']>;
+};
+
+export type TextBlockOrder =
+  | 'slug_ASC'
+  | 'slug_DESC'
+  | 'sys_firstPublishedAt_ASC'
+  | 'sys_firstPublishedAt_DESC'
+  | 'sys_id_ASC'
+  | 'sys_id_DESC'
+  | 'sys_publishedAt_ASC'
+  | 'sys_publishedAt_DESC'
+  | 'sys_publishedVersion_ASC'
+  | 'sys_publishedVersion_DESC';
 
 export type CfLinkNestedFilter = {
   readonly AND: InputMaybe<ReadonlyArray<InputMaybe<CfLinkNestedFilter>>>;

--- a/src/api/contentful/generated/fetchIntroBlock.generated.ts
+++ b/src/api/contentful/generated/fetchIntroBlock.generated.ts
@@ -1,0 +1,63 @@
+import type * as Types from './api.generated';
+
+export type IntroBlockQueryVariables = Types.Exact<{ [key: string]: never }>;
+
+export type IntroBlockQuery = {
+  readonly asset:
+    | {
+        readonly url: string | undefined;
+        readonly width: number | undefined;
+        readonly height: number | undefined;
+        readonly title: string | undefined;
+      }
+    | undefined;
+  readonly textBlockCollection:
+    | {
+        readonly items: ReadonlyArray<
+          | {
+              readonly content:
+                | {
+                    readonly json: any;
+                    readonly links: {
+                      readonly entries: {
+                        readonly inline: ReadonlyArray<
+                          | {
+                              readonly title: string | undefined;
+                              readonly url: string | undefined;
+                              readonly icon: string | undefined;
+                            }
+                          | {}
+                          | undefined
+                        >;
+                        readonly block: ReadonlyArray<
+                          | {
+                              readonly title: string | undefined;
+                              readonly url: string | undefined;
+                              readonly icon: string | undefined;
+                            }
+                          | {}
+                          | undefined
+                        >;
+                      };
+                      readonly assets: {
+                        readonly block: ReadonlyArray<
+                          | {
+                              readonly url: string | undefined;
+                              readonly title: string | undefined;
+                              readonly width: number | undefined;
+                              readonly height: number | undefined;
+                              readonly description: string | undefined;
+                              readonly sys: { readonly id: string };
+                            }
+                          | undefined
+                        >;
+                      };
+                    };
+                  }
+                | undefined;
+            }
+          | undefined
+        >;
+      }
+    | undefined;
+};

--- a/src/api/contentful/typeguards.ts
+++ b/src/api/contentful/typeguards.ts
@@ -1,4 +1,4 @@
-import type { Link, Project } from './generated/api.generated';
+import type { Link, Project, TextBlock } from './generated/api.generated';
 
 /**
  * Type guard to get a link out
@@ -13,6 +13,14 @@ export const isLink = (item: Link | undefined | Record<string, unknown>): item i
 export const isProject = (item: Project | undefined | Record<string, unknown>): item is Project =>
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   !!(item as Project)?.creationDate && !!(item as Project)?.thumbnail;
+
+/**
+ * Type guard to get a text block out
+ */
+export const isTextBlock = (
+  item: TextBlock | undefined | Record<string, unknown>,
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+): item is TextBlock => !!(item as TextBlock)?.content?.json;
 
 /**
  * Type guard to filter out null or undefined items

--- a/src/api/github/generated/api.generated.ts
+++ b/src/api/github/generated/api.generated.ts
@@ -2553,6 +2553,8 @@ export type PullRequestState =
 
 /** The possible item types found in a timeline. */
 export type PullRequestTimelineItemsItemType =
+  /** Represents a 'added_to_merge_queue' event on a given pull request. */
+  | 'ADDED_TO_MERGE_QUEUE_EVENT'
   /** Represents a 'added_to_project' event on a given issue or pull request. */
   | 'ADDED_TO_PROJECT_EVENT'
   /** Represents an 'assigned' event on any assignable object. */
@@ -2635,6 +2637,8 @@ export type PullRequestTimelineItemsItemType =
   | 'READY_FOR_REVIEW_EVENT'
   /** Represents a 'referenced' event on a given `ReferencedSubject`. */
   | 'REFERENCED_EVENT'
+  /** Represents a 'removed_from_merge_queue' event on a given pull request. */
+  | 'REMOVED_FROM_MERGE_QUEUE_EVENT'
   /** Represents a 'removed_from_project' event on a given issue or pull request. */
   | 'REMOVED_FROM_PROJECT_EVENT'
   /** Represents a 'renamed' event on a given issue or pull request */

--- a/src/api/useData.ts
+++ b/src/api/useData.ts
@@ -1,4 +1,5 @@
 import useSWR from 'swr';
+import fetchIntroBlock from './contentful/fetchIntroBlock';
 import fetchProjects from './contentful/fetchProjects';
 import fetchSiteFooter from './contentful/fetchSiteFooter';
 import fetchSiteHeader from './contentful/fetchSiteHeader';
@@ -46,6 +47,11 @@ const fetchers = {
    * All projects to list on home page
    */
   projects: fetchProjects,
+
+  /**
+   * The introduction rich text block for the homepage
+   */
+  introBlock: fetchIntroBlock,
 } as const;
 
 /**

--- a/src/components/ContentCard.tsx
+++ b/src/components/ContentCard.tsx
@@ -55,11 +55,16 @@ const Card = styled.article<CardProps>`
     `}
 
   ${({ $hSpan }) => css`
-    grid-column-start: span ${$hSpan};
+    @media (min-width: 768px) {
+      width: ${cardSizeInEm($hSpan)}em;
+      grid-column-start: span ${$hSpan};
+    }
   `};
   ${({ $vSpan }) =>
     css`
-      height: ${cardSizeInEm($vSpan)}em;
+      @media (min-width: 768px) {
+        height: ${cardSizeInEm($vSpan)}em;
+      }
       grid-row-start: span ${$vSpan};
     `}
 `;

--- a/src/components/ContentGrid.tsx
+++ b/src/components/ContentGrid.tsx
@@ -1,14 +1,18 @@
 import styled from 'styled-components';
 
+// Auto fits above 992px, and kept to two columns for tablet. Mobile is one wide only.
 const Grid = styled.div`
   display: grid;
   gap: var(--content-grid-gap-em);
-  grid-auto-rows: 1fr;
-  grid-auto-columns: 1fr;
-  grid-template-columns: repeat(auto-fit, var(--content-grid-dimension-em));
-  grid-template-rows: repeat(auto-fit, var(--content-grid-dimension-em));
-  grid-auto-flow: dense;
+  grid: 1fr;
   justify-content: center;
+  @media (min-width: 768px) {
+    grid: auto-flow dense / 1fr 1fr;
+  }
+  @media (min-width: 992px) {
+    grid-template-columns: repeat(auto-fit, var(--content-grid-dimension-em));
+    grid-template-rows: repeat(auto-fit, var(--content-grid-dimension-em));
+  }
 `;
 
 /**

--- a/src/components/ContentWrappingLink.tsx
+++ b/src/components/ContentWrappingLink.tsx
@@ -1,0 +1,25 @@
+import type { Link as LinkProps } from 'api/contentful/generated/api.generated';
+import NextLink from 'next/link';
+
+type Props = Pick<React.ComponentProps<'div'>, 'children'> & {
+  /**
+   * The link whose URL we should render
+   */
+  link: LinkProps | undefined;
+};
+
+/**
+ * Renders a link that wraps the given children. Compliant with Next's Link too.
+ */
+const ContentWrappingLink = ({ link, children }: Props) => {
+  if (!link?.url) {
+    return null;
+  }
+  return (
+    <NextLink passHref href={link.url}>
+      <a href={link.url}>{children}</a>
+    </NextLink>
+  );
+};
+
+export default ContentWrappingLink;

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,20 @@
 import useData from 'api/useData';
+import styled from 'styled-components';
 import Link from './Link';
+
+// Switches to two rows for mobile
+const Navigation = styled.nav`
+  flex-direction: column;
+  @media (min-width: 768px) {
+    flex-direction: row;
+  }
+`;
+
+// Wraps so it can collapse better on mobile
+const FlexList = styled.ul`
+  display: flex;
+  flex-wrap: wrap;
+`;
 
 /**
  * Creates the site footer component - shows version data + copyright
@@ -14,13 +29,13 @@ const Footer = () => {
   ));
   return (
     <footer>
-      <nav>
-        <ul>
+      <Navigation>
+        <FlexList>
           <li>© {new Date().getFullYear()} Dylan Gattey</li>
           <li>{version}</li>
-        </ul>
-        <ul>{listedLinkElements}</ul>
-      </nav>
+        </FlexList>
+        <FlexList>{listedLinkElements}</FlexList>
+      </Navigation>
     </footer>
   );
 };

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,8 +1,5 @@
 import useData from 'api/useData';
-import Link from 'next/link';
-import styled from 'styled-components';
-
-const IconLink = styled.a``;
+import Link from './Link';
 
 /**
  * Creates the site footer component - shows version data + copyright
@@ -10,21 +7,11 @@ const IconLink = styled.a``;
 const Footer = () => {
   const { data: version } = useData('version');
   const { data: footerLinks } = useData('siteFooter');
-  const listedLinkElements = footerLinks?.map(
-    ({ title, url, icon: iconHtml }) =>
-      url &&
-      title && (
-        <li key={url}>
-          {iconHtml ? (
-            <Link href={url} passHref>
-              <IconLink dangerouslySetInnerHTML={{ __html: iconHtml }} />
-            </Link>
-          ) : (
-            <Link href={url}>{title}</Link>
-          )}
-        </li>
-      ),
-  );
+  const listedLinkElements = footerLinks?.map((link) => (
+    <li key={link.url}>
+      <Link {...link} />
+    </li>
+  ));
   return (
     <footer>
       <nav>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,6 @@
 import useData from 'api/useData';
-import Link from 'next/link';
 import styled from 'styled-components';
+import Link from './Link';
 
 const SpacedHeader = styled.header`
   margin-top: var(--block-spacing-vertical);
@@ -13,15 +13,11 @@ const Header = () => {
   const { data: headerLinks } = useData('siteHeader');
   const linkElements = headerLinks && (
     <ul>
-      {headerLinks.map(
-        ({ title, url }) =>
-          url &&
-          title && (
-            <li key={url}>
-              <Link href={url}>{title}</Link>
-            </li>
-          ),
-      )}
+      {headerLinks.map((link) => (
+        <li key={link.url}>
+          <Link {...link} />
+        </li>
+      ))}
     </ul>
   );
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -10,8 +10,21 @@ const SpacedHeader = styled.header`
  * Creates the site header component - shows header links
  */
 const Header = () => {
-  const { data: siteHeader } = useData('siteHeader');
-  const { links } = siteHeader ?? {};
+  const { data: headerLinks } = useData('siteHeader');
+  const linkElements = headerLinks && (
+    <ul>
+      {headerLinks.map(
+        ({ title, url }) =>
+          url &&
+          title && (
+            <li key={url}>
+              <Link href={url}>{title}</Link>
+            </li>
+          ),
+      )}
+    </ul>
+  );
+
   return (
     <SpacedHeader>
       <nav>
@@ -20,19 +33,7 @@ const Header = () => {
             <strong>Dylan Gattey</strong>
           </li>
         </ul>
-        {links && (
-          <ul>
-            {links.map(
-              ({ title, url }) =>
-                url &&
-                title && (
-                  <li key={url}>
-                    <Link href={url}>{title}</Link>
-                  </li>
-                ),
-            )}
-          </ul>
-        )}
+        {linkElements}
       </nav>
     </SpacedHeader>
   );

--- a/src/components/Image.tsx
+++ b/src/components/Image.tsx
@@ -1,0 +1,32 @@
+import { Asset } from 'api/contentful/generated/api.generated';
+import NextImage, { ImageProps } from 'next/image';
+
+type Props = Pick<React.ComponentProps<'img'>, 'className'> &
+  Partial<Asset> &
+  Pick<Asset, 'url' | 'width' | 'height'> & {
+    /**
+     * Alt text, required, but defaults to title
+     */
+    alt?: string;
+
+    /**
+     * The image layout, defaulting to responsive
+     */
+    layout?: ImageProps['layout'];
+  };
+
+/**
+ * Shows a Next Image with the contents of the Asset. Layout defaults to responsive.
+ */
+const Image = ({ url, width, height, layout = 'responsive', title, alt, className }: Props) => (
+  <NextImage
+    className={className}
+    src={url}
+    alt={alt ?? title}
+    width={width}
+    height={height}
+    layout={layout}
+  />
+);
+
+export default Image;

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -1,0 +1,25 @@
+import { Link as LinkProps } from 'api/contentful/generated/api.generated';
+import NextLink from 'next/link';
+import styled from 'styled-components';
+
+type Props = LinkProps;
+
+const IconLink = styled.a``;
+
+/**
+ * Renders a link component from Contentful
+ */
+const Link = ({ title, url, icon }: Props) => {
+  if (!url) {
+    return null;
+  }
+  return icon ? (
+    <NextLink href={url} passHref>
+      <IconLink dangerouslySetInnerHTML={{ __html: icon }} />
+    </NextLink>
+  ) : (
+    <NextLink href={url}>{title}</NextLink>
+  );
+};
+
+export default Link;

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -1,8 +1,8 @@
 import { Project } from 'api/contentful/generated/api.generated';
 import Image from 'next/image';
-import Link from 'next/link';
 import styled from 'styled-components';
 import ContentCard from './ContentCard';
+import ContentWrappingLink from './ContentWrappingLink';
 import ProjectIcon from './ProjectIcon';
 import Stack from './Stack';
 
@@ -58,29 +58,24 @@ const ProjectCard = ({ title, layout, link, thumbnail, type }: Props) => {
   const verticalSpan = layout === 'tall' ? 2 : 1;
   const horizontalSpan = layout === 'wide' ? 2 : 1;
 
-  if (!link?.url) {
-    return null;
-  }
   return (
-    <Link passHref href={link.url}>
-      <Card verticalSpan={verticalSpan} horizontalSpan={horizontalSpan} isClickable={!!link}>
-        <a href={link.url}>
-          {thumbnail && (
-            <Image
-              src={thumbnail?.url}
-              alt={title}
-              layout="responsive"
-              width={thumbnail?.width}
-              height={thumbnail?.height}
-            />
-          )}
-          <TitleStack>
-            <TitleText>{title}</TitleText>
-            <ProjectIconWithBackground type={type} />
-          </TitleStack>
-        </a>
-      </Card>
-    </Link>
+    <Card verticalSpan={verticalSpan} horizontalSpan={horizontalSpan} isClickable={!!link}>
+      <ContentWrappingLink link={link}>
+        {thumbnail && (
+          <Image
+            src={thumbnail?.url}
+            alt={title}
+            layout="responsive"
+            width={thumbnail?.width}
+            height={thumbnail?.height}
+          />
+        )}
+        <TitleStack>
+          <TitleText>{title}</TitleText>
+          <ProjectIconWithBackground type={type} />
+        </TitleStack>
+      </ContentWrappingLink>
+    </Card>
   );
 };
 

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -1,8 +1,8 @@
 import { Project } from 'api/contentful/generated/api.generated';
-import Image from 'next/image';
 import styled from 'styled-components';
 import ContentCard from './ContentCard';
 import ContentWrappingLink from './ContentWrappingLink';
+import Image from './Image';
 import ProjectIcon from './ProjectIcon';
 import Stack from './Stack';
 
@@ -61,15 +61,7 @@ const ProjectCard = ({ title, layout, link, thumbnail, type }: Props) => {
   return (
     <Card verticalSpan={verticalSpan} horizontalSpan={horizontalSpan} isClickable={!!link}>
       <ContentWrappingLink link={link}>
-        {thumbnail && (
-          <Image
-            src={thumbnail?.url}
-            alt={title}
-            layout="responsive"
-            width={thumbnail?.width}
-            height={thumbnail?.height}
-          />
-        )}
+        {thumbnail && <Image {...thumbnail} alt={title} />}
         <TitleStack>
           <TitleText>{title}</TitleText>
           <ProjectIconWithBackground type={type} />

--- a/src/components/ProjectGrid.tsx
+++ b/src/components/ProjectGrid.tsx
@@ -1,15 +1,52 @@
 import useData from 'api/useData';
 import React from 'react';
+import styled from 'styled-components';
+import ContentCard from './ContentCard';
 import ContentGrid from './ContentGrid';
+import Image from './Image';
 import ProjectCard from './ProjectCard';
+import RichText from './RichText';
+
+const ImageCard = styled(ContentCard)`
+  display: none;
+  @media (min-width: 768px) {
+    display: flex;
+  }
+`;
+
+const IntroCard = styled(ContentCard)`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  & h1 {
+    --typography-spacing-vertical: 1.5rem;
+  }
+  & p {
+    font-size: 0.9em;
+  }
+  background: none;
+  border: none;
+  box-shadow: none;
+`;
 
 /**
  * Puts all projects into a grid using `projects` data
  */
 const ProjectGrid = () => {
   const { data: projects } = useData('projects');
+  const { data: introBlock } = useData('introBlock');
   return (
     <ContentGrid>
+      {introBlock?.textBlock?.content && (
+        <>
+          <ImageCard>
+            <Image {...introBlock.image} alt={introBlock.image.title} layout="fill" />
+          </ImageCard>
+          <IntroCard>
+            <RichText {...introBlock.textBlock.content} />
+          </IntroCard>
+        </>
+      )}
       {projects?.map((project) => (
         <ProjectCard key={project.title} {...project} />
       ))}

--- a/src/components/RichText.tsx
+++ b/src/components/RichText.tsx
@@ -1,0 +1,92 @@
+import { documentToReactComponents, Options } from '@contentful/rich-text-react-renderer';
+import type { Document, NodeData } from '@contentful/rich-text-types';
+import { BLOCKS, INLINES } from '@contentful/rich-text-types';
+import type { Asset, Entry, TextBlockContent } from 'api/contentful/generated/api.generated';
+import { isDefinedItem, isLink } from 'api/contentful/typeguards';
+import Image from './Image';
+import Link from './Link';
+
+type Props = TextBlockContent;
+
+/**
+ * Defines a Node's Data with actual data
+ */
+type DataWithId = {
+  target?: {
+    sys?: {
+      /**
+       * UUID for the value
+       */
+      id: string;
+    };
+  };
+};
+
+/**
+ * Typeguard for converting the `any` to a structured object
+ */
+const isDataWithId = (data: NodeData): data is DataWithId =>
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  !!(data as DataWithId)?.target?.sys?.id;
+
+// Create a bespoke renderOptions object to target BLOCKS.EMBEDDED_ENTRY (linked block entries e.g. code blocks)
+// INLINES.EMBEDDED_ENTRY (linked inline entries e.g. a reference to another blog post)
+// and BLOCKS.EMBEDDED_ASSET (linked assets e.g. images)
+
+const renderOptions = (links: TextBlockContent['links']): Options => {
+  // Map the assets
+  const assetMap = new Map<string | undefined, Asset>();
+  links.assets.block.filter(isDefinedItem).forEach((asset) => assetMap.set(asset?.sys.id, asset));
+
+  // Map the inline and block entries
+  const entryMap = new Map<string | undefined, Entry>();
+  links.entries.block.filter(isDefinedItem).forEach((entry) => entryMap.set(entry?.sys.id, entry));
+  links.entries.inline.filter(isDefinedItem).forEach((entry) => entryMap.set(entry?.sys.id, entry));
+
+  return {
+    renderNode: {
+      [INLINES.EMBEDDED_ENTRY]: ({ data }) => {
+        if (!isDataWithId(data)) {
+          return null;
+        }
+        const entry = entryMap.get(data.target?.sys?.id);
+
+        if (isLink(entry)) {
+          return <Link {...entry} />;
+        }
+
+        return null;
+      },
+      [BLOCKS.EMBEDDED_ENTRY]: ({ data }) => {
+        if (!isDataWithId(data)) {
+          return null;
+        }
+        const entry = entryMap.get(data.target?.sys?.id);
+
+        if (isLink(entry)) {
+          return <Link {...entry} />;
+        }
+
+        return null;
+      },
+      [BLOCKS.EMBEDDED_ASSET]: ({ data }) => {
+        if (!isDataWithId(data)) {
+          return null;
+        }
+        const asset = assetMap.get(data.target?.sys?.id);
+        return asset ? <Image {...asset} alt={asset.title} /> : null;
+      },
+    },
+  };
+};
+
+/**
+ * Complicated component to render rich text from Contentful's rich
+ * text renderer, resolving all items to components
+ */
+const RichText = ({ json, links }: Props) => (
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  <>{documentToReactComponents(json as unknown as Document, renderOptions(links))}</>
+);
+
+export default RichText;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -10,7 +10,7 @@ interface Props {
   /**
    * Provides SWR with fallback version data
    */
-  fallback: Fallback<'version' | 'siteFooter' | 'siteHeader' | 'projects'>;
+  fallback: Fallback<'version' | 'siteFooter' | 'siteHeader' | 'projects' | 'introBlock'>;
 }
 
 /**
@@ -18,11 +18,12 @@ interface Props {
  * provide a fallback for the server side rendering done elsewhere.
  */
 export const getStaticProps: GetStaticProps<Props> = async () => {
-  const [version, siteFooter, siteHeader, projects] = await Promise.all([
+  const [version, siteFooter, siteHeader, projects, introBlock] = await Promise.all([
     fetchData('version'),
     fetchData('siteFooter'),
     fetchData('siteHeader'),
     fetchData('projects'),
+    fetchData('introBlock'),
   ]);
   return {
     props: {
@@ -31,6 +32,7 @@ export const getStaticProps: GetStaticProps<Props> = async () => {
         siteFooter,
         siteHeader,
         projects,
+        introBlock,
       },
     },
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -733,6 +733,18 @@
   dependencies:
     chalk "^4.0.0"
 
+"@contentful/rich-text-react-renderer@15.11.1":
+  version "15.11.1"
+  resolved "https://registry.yarnpkg.com/@contentful/rich-text-react-renderer/-/rich-text-react-renderer-15.11.1.tgz#54305dc9561ed5d98bb65e8eb054ba1707d44af0"
+  integrity sha512-u1dSlUDSDR19/RGVbmwkbhEOTwRerIaMbea92vchd2mM6lk6X+qp6BS6HTABROcXGVAwhIHtarZ8fX5Zu7uiYA==
+  dependencies:
+    "@contentful/rich-text-types" "^15.11.1"
+
+"@contentful/rich-text-types@15.11.1", "@contentful/rich-text-types@^15.11.1":
+  version "15.11.1"
+  resolved "https://registry.yarnpkg.com/@contentful/rich-text-types/-/rich-text-types-15.11.1.tgz#755e3efd5e0ac277d554e6f731ba9fdc1c45f6fe"
+  integrity sha512-seO8Nl9cp894v7an6R8isX+HqYwVUesviGULTh/rIj2DCv2tXUU1GCqzSkt84XN6c6nbFYow9+Wzezkxx/IdIA==
+
 "@emotion/is-prop-valid@^0.8.8":
   version "0.8.8"
   resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"


### PR DESCRIPTION
# Description of changes
 
1. Creates separate components for Image and Link, rendering from Asset/Link from Contentful
2. RichText support from Contentful, right now only rendering images and Links. Will be added to.
3. Cleaner mobile support (footer now stacked, content grid now one wide without artifacts underneath the images)
4. Intro cards using RichText + image