### PR TITLE
fix: simplified content grid logic without jump of text

### DIFF
--- a/src/components/ContentCard.tsx
+++ b/src/components/ContentCard.tsx
@@ -66,7 +66,7 @@ const HiddenElement = styled.span`
 `;
 
 // A stack for an overlay that animates in from slightly offscreen left when hovered
-const OverlayStack = styled(Stack).attrs({ $alignItems: 'center', $gap: '8px' })`
+export const OverlayStack = styled(Stack).attrs({ $alignItems: 'center', $gap: '8px' })`
   overflow: hidden;
   position: absolute;
   bottom: 0.5em;

--- a/src/components/ContentGrid.tsx
+++ b/src/components/ContentGrid.tsx
@@ -1,12 +1,21 @@
 import styled from 'styled-components';
 
-// Auto fits densely to properly fill in all gaps at every size. Means that things will jump around a bit
+/**
+ * Auto fits densely to properly fill in all gaps at every size. Use
+ * of auto on smallest screens means the items will fill the screen instead
+ * of being small in the center. Once we hit tablet, we swap to using static
+ * widths for our columns to allow 3 or more on bigger screens
+ */
 const Grid = styled.div`
   display: grid;
   gap: var(--content-grid-gap-em);
-  grid-template-columns: repeat(auto-fit, var(--content-grid-dimension-em));
+  grid-template-columns: repeat(auto-fit, auto);
   grid-auto-flow: dense;
   justify-content: center;
+
+  @media (min-width: 768px) {
+    grid-template-columns: repeat(auto-fit, var(--content-grid-dimension-em));
+  }
 `;
 
 /**

--- a/src/components/ContentGrid.tsx
+++ b/src/components/ContentGrid.tsx
@@ -1,18 +1,12 @@
 import styled from 'styled-components';
 
-// Auto fits above 992px, and kept to two columns for tablet. Mobile is one wide only.
+// Auto fits densely to properly fill in all gaps at every size. Means that things will jump around a bit
 const Grid = styled.div`
   display: grid;
   gap: var(--content-grid-gap-em);
-  grid: 1fr;
+  grid-template-columns: repeat(auto-fit, var(--content-grid-dimension-em));
+  grid-auto-flow: dense;
   justify-content: center;
-  @media (min-width: 768px) {
-    grid: auto-flow dense / 1fr 1fr;
-  }
-  @media (min-width: 992px) {
-    grid-template-columns: repeat(auto-fit, var(--content-grid-dimension-em));
-    grid-template-rows: repeat(auto-fit, var(--content-grid-dimension-em));
-  }
 `;
 
 /**

--- a/src/components/homepage/IntroCard.tsx
+++ b/src/components/homepage/IntroCard.tsx
@@ -1,14 +1,21 @@
 import useData from 'api/useData';
-import ContentCard from 'components/ContentCard';
+import ContentCard, { OverlayStack } from 'components/ContentCard';
 import Image from 'components/Image';
 import RichText from 'components/RichText';
 import { FiUser } from 'react-icons/fi';
 import styled from 'styled-components';
 
 const ImageCard = styled(ContentCard)`
-  display: none;
-  @media (min-width: 768px) {
+  @media (max-width: 767.96px) {
+    --size: 12em;
+    justify-self: center;
+    width: var(--size);
+    height: var(--size);
     display: flex;
+    border-radius: calc(var(--size) / 2);
+    ${OverlayStack} {
+      opacity: 0;
+    }
   }
 `;
 

--- a/src/components/homepage/MapCard.tsx
+++ b/src/components/homepage/MapCard.tsx
@@ -4,12 +4,19 @@ import { useState } from 'react';
 import MapGL from 'react-map-gl';
 import styled from 'styled-components';
 
+const Card = styled(ContentCard)`
+  min-height: 200px;
+`;
+
 const StyledMap = styled(MapGL)`
   & .mapboxgl-canvas {
     border-radius: var(--border-radius);
   }
 `;
 
+/**
+ * Uses Mapbox to show a canvas-based map of my current location.
+ */
 const MapCard = () => {
   const { data: location } = useData('myLocation');
   const [viewport, setViewport] = useState({
@@ -21,7 +28,7 @@ const MapCard = () => {
   });
 
   return (
-    <ContentCard>
+    <Card>
       <StyledMap
         {...viewport}
         attributionControl={false}
@@ -35,7 +42,7 @@ const MapCard = () => {
         onViewportChange={setViewport}
         mapboxApiAccessToken={process.env.NEXT_PUBLIC_MAPBOX_TOKEN}
       />
-    </ContentCard>
+    </Card>
   );
 };
 

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -8,7 +8,7 @@ import { ServerStyleSheet } from 'styled-components';
 export default class Document extends NextDocument {
   render() {
     return (
-      <Html>
+      <Html lang="en">
         <Head>
           <link rel="preconnect" href="https://fonts.googleapis.com" />
           <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />


### PR DESCRIPTION
# Description of changes

Figured out how to avoid having three declarations for the grid flow with the very overlooked `grid-auto-flow: dense` 🤦 also rounds intro card avatar on mobile (and makes it smaller).

Also makes sure the map shows on mobile!!