### PR TITLE
feat: add ColorSchemeToggleCard to project grid

### DIFF
--- a/src/components/AppStyle.tsx
+++ b/src/components/AppStyle.tsx
@@ -17,6 +17,8 @@ export const cardSizeInEm = (span = 1) =>
 const darkModeVariables = css`
   --contrast-overlay: var(--contrast-inverse);
   --contrast-overlay-inverse: var(--contrast);
+  --card-hovered-box-shadow: 0 0.125rem 2rem rgba(0, 0, 0, 0.06),
+    0 0.125rem 4rem rgba(0, 0, 0, 0.12), 0 0 0 0.125rem rgba(0, 0, 0, 0.036);
 `;
 
 /**
@@ -26,6 +28,8 @@ const darkModeVariables = css`
 const lightModeVariables = css`
   --contrast-overlay: var(--secondary);
   --contrast-overlay-inverse: var(--secondary-inverse);
+  --card-hovered-box-shadow: 0 0.125rem 2rem rgba(27, 40, 50, 0.04),
+    0 0.125rem 4rem rgba(27, 40, 50, 0.08), 0 0 0 0.125rem rgba(27, 40, 50, 0.024);
 `;
 
 /**

--- a/src/components/AppStyle.tsx
+++ b/src/components/AppStyle.tsx
@@ -19,6 +19,8 @@ const darkModeVariables = css`
   --contrast-overlay-inverse: var(--contrast);
   --card-hovered-box-shadow: 0 0.125rem 2rem rgba(0, 0, 0, 0.06),
     0 0.125rem 4rem rgba(0, 0, 0, 0.12), 0 0 0 0.125rem rgba(0, 0, 0, 0.036);
+  --yellow: yellow;
+  --navy: #0a6280;
 `;
 
 /**
@@ -30,6 +32,8 @@ const lightModeVariables = css`
   --contrast-overlay-inverse: var(--secondary-inverse);
   --card-hovered-box-shadow: 0 0.125rem 2rem rgba(27, 40, 50, 0.04),
     0 0.125rem 4rem rgba(27, 40, 50, 0.08), 0 0 0 0.125rem rgba(27, 40, 50, 0.024);
+  --yellow: rgb(222, 197, 29);
+  --navy: #0a6280;
 `;
 
 /**

--- a/src/components/ColorSchemeToggleCard.tsx
+++ b/src/components/ColorSchemeToggleCard.tsx
@@ -75,17 +75,24 @@ const Button = styled.button<{ $visible: boolean }>`
 `;
 
 // Reset the state that tooltips give to the element since it acts as a button here.
-const ClickableIcon = styled.span`
+const ClickableIcon = styled.span<{ $disabled: boolean }>`
   && {
-    cursor: pointer;
+    ${({ $disabled }) =>
+      $disabled
+        ? css`
+            cursor: not-allowed;
+          `
+        : css`
+            cursor: pointer;
+            & svg:hover {
+              transform: rotate(45deg);
+            }
+          `}
     border-bottom: none;
     & svg {
       font-size: 1.5em;
       transition: transform var(--transition);
       transform-origin: center;
-      :hover {
-        transform: rotate(45deg);
-      }
     }
   }
 `;
@@ -111,7 +118,11 @@ const ColorSchemeToggleCard = () => {
   return (
     <Card>
       <ContentStack $gap="1em">
-        <ClickableIcon onClick={setLightScheme} data-tooltip="Sun, up!">
+        <ClickableIcon
+          $disabled={!isInitializedWithSystemScheme}
+          onClick={isInitializedWithSystemScheme ? setLightScheme : undefined}
+          data-tooltip={isInitializedWithSystemScheme ? 'Sun, up!' : undefined}
+        >
           <FiSun color="var(--yellow)" />
         </ClickableIcon>
         <ColorSchemeSwitch
@@ -120,7 +131,11 @@ const ColorSchemeToggleCard = () => {
           onChange={setInvertedScheme}
           checked={isInitializedWithSystemScheme && colorScheme === 'dark'}
         />
-        <ClickableIcon onClick={setDarkScheme} data-tooltip="Lights out">
+        <ClickableIcon
+          $disabled={!isInitializedWithSystemScheme}
+          onClick={isInitializedWithSystemScheme ? setDarkScheme : undefined}
+          data-tooltip={isInitializedWithSystemScheme ? 'Lights out' : undefined}
+        >
           <FiMoon color="var(--secondary)" />
         </ClickableIcon>
       </ContentStack>

--- a/src/components/ColorSchemeToggleCard.tsx
+++ b/src/components/ColorSchemeToggleCard.tsx
@@ -115,6 +115,7 @@ const ColorSchemeToggleCard = () => {
           <FiSun color="var(--yellow)" />
         </ClickableIcon>
         <ColorSchemeSwitch
+          disabled={!isInitializedWithSystemScheme}
           $colorScheme={!isInitializedWithSystemScheme ? null : colorScheme}
           onChange={setInvertedScheme}
           checked={isInitializedWithSystemScheme && colorScheme === 'dark'}

--- a/src/components/ColorSchemeToggleCard.tsx
+++ b/src/components/ColorSchemeToggleCard.tsx
@@ -1,6 +1,6 @@
 import useColorScheme, { ColorScheme } from 'hooks/useColorScheme';
 import { FiMoon, FiSun } from 'react-icons/fi';
-import styled, { css, FlattenSimpleInterpolation } from 'styled-components';
+import styled, { css } from 'styled-components';
 import ContentCard from './ContentCard';
 import Stack from './Stack';
 
@@ -19,33 +19,29 @@ const ContentStack = styled(Stack)`
   margin-top: calc(var(--stack-gap) + 2.5em);
 `;
 
-// Provides color scheme specific css for the switch - unknown is basically just server-rendered
-const SWITCH_COLOR_SCHEME_CSS: Record<ColorScheme | 'unknown', FlattenSimpleInterpolation> = {
-  unknown: css`
-    --switch-background-color: var(--secondary);
-  `,
-  light: css`
-    --switch-background-color: var(--yellow);
-  `,
-  dark: css`
-    --switch-background-color: var(--navy);
-    --calculated-margin: calc(var(--switch-width) - var(--switch-height));
-    &&& {
-      --border-color: var(--switch-background-color);
-      --background-color: var(--switch-background-color);
-    }
-    &&&:before {
-      margin-left: var(--calculated-margin);
-      margin-inline-start: var(--calculated-margin);
-    }
-  `,
+// Provides color scheme specific variable names for the switch - unknown is basically just server-rendered
+const SWITCH_COLOR_SCHEME_CSS: Record<ColorScheme | 'unknown', string> = {
+  unknown: '--secondary',
+  light: '--yellow',
+  dark: '--navy',
 };
 
 // Combo of CSS + $colorScheme to set two separate states, using a lot of Pico CSS switch variables
 const ColorSchemeSwitch = styled.input.attrs({ role: 'switch', type: 'checkbox' })<{
   $colorScheme: ColorScheme | null;
 }>`
-  ${({ $colorScheme }) => SWITCH_COLOR_SCHEME_CSS[$colorScheme ?? 'unknown']};
+  ${({ $colorScheme }) => css`
+    --switch-background-color: var(${SWITCH_COLOR_SCHEME_CSS[$colorScheme ?? 'unknown']});
+  `};
+  &&:checked {
+    --calculated-margin: calc(var(--switch-width) - var(--switch-height));
+    --border-color: var(--switch-background-color);
+    --background-color: var(--switch-background-color);
+    &:before {
+      margin-left: var(--calculated-margin);
+      margin-inline-start: var(--calculated-margin);
+    }
+  }
   && {
     --border-width: 6px;
     --switch-height: 2em;

--- a/src/components/ColorSchemeToggleCard.tsx
+++ b/src/components/ColorSchemeToggleCard.tsx
@@ -1,0 +1,143 @@
+import useColorScheme, { ColorScheme } from 'hooks/useColorScheme';
+import { FiMoon, FiSun } from 'react-icons/fi';
+import styled, { css, FlattenSimpleInterpolation } from 'styled-components';
+import ContentCard from './ContentCard';
+import Stack from './Stack';
+
+// Stack items in center
+const Card = styled(ContentCard)`
+  --stack-gap: 2em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: var(--stack-gap);
+`;
+
+// Magic value to place the switch exactly in the center of the card by offsetting the button height + spacing up
+const ContentStack = styled(Stack)`
+  margin-top: calc(var(--stack-gap) + 2.5em);
+`;
+
+// Provides color scheme specific css for the switch - unknown is basically just server-rendered
+const SWITCH_COLOR_SCHEME_CSS: Record<ColorScheme | 'unknown', FlattenSimpleInterpolation> = {
+  unknown: css`
+    --switch-background-color: var(--secondary);
+  `,
+  light: css`
+    --switch-background-color: var(--yellow);
+  `,
+  dark: css`
+    --switch-background-color: var(--navy);
+    --calculated-margin: calc(var(--switch-width) - var(--switch-height));
+    &&& {
+      --border-color: var(--switch-background-color);
+      --background-color: var(--switch-background-color);
+    }
+    &&&:before {
+      margin-left: var(--calculated-margin);
+      margin-inline-start: var(--calculated-margin);
+    }
+  `,
+};
+
+// Combo of CSS + $colorScheme to set two separate states, using a lot of Pico CSS switch variables
+const ColorSchemeSwitch = styled.input.attrs({ role: 'switch', type: 'checkbox' })<{
+  $colorScheme: ColorScheme | null;
+}>`
+  ${({ $colorScheme }) => SWITCH_COLOR_SCHEME_CSS[$colorScheme ?? 'unknown']};
+  && {
+    --border-width: 6px;
+    --switch-height: 2em;
+    --switch-width: 4.5em;
+    --switch-track-size: 1.25em;
+    width: var(--switch-width);
+    height: var(--switch-height);
+    :before {
+      width: calc(var(--switch-height) - (var(--border-width) * 2));
+      transition: margin var(--transition);
+    }
+  }
+`;
+
+// Inline button that's not very prominent
+const Button = styled.button<{ $visible: boolean }>`
+  --border-radius: 2em;
+  --form-element-spacing-vertical: 0.25em;
+  --form-element-spacing-horizontal: 0.75em;
+  font-size: 0.75em;
+  display: inline-flex;
+  gap: 0.5em;
+  width: fit-content;
+  transition: opacity var(--transition);
+  && {
+    ${({ $visible }) =>
+      css`
+        opacity: ${$visible ? 1 : 0};
+      `};
+  }
+`;
+
+// Reset the state that tooltips give to the element since it acts as a button here.
+const ClickableIcon = styled.span`
+  && {
+    cursor: pointer;
+    border-bottom: none;
+    & svg {
+      font-size: 1.5em;
+      transition: transform var(--transition);
+      transform-origin: center;
+      :hover {
+        transform: rotate(45deg);
+      }
+    }
+  }
+`;
+
+/**
+ * Inverts a "dark" or "light" value to the other
+ */
+const inverted = (colorScheme: ColorScheme) => (colorScheme === 'dark' ? 'light' : 'dark');
+
+/**
+ * Provides the ability to toggle the page's color scheme between
+ * system, light, and dark. Prerendered, `colorScheme` is `light`
+ * and `isSystemScheme` is true.
+ */
+const ColorSchemeToggleCard = () => {
+  const { colorScheme, isSystemScheme, isInitializedWithSystemScheme, updatePreferredScheme } =
+    useColorScheme();
+  const setLightScheme = () => updatePreferredScheme('light');
+  const setInvertedScheme = () => updatePreferredScheme(inverted(colorScheme));
+  const setDarkScheme = () => updatePreferredScheme('dark');
+  const clearSavedScheme = () => updatePreferredScheme(null);
+
+  return (
+    <Card>
+      <ContentStack $gap="1em">
+        <ClickableIcon onClick={setLightScheme} data-tooltip="Sun, up!">
+          <FiSun color="var(--yellow)" />
+        </ClickableIcon>
+        <ColorSchemeSwitch
+          $colorScheme={!isInitializedWithSystemScheme ? null : colorScheme}
+          onChange={setInvertedScheme}
+          checked={isInitializedWithSystemScheme && colorScheme === 'dark'}
+        />
+        <ClickableIcon onClick={setDarkScheme} data-tooltip="Lights out">
+          <FiMoon color="var(--secondary)" />
+        </ClickableIcon>
+      </ContentStack>
+      <Button
+        role="button"
+        className="secondary outline"
+        disabled={isSystemScheme}
+        onClick={clearSavedScheme}
+        $visible={!isSystemScheme}
+      >
+        Reset to system theme
+      </Button>
+    </Card>
+  );
+};
+
+export default ColorSchemeToggleCard;

--- a/src/components/ContentCard.tsx
+++ b/src/components/ContentCard.tsx
@@ -48,9 +48,11 @@ const Card = styled.article<CardProps>`
     css`
       cursor: pointer;
       -webkit-transform-style: preserve-3d;
-      transition: transform var(--transition);
+      /* Not as performant as using pseudo element + opacity for shadow, but that doesn't work with overflow: hidden */
+      transition: transform var(--transition), box-shadow var(--transition);
       &:hover {
-        transform: scale(1.02);
+        transform: scale(1.05);
+        box-shadow: var(--card-hovered-box-shadow);
       }
     `}
 

--- a/src/components/Image.tsx
+++ b/src/components/Image.tsx
@@ -23,8 +23,8 @@ const Image = ({ url, width, height, layout = 'responsive', title, alt, classNam
     className={className}
     src={url}
     alt={alt ?? title}
-    width={width}
-    height={height}
+    width={layout !== 'fill' ? width : undefined}
+    height={layout !== 'fill' ? height : undefined}
     layout={layout}
   />
 );

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -1,5 +1,14 @@
 import { Link as LinkProps } from 'api/contentful/generated/api.generated';
 import NextLink from 'next/link';
+import {
+  FaGithubAlt,
+  FaInstagram,
+  FaLinkedinIn,
+  FaPaperPlane,
+  FaQuestion,
+  FaSpotify,
+  FaStrava,
+} from 'react-icons/fa';
 import styled from 'styled-components';
 
 type Props = LinkProps;
@@ -7,15 +16,35 @@ type Props = LinkProps;
 const IconLink = styled.a``;
 
 /**
- * Renders a link component from Contentful
+ * All built in mappings for icon name to element
+ */
+const BUILT_IN_ICONS: Record<string, JSX.Element> = {
+  strava: <FaStrava />,
+  spotify: <FaSpotify />,
+  github: <FaGithubAlt />,
+  linkedin: <FaLinkedinIn />,
+  instagram: <FaInstagram />,
+  about: <FaQuestion />,
+  email: <FaPaperPlane />,
+};
+
+/**
+ * Renders a link component from Contentful. Sometimes the icons are
+ * just specifications for what to render using an icon library,
+ * sometimes they're actual SVG html. When in doubt we assume html.
  */
 const Link = ({ title, url, icon }: Props) => {
   if (!url) {
     return null;
   }
+  const builtInIcon = icon ? BUILT_IN_ICONS[icon] : null;
   return icon ? (
     <NextLink href={url} passHref>
-      <IconLink dangerouslySetInnerHTML={{ __html: icon }} />
+      {builtInIcon ? (
+        <IconLink data-tooltip={title}>{builtInIcon}</IconLink>
+      ) : (
+        <IconLink data-tooltip={title} dangerouslySetInnerHTML={{ __html: icon }} />
+      )}
     </NextLink>
   ) : (
     <NextLink href={url}>{title}</NextLink>

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -29,7 +29,7 @@ const TitleText = styled.strong`
   white-space: nowrap;
   transition: opacity var(--transition), transform var(--transition);
   opacity: 0;
-  transform-origin: right;
+  transform-origin: left;
   transform: translateX(100%);
 `;
 

--- a/src/components/ProjectGrid.tsx
+++ b/src/components/ProjectGrid.tsx
@@ -1,6 +1,7 @@
 import useData from 'api/useData';
 import React from 'react';
 import styled from 'styled-components';
+import ColorSchemeToggleCard from './ColorSchemeToggleCard';
 import ContentCard from './ContentCard';
 import ContentGrid from './ContentGrid';
 import Image from './Image';
@@ -35,23 +36,30 @@ const IntroCard = styled(ContentCard)`
 const ProjectGrid = () => {
   const { data: projects } = useData('projects');
   const { data: introBlock } = useData('introBlock');
-  return (
-    <ContentGrid>
-      {introBlock?.textBlock?.content && (
-        <>
-          <ImageCard>
-            <Image {...introBlock.image} alt={introBlock.image.title} layout="fill" />
-          </ImageCard>
-          <IntroCard>
-            <RichText {...introBlock.textBlock.content} />
-          </IntroCard>
-        </>
-      )}
-      {projects?.map((project) => (
-        <ProjectCard key={project.title} {...project} />
-      ))}
-    </ContentGrid>
-  );
+
+  const introCards = introBlock?.textBlock?.content
+    ? [
+        <ImageCard key="image">
+          <Image {...introBlock.image} alt={introBlock.image.title} layout="fill" />
+        </ImageCard>,
+        <IntroCard key="text-content">
+          <RichText {...introBlock.textBlock.content} />
+        </IntroCard>,
+      ]
+    : [];
+
+  const projectCards =
+    projects?.map((project) => <ProjectCard key={project.title} {...project} />) ?? [];
+
+  // Insert the light/dark mode toggle into the grid a few into the project cards
+  const cards = [
+    ...introCards,
+    ...projectCards.slice(0, 2),
+    <ColorSchemeToggleCard key="theme-toggle" />,
+    ...projectCards.slice(2),
+  ];
+
+  return <ContentGrid>{cards}</ContentGrid>;
 };
 
 export default ProjectGrid;

--- a/src/hooks/useColorScheme.ts
+++ b/src/hooks/useColorScheme.ts
@@ -1,0 +1,77 @@
+import { useEffect, useState } from 'react';
+import useLocalStorageValue from './useLocalStorageValue';
+
+/**
+ * The color scheme the system prefers by default
+ */
+export type ColorScheme = 'dark' | 'light';
+
+// Name of the attribute for theme we add on `html`
+const THEME_ATTRIBUTE = 'data-theme';
+
+// The media query we'd like to match
+const PREFERS_DARK = '(prefers-color-scheme: dark)';
+
+/**
+ * Hook to fetch the current color scheme based both off a value saved by the
+ * user (optional) or the value of the `prefers-color-scheme` media query. For
+ * prerendering, it defaults the color scheme to light + using the system
+ * scheme. May result in bugs if Javascript is off + the values of
+ * `colorScheme`/`isSystemScheme` are used for prerendered data, as locally,
+ * the page will still reflect the system color but anything using this JS
+ * is artifically defaulted to light.
+ */
+const useColorScheme = () => {
+  // The value of these will be different on server vs client - don't use outside a `useEffect`
+  const [preferredScheme, updatePreferredScheme, deletePreferredScheme] =
+    useLocalStorageValue<ColorScheme | null>('colorScheme', null);
+  const updateOrDeletePreferredScheme = (value: ColorScheme | null) =>
+    value ? updatePreferredScheme(value) : deletePreferredScheme();
+  const [systemScheme, setSystemScheme] = useState<ColorScheme | null>(null);
+
+  // These values are set in a `useEffect` and can be used for prerendered content safely
+  const [colorScheme, setColorScheme] = useState<ColorScheme>('light');
+  const [isSystemScheme, setIsSystemScheme] = useState(true);
+
+  // Set our locally-rendered values during client hydration
+  useEffect(() => {
+    setColorScheme(preferredScheme ?? systemScheme ?? 'light');
+    setIsSystemScheme(preferredScheme === null);
+  }, [setColorScheme, systemScheme, preferredScheme]);
+
+  // Adds an attribute on the html element for the page based on current theme
+  useEffect(() => {
+    const htmlElement = document.documentElement;
+    if (isSystemScheme) {
+      htmlElement.removeAttribute(THEME_ATTRIBUTE);
+      return;
+    }
+    document.documentElement.setAttribute(THEME_ATTRIBUTE, colorScheme);
+  }, [colorScheme, isSystemScheme]);
+
+  // Setup event listenter for later changes + set the initial value from `prefers-color-scheme`
+  useEffect(() => {
+    if (!window) {
+      return;
+    }
+    const prefersDark = window.matchMedia(PREFERS_DARK);
+    setSystemScheme(prefersDark.matches ? 'dark' : 'light');
+
+    const listener = (event: MediaQueryListEvent) =>
+      setSystemScheme(event.matches ? 'dark' : 'light');
+    prefersDark.addEventListener('change', listener);
+    return () => {
+      prefersDark.removeEventListener('change', listener);
+    };
+  }, []);
+
+  // The update here actually updates or deletes the local storage value for cleanup
+  return {
+    colorScheme,
+    isSystemScheme,
+    isInitializedWithSystemScheme: systemScheme !== null,
+    updatePreferredScheme: updateOrDeletePreferredScheme,
+  } as const;
+};
+
+export default useColorScheme;

--- a/src/hooks/useLocalStorageValue.ts
+++ b/src/hooks/useLocalStorageValue.ts
@@ -1,0 +1,36 @@
+import { useState } from 'react';
+
+export type LocalStorageKey = 'colorScheme';
+
+/**
+ * Uses local storage to fetch/store a given value.
+ */
+const useLocalStorageValue = <Value>(key: LocalStorageKey, initialValue: Value) => {
+  const resolvedKey = `com.dg.${key}`;
+  const [storedValue, setStoredValue] = useState<Value>(() => {
+    try {
+      const item = window.localStorage.getItem(resolvedKey);
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      return item ? (JSON.parse(item) as Value) : initialValue;
+    } catch {
+      return initialValue;
+    }
+  });
+
+  /**
+   * Saves a new value to local storage, returning if it was saved
+   * successfully.
+   */
+  const setValue = (value: Value) => {
+    try {
+      setStoredValue(value);
+      window.localStorage.setItem(resolvedKey, JSON.stringify(value));
+      return true;
+    } catch {
+      return false;
+    }
+  };
+  return [storedValue, setValue] as const;
+};
+
+export default useLocalStorageValue;

--- a/src/hooks/useLocalStorageValue.ts
+++ b/src/hooks/useLocalStorageValue.ts
@@ -7,7 +7,7 @@ export type LocalStorageKey = 'colorScheme';
  */
 const useLocalStorageValue = <Value>(key: LocalStorageKey, initialValue: Value) => {
   const resolvedKey = `com.dg.${key}`;
-  const [storedValue, setStoredValue] = useState<Value>(() => {
+  const [storedValue, setStoredValue] = useState<Value | null>(() => {
     try {
       const item = window.localStorage.getItem(resolvedKey);
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
@@ -30,7 +30,22 @@ const useLocalStorageValue = <Value>(key: LocalStorageKey, initialValue: Value) 
       return false;
     }
   };
-  return [storedValue, setValue] as const;
+
+  /**
+   * Deletes the value from local storage, returning if it was deleted
+   * successfully.
+   */
+  const deleteValue = () => {
+    try {
+      setStoredValue(null);
+      window.localStorage.removeItem(resolvedKey);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  return [storedValue, setValue, deleteValue] as const;
 };
 
 export default useLocalStorageValue;


### PR DESCRIPTION
# Description of changes

1. Links now can render built in icons instead of always being SVG (used for new footer icons)
2. Fixed warning about images & attrs
3. Bigger shadows on project cards on hover
4. Local storage hooks
5. Color scheme hooks (for system-defined and user-preferred)
6. ColorSchemeToggleCard to allow changing color scheme (uses local storage for persistence + is fully compatible with SSR)
<img width="383" alt="image" src="https://user-images.githubusercontent.com/982182/149601332-922397a1-4301-413a-8ec9-ebd27e5541fd.png">
<img width="378" alt="image" src="https://user-images.githubusercontent.com/982182/149601340-3157df67-3e8a-4648-b6d7-f2b54f1aa5d4.png">
<img width="375" alt="image" src="https://user-images.githubusercontent.com/982182/149601343-46d5e416-a72f-4fc0-9afe-579df3400b04.png">
<img width="259" alt="image" src="https://user-images.githubusercontent.com/982182/149601377-c5970ab6-f7ae-4d4c-9cb0-34f7ed97ac65.png">
<img width="265" alt="image" src="https://user-images.githubusercontent.com/982182/149601388-0fdb3f5d-33fd-494b-b0bd-ed1eb7079ac5.png">
