### PR TITLE
fix: improve Safari logo perf + logo hover + file organization

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@contentful/rich-text-react-renderer": "15.11.1",
     "@contentful/rich-text-types": "15.11.1",
     "@picocss/pico": "1.4.2",
+    "@react-hook/throttle": "2.2.0",
     "blobs": "2.2.1-beta.1",
     "graphql": "16.2.0",
     "graphql-request": "3.7.0",

--- a/src/components/AppStyle.tsx
+++ b/src/components/AppStyle.tsx
@@ -17,8 +17,12 @@ export const cardSizeInEm = (span = 1) =>
 const darkModeVariables = css`
   --contrast-overlay: var(--contrast-inverse);
   --contrast-overlay-inverse: var(--contrast);
+  --blob-border-width: 0.08px;
+
+  // Same as --card-box-shadow with the fade doubled
   --card-hovered-box-shadow: 0 0.125rem 2rem rgba(0, 0, 0, 0.06),
     0 0.125rem 4rem rgba(0, 0, 0, 0.12), 0 0 0 0.125rem rgba(0, 0, 0, 0.036);
+
   --yellow: yellow;
   --navy: #0a6280;
 `;
@@ -30,8 +34,12 @@ const darkModeVariables = css`
 const lightModeVariables = css`
   --contrast-overlay: var(--secondary);
   --contrast-overlay-inverse: var(--secondary-inverse);
+  --blob-border-width: 0;
+
+  // Same as --card-box-shadow with the fade doubled
   --card-hovered-box-shadow: 0 0.125rem 2rem rgba(27, 40, 50, 0.04),
     0 0.125rem 4rem rgba(27, 40, 50, 0.08), 0 0 0 0.125rem rgba(27, 40, 50, 0.024);
+
   --yellow: rgb(222, 197, 29);
   --navy: #0a6280;
 `;
@@ -47,6 +55,9 @@ const AppStyle = createGlobalStyle`
       /* Below here are new variables */
       --content-grid-dimension-em: ${CONTENT_GRID_DIMENSION}em;
       --content-grid-gap-em: ${CONTENT_GRID_GAP}em;
+
+      // Similar to the card box shadow but for filters (much simpler, for perf)
+      --filter-drop-shadow: drop-shadow(0 0.125rem 1rem rgba(27, 40, 50, 0.08));
   }
 
   // When a page/component is set to light or the root has no dark theme applied

--- a/src/components/Blob.tsx
+++ b/src/components/Blob.tsx
@@ -1,14 +1,72 @@
 import * as blobs from 'blobs/v2';
+import styled, { css } from 'styled-components';
 
-const SIZE = 1000;
+interface Props {
+  /**
+   * Used to generate the blob shape
+   */
+  seed: number;
+
+  /**
+   * If passed something, sets the fill on hover
+   */
+  hoveredFill?: React.ComponentProps<'svg'>['fill'];
+}
+
+// Size of the element in pixels - but as it's used for viewBox, the svg will always be the same size
+const SIZE = 100;
 
 /**
- * Creates a fun random blob that's almost a circle but has some randomness, with a size of 200.
+ * If clickable, make sure only the fill takes pointer events
+ * (not transparent area behind). Fill/fill on hover can be
+ * passed for the right css for it.
+ */
+const Path = styled.path<{
+  $isClickable: boolean;
+  $fill: React.ComponentProps<'svg'>['fill'];
+  $hoveredFill: React.ComponentProps<'svg'>['fill'];
+}>`
+  stroke-width: var(--blob-border-width);
+  stroke: var(--primary-focus);
+  ${({ $fill }) =>
+    $fill &&
+    css`
+      fill: ${$fill};
+    `};
+  ${({ $hoveredFill }) =>
+    $hoveredFill &&
+    css`
+      :hover {
+        transition: fill var(--transition);
+        fill: ${$hoveredFill};
+      }
+    `}
+  ${({ $isClickable }) =>
+    $isClickable &&
+    css`
+      cursor: pointer;
+      pointer-events: visibleFill;
+    `}
+`;
+
+/**
+ * Creates a fun random blob that's almost a circle but has some
+ * randomness built in. Generates a new blob for every seed that's
+ * passed. SVG is what's returned, and it must be manually sized.
+ *
+ * IMPORTANT: this element is NOT safe to server render, as rounding
+ * of floats make the `path` values slightly different and Next warns
+ * about mismatched data. To use, wrap in a `dynamic` import from
+ * Next to use only on client. Helps with page weight too, since the
+ * `blobs` package should be an import specific to this page.
  */
 const Blob = ({
   className,
+  onClick,
   seed,
-}: Pick<React.ComponentProps<'svg'>, 'className'> & { seed: number }) => {
+  fill,
+  hoveredFill,
+}: Pick<React.ComponentProps<'svg'>, 'className' | 'onClick' | 'fill'> & Props) => {
   const path = blobs.svgPath({
     seed,
     extraPoints: 7,
@@ -16,8 +74,13 @@ const Blob = ({
     size: SIZE,
   });
   return (
-    <svg className={className} viewBox={`0 0 ${SIZE} ${SIZE}`} xmlns="http://www.w3.org/2000/svg">
-      <path d={path} />
+    <svg
+      className={className}
+      onClick={onClick}
+      viewBox={`0 0 ${SIZE} ${SIZE}`}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <Path d={path} $fill={fill} $hoveredFill={hoveredFill} $isClickable={!!onClick} />
     </svg>
   );
 };

--- a/src/components/ContentCard.tsx
+++ b/src/components/ContentCard.tsx
@@ -91,7 +91,6 @@ const Card = styled.article<CardProps>`
     $isClickable &&
     css`
       cursor: pointer;
-      -webkit-transform-style: preserve-3d;
       /* Not as performant as using pseudo element + opacity for shadow, but that doesn't work with overflow: hidden */
       transition: transform var(--transition), box-shadow var(--transition);
       &:hover {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,108 +1,19 @@
 import useData from 'api/useData';
-import useScrollPosition from 'hooks/useScrollPosition';
-import dynamic from 'next/dynamic';
-import { useEffect, useState } from 'react';
-import { FiArrowUp } from 'react-icons/fi';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import Link from './Link';
+import Logo from './Logo';
 
-// Amount in px we have to scroll to get the fancy effect on the logo
-const THRESHOLD = 80;
-
-// Imports without SSR to avoid the rounding problems causing bugs
-const Blob = dynamic(() => import('./Blob'), { ssr: false });
-
-// Uses Inter for header + links up top
 const SpacedHeader = styled.header`
   margin-top: var(--spacing);
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu,
-    Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
-  font-weight: 600;
-`;
-
-// Absolutely positions & scales up the blob to fit behind the logo, with transitions
-const StyledBlob = styled(Blob)`
-  z-index: -1;
-  position: absolute;
-  top: -11em;
-  left: -8em;
-  width: 14em;
-  opacity: 0;
-  path {
-    transition: fill var(--transition);
-    fill: var(--background-color);
-  }
-  filter: drop-shadow(0 0.125rem 1rem rgba(27, 40, 50, 0.12));
-  transition: transform var(--transition), opacity var(--transition), path var(--transition);
-`;
-
-// Bold, big, and squishy Inter
-const Logo = styled.span<{ $isFancy: boolean }>`
-  display: block;
-  position: relative;
-  color: var(--secondary);
-  font-size: 2.5em;
-  font-weight: 800;
-  letter-spacing: -0.12em;
-  transition: transform var(--transition), color var(--transition);
-  ${({ $isFancy }) =>
-    $isFancy &&
-    css`
-      cursor: pointer;
-      ${StyledBlob} {
-        opacity: 1;
-      }
-      &:hover {
-        transform: scale(1.05);
-        color: #ffffff;
-        ${StyledBlob} {
-          path {
-            fill: var(--primary);
-          }
-          transform: rotate(-11deg);
-        }
-      }
-    `}
 `;
 
 /**
- * Creates the site header component - shows header links + fancy animated
- * logo blob that scrolls you to top of page when clicked.
+ * Creates the site header component. It's a bar that spans across the
+ * page and shows a logo + header links if they exist.
  */
 const Header = () => {
   const { data: headerLinks } = useData('siteHeader');
-  const { scrollY } = useScrollPosition();
-  const [lastScrollY, setLastScrollY] = useState(0);
-  const [blobSeed, setBlobSeed] = useState(Math.random());
-
-  // If we should show a blob background
-  const isFancyLogo = !!scrollY && scrollY > THRESHOLD;
-  const scrollToTop = () => window.scrollTo({ top: 0, behavior: 'smooth' });
-
-  // Save the last scroll Y to crudely determine when we're scrolling under threshold
-  useEffect(() => {
-    if (!scrollY) {
-      return;
-    }
-    if (scrollY > THRESHOLD) {
-      setLastScrollY(scrollY);
-    } else {
-      setLastScrollY(-1);
-    }
-  }, [scrollY]);
-
-  // When we scroll under the threshold again, set a new blob seed
-  useEffect(() => {
-    if (!(scrollY && scrollY <= THRESHOLD && lastScrollY > THRESHOLD)) {
-      return;
-    }
-
-    // Matches timeout of the standard animation - intentionally NOT cancelled so it actually finishes
-    setTimeout(() => setBlobSeed(Math.random()), 200);
-  }, [blobSeed, lastScrollY, scrollY]);
-
-  // Each of the header links, mapped
-  const linkElements = headerLinks && (
+  const headerLinkElements = headerLinks && (
     <ul>
       {headerLinks.map((link) => (
         <li key={link.url}>
@@ -112,24 +23,15 @@ const Header = () => {
     </ul>
   );
 
-  // Logo and the blob behind
-  const logo = (
-    <Logo aria-hidden $isFancy={isFancyLogo} onClick={isFancyLogo ? scrollToTop : undefined}>
-      <StyledBlob seed={blobSeed} />
-      dg.
-      <FiArrowUp
-        style={{ opacity: isFancyLogo ? 1 : 0, marginLeft: '0.25em', fontSize: '0.75em' }}
-      />
-    </Logo>
-  );
-
   return (
     <SpacedHeader>
       <nav>
         <ul>
-          <li>{logo}</li>
+          <li>
+            <Logo />
+          </li>
         </ul>
-        {linkElements}
+        {headerLinkElements}
       </nav>
     </SpacedHeader>
   );

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -2,14 +2,18 @@ import styled from 'styled-components';
 import Footer from './Footer';
 import Header from './Header';
 
+// Makes the header bar sticky and not responsive to user events by default
 const HeaderBar = styled.div`
   position: sticky;
-  top: 0;
+  top: -1em;
   z-index: 1;
+  pointer-events: none;
 `;
 
 /**
- * Creates a basic page layout. Should wrap every page!
+ * Basic page layout for every page. Has a sticky, contained header above
+ * the main (contained) content, with a (contained) footer below. No wrapper
+ * around all items to save on divs.
  */
 const Layout = ({ children }: Pick<React.ComponentProps<'div'>, 'children'>) => (
   <>

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -1,0 +1,123 @@
+import useScrollPosition from 'hooks/useScrollPosition';
+import dynamic from 'next/dynamic';
+import { useEffect, useMemo, useState } from 'react';
+import { FiArrowUp } from 'react-icons/fi';
+import styled, { css } from 'styled-components';
+
+// Amount in px we have to scroll to get the fancy effect on the logo
+const THRESHOLD = 80;
+
+/**
+ * Creates a blob element that appears behind the logo when scrolled
+ * down on the page. Imports without SSR to force client-side rendering
+ * only (see `Blob` for more about this). Scales it up and offscreen
+ * quite a bit to make it the background of the logo visually. Shows
+ * only once we scroll down.
+ */
+const LogoBlobBackground = styled(dynamic(() => import('./Blob'), { ssr: false }))<{
+  $isBlobBackgroundVisible: boolean;
+}>`
+  position: absolute;
+  top: -11em;
+  left: -8em;
+  width: 14em;
+  filter: var(--filter-drop-shadow);
+  transition: transform var(--transition), opacity var(--transition);
+  opacity: 0;
+  z-index: -1;
+  will-change: transform, opacity;
+  ${({ $isBlobBackgroundVisible }) =>
+    $isBlobBackgroundVisible &&
+    css`
+      opacity: 1;
+      :hover {
+        transform: rotate(-15deg);
+      }
+    `}
+`;
+
+/**
+ * Big, bold, and squished text for use as logo, with Inter font
+ * (loaded on all pages via document.tsx)
+ */
+const LogoText = styled.span`
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu,
+    Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  font-weight: 800;
+  letter-spacing: -0.12em;
+`;
+
+/**
+ * Contains all elements, relatively positioned so we can
+ * absolutely position the blob. If we scroll down, adds a
+ * hover effect to indicate clickability.
+ */
+const Container = styled.div<{ $isBlobBackgroundVisible: boolean }>`
+  position: relative;
+  font-size: 2.5em;
+  color: var(--secondary);
+  transition: color var(--transition);
+  ${({ $isBlobBackgroundVisible }) =>
+    $isBlobBackgroundVisible &&
+    css`
+      &:hover {
+        color: #ffffff;
+      }
+    `}
+`;
+
+/**
+ * Arrow up to show scrollability. Fades in, and is on own layer to
+ * prevent jittering as it fades in.
+ */
+const ScrollUpIndicator = styled(FiArrowUp)<{ $isBlobBackgroundVisible: boolean }>`
+  margin-left: 0.25em;
+  font-size: 0.5em;
+  transition: opacity var(--transition);
+  will-change: transform;
+  ${({ $isBlobBackgroundVisible }) => css`
+    opacity: ${$isBlobBackgroundVisible ? 1 : 0};
+  `}
+`;
+
+/**
+ * Creates a logo out of plain text + a "blob" that appears behind it.
+ * The blob only appears when you scroll down the page, and with the
+ * blob, there's a scroll to top button to jump you up.
+ */
+const Logo = () => {
+  const { scrollY } = useScrollPosition();
+  const [lastScrollY, setLastScrollY] = useState(0);
+  const [blobSeed, setBlobSeed] = useState(Math.random());
+  const scrollToTop = () => window.scrollTo({ top: 0, behavior: 'smooth' });
+  const isBlobBackgroundVisible = useMemo(() => !!scrollY && scrollY > THRESHOLD, [scrollY]);
+
+  // Save last scroll Y if we went beyond the threshold
+  useEffect(
+    () => setLastScrollY(scrollY && isBlobBackgroundVisible ? scrollY : -1),
+    [isBlobBackgroundVisible, scrollY],
+  );
+
+  // If we scroll under the threshold (up to top of page), refresh seed - intentionally delayed & NOT cancelled so it actually finishes
+  useEffect(() => {
+    if (scrollY && !isBlobBackgroundVisible && lastScrollY > THRESHOLD) {
+      setTimeout(() => setBlobSeed(Math.random()), 200);
+    }
+  }, [blobSeed, isBlobBackgroundVisible, lastScrollY, scrollY]);
+
+  return (
+    <Container $isBlobBackgroundVisible={isBlobBackgroundVisible}>
+      <LogoBlobBackground
+        seed={blobSeed}
+        fill="var(--background-color)"
+        hoveredFill="var(--primary)"
+        onClick={isBlobBackgroundVisible ? scrollToTop : undefined}
+        $isBlobBackgroundVisible={isBlobBackgroundVisible}
+      />
+      <LogoText aria-hidden>dg.</LogoText>
+      <ScrollUpIndicator $isBlobBackgroundVisible={isBlobBackgroundVisible} />
+    </Container>
+  );
+};
+
+export default Logo;

--- a/src/hooks/useScrollPosition.ts
+++ b/src/hooks/useScrollPosition.ts
@@ -1,34 +1,28 @@
-/**
- * useScroll React custom hook
- * Usage:
- *    const { scrollX, scrollY, scrollDirection } = useScroll();
- */
-
+import { useThrottleCallback } from '@react-hook/throttle';
 import { useEffect, useState } from 'react';
 
 /**
- * Grabs the document's scroll X and Y
+ * Reports the document's X and Y offset, with a delay
  */
 const useScrollPosition = () => {
-  const [bodyOffset, setBodyOffset] = useState<DOMRect | null>(null);
-  const [scrollY, setScrollY] = useState(bodyOffset?.top);
-  const [scrollX, setScrollX] = useState(bodyOffset?.left);
+  const [scrollY, setScrollY] = useState(0);
+  const [scrollX, setScrollX] = useState(0);
 
-  const updateOffset = () =>
-    requestAnimationFrame(() => {
-      const rect = document.body.getBoundingClientRect();
-      setBodyOffset(rect);
-      setScrollY(-rect.top);
-      setScrollX(rect.left);
-    });
+  // Updates the offset with a resolution of 15 FPS for best performance
+  const updateOffset = useThrottleCallback(() => {
+    const rect = document.body.getBoundingClientRect();
+    setScrollY(-rect.top);
+    setScrollX(rect.left);
+  }, 15);
 
+  // Attach to the window's scroll listener
   useEffect(() => {
     updateOffset();
     window.addEventListener('scroll', updateOffset);
     return () => {
       window.removeEventListener('scroll', updateOffset);
     };
-  }, []);
+  }, [updateOffset]);
 
   return {
     scrollY,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1579,6 +1579,18 @@
   resolved "https://registry.yarnpkg.com/@picocss/pico/-/pico-1.4.2.tgz#6677d0ec854e2adf12086be5857ae45fc89f04f9"
   integrity sha512-bHYgmia0nQRCLHn9GLVDHfw5ViqSbFN1cXvOXlMCuoqsuJamxgbpw5HGFC0qyhqD05WfJjNXH5rL9vN6cMjH3w==
 
+"@react-hook/latest@^1.0.2":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@react-hook/latest/-/latest-1.0.3.tgz#c2d1d0b0af8b69ec6e2b3a2412ba0768ac82db80"
+  integrity sha512-dy6duzl+JnAZcDbNTfmaP3xHiKtbXYOaz3G51MGVljh548Y8MWzTr+PHLOfvpypEVW9zwvl+VyKjbWKEVbV1Rg==
+
+"@react-hook/throttle@2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@react-hook/throttle/-/throttle-2.2.0.tgz#d0402714a06e1ba0bc1da1fdf5c3c5cd0e08d45a"
+  integrity sha512-LJ5eg+yMV8lXtqK3lR+OtOZ2WH/EfWvuiEEu0M3bhR7dZRfTyEJKxH1oK9uyBxiXPtWXiQggWbZirMCXam51tg==
+  dependencies:
+    "@react-hook/latest" "^1.0.2"
+
 "@rushstack/eslint-patch@^1.0.8":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.1.0.tgz#7f698254aadf921e48dda8c0a6b304026b8a9323"


### PR DESCRIPTION
# Description of changes

1. Moves logo to its own file for readability + renames some weird variables + reorganizes file + moves it upward an em on scroll
2. Adds border to blob on dark mode for visibility
3. Smoother performance on Safari especially through putting content on its own layer. Also prevents animations when swapping dark/light mode for the same reason. Way faster to transition themes. Should keep that in mind for the future too.
4. Content cards no longer need `-webkit-transform-style: preserve-3d;`
5. Scroll y position hook is now debounced significantly for perf