### PR TITLE
fix: stretch blob to better scale under the logo

### DIFF
--- a/src/components/Blob.tsx
+++ b/src/components/Blob.tsx
@@ -78,6 +78,7 @@ const Blob = ({
       className={className}
       onClick={onClick}
       viewBox={`0 0 ${SIZE} ${SIZE}`}
+      preserveAspectRatio="none"
       xmlns="http://www.w3.org/2000/svg"
     >
       <Path d={path} $fill={fill} $hoveredFill={hoveredFill} $isClickable={!!onClick} />

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -22,9 +22,10 @@ const LogoBlobBackground = styled(dynamic(() => import('./Blob'), { ssr: false }
   $isBlobBackgroundVisible: boolean;
 }>`
   position: absolute;
-  top: -15em;
-  left: -11em;
-  width: 20em;
+  top: -400%;
+  left: -550%;
+  width: 900%;
+  height: 600%;
   filter: var(--filter-drop-shadow);
   transition: transform var(--transition), opacity var(--transition);
   opacity: 0;
@@ -35,7 +36,7 @@ const LogoBlobBackground = styled(dynamic(() => import('./Blob'), { ssr: false }
     css`
       opacity: 1;
       :hover {
-        transform: rotate(-15deg);
+        transform: rotate(-10deg);
       }
     `}
 `;


### PR DESCRIPTION
# Description of changes
Yet another logo blob tweak. Now scales non-uniformly sideways to better "stick" to the corner and go under the logo.

<img width="347" alt="image" src="https://user-images.githubusercontent.com/982182/149646720-7f3f5f1f-89c0-4c50-a0c9-222965154260.png">
