### PR TITLE
fix: make scroll to top more obvious

### DIFF
--- a/src/components/Blob.tsx
+++ b/src/components/Blob.tsx
@@ -69,7 +69,7 @@ const Blob = ({
 }: Pick<React.ComponentProps<'svg'>, 'className' | 'onClick' | 'fill'> & Props) => {
   const path = blobs.svgPath({
     seed,
-    extraPoints: 7,
+    extraPoints: 5,
     randomness: 2,
     size: SIZE,
   });

--- a/src/components/ContentCard.tsx
+++ b/src/components/ContentCard.tsx
@@ -57,6 +57,14 @@ interface CardProps {
   $isClickable: boolean;
 }
 
+// Animates left on hover, as the container animates right, so it appears to stay in place as in comes in
+const HiddenElement = styled.span`
+  transition: opacity var(--transition), transform var(--transition);
+  opacity: 0;
+  transform-origin: left;
+  transform: translateX(100%);
+`;
+
 // A stack for an overlay that animates in from slightly offscreen left when hovered
 const OverlayStack = styled(Stack).attrs({ $alignItems: 'center', $gap: '8px' })`
   overflow: hidden;
@@ -71,14 +79,13 @@ const OverlayStack = styled(Stack).attrs({ $alignItems: 'center', $gap: '8px' })
 
   transition: transform var(--transition);
   transform: translateX(calc(2em - 100%));
-`;
-
-// Animates left on hover, as the container animates right, so it appears to stay in place as in comes in
-const HiddenElement = styled.span`
-  transition: opacity var(--transition), transform var(--transition);
-  opacity: 0;
-  transform-origin: left;
-  transform: translateX(100%);
+  &:hover {
+    transform: initial;
+    ${HiddenElement} {
+      opacity: 1;
+      transform: initial;
+    }
+  }
 `;
 
 // Card component that spans an arbitrary number of rows/cols

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -3,6 +3,7 @@ import dynamic from 'next/dynamic';
 import { useEffect, useMemo, useState } from 'react';
 import { FiArrowUp } from 'react-icons/fi';
 import styled, { css } from 'styled-components';
+import Stack from './Stack';
 
 // Amount in px we have to scroll to get the fancy effect on the logo
 const THRESHOLD = 80;
@@ -21,9 +22,9 @@ const LogoBlobBackground = styled(dynamic(() => import('./Blob'), { ssr: false }
   $isBlobBackgroundVisible: boolean;
 }>`
   position: absolute;
-  top: -11em;
-  left: -8em;
-  width: 14em;
+  top: -15em;
+  left: -11em;
+  width: 20em;
   filter: var(--filter-drop-shadow);
   transition: transform var(--transition), opacity var(--transition);
   opacity: 0;
@@ -59,10 +60,12 @@ const Container = styled.div<{ $isBlobBackgroundVisible: boolean }>`
   position: relative;
   font-size: 2.5em;
   color: var(--secondary);
-  transition: color var(--transition);
+  transform-origin: top left;
+  transition: color var(--transition), transform var(--transition);
   ${({ $isBlobBackgroundVisible }) =>
     $isBlobBackgroundVisible &&
     css`
+      transform: scale(0.64);
       &:hover {
         color: #ffffff;
       }
@@ -73,9 +76,11 @@ const Container = styled.div<{ $isBlobBackgroundVisible: boolean }>`
  * Arrow up to show scrollability. Fades in, and is on own layer to
  * prevent jittering as it fades in.
  */
-const ScrollUpIndicator = styled(FiArrowUp)<{ $isBlobBackgroundVisible: boolean }>`
+const ScrollUpIndicator = styled(Stack)<{ $isBlobBackgroundVisible: boolean }>`
   margin-left: 0.25em;
-  font-size: 0.5em;
+  font-size: 0.45em;
+  letter-spacing: 0.03em;
+  font-weight: 600;
   transition: opacity var(--transition);
   will-change: transform;
   ${({ $isBlobBackgroundVisible }) => css`
@@ -116,7 +121,14 @@ const Logo = () => {
         $isBlobBackgroundVisible={isBlobBackgroundVisible}
       />
       <LogoText aria-hidden>dg.</LogoText>
-      <ScrollUpIndicator $isBlobBackgroundVisible={isBlobBackgroundVisible} />
+      <ScrollUpIndicator
+        $isBlobBackgroundVisible={isBlobBackgroundVisible}
+        $gap="2px"
+        $alignItems="center"
+      >
+        To Top
+        <FiArrowUp />
+      </ScrollUpIndicator>
     </Container>
   );
 };

--- a/src/components/homepage/ColorSchemeIcon.tsx
+++ b/src/components/homepage/ColorSchemeIcon.tsx
@@ -30,9 +30,17 @@ const TOOLTIPS: Record<ColorScheme, string> = {
 /**
  * Maps color scheme to icon element
  */
-const ICONS: Record<ColorScheme, JSX.Element> = {
+const COLORED_ICONS: Record<ColorScheme, JSX.Element> = {
   dark: <FiMoon color="var(--secondary)" />,
   light: <FiSun color="var(--yellow)" />,
+};
+
+/**
+ * Uncolored icons for use elsewhere
+ */
+export const ICONS: Record<ColorScheme, JSX.Element> = {
+  dark: <FiMoon />,
+  light: <FiSun />,
 };
 
 // Reset the state that tooltips give to the element since it acts as a button here.
@@ -68,7 +76,7 @@ const ColorSchemeIcon = ({ scheme, hasTheme, updatePreferredScheme }: Props) => 
     onClick={hasTheme ? () => updatePreferredScheme(scheme) : undefined}
     data-tooltip={hasTheme ? TOOLTIPS[scheme] : undefined}
   >
-    {ICONS[scheme]}
+    {COLORED_ICONS[scheme]}
   </IconWrapper>
 );
 


### PR DESCRIPTION
# Description of changes

Adds a second line under the logo that says "To Top" in small text. Adjusts the blob to hopefully cover it usually