### PR TITLE
fix: rounder cards, disabled animations when swapping color schemes

### DIFF
--- a/src/components/AppStyle.tsx
+++ b/src/components/AppStyle.tsx
@@ -3,15 +3,6 @@ import { ANIMATE_ATTRIBUTE } from 'hooks/useColorScheme';
 import 'mapbox-gl/dist/mapbox-gl.css';
 import { createGlobalStyle, css } from 'styled-components';
 
-const CONTENT_GRID_DIMENSION = 17;
-const CONTENT_GRID_GAP = 2.5;
-
-/**
- * Creates a card size in em from a span
- */
-export const cardSizeInEm = (span = 1) =>
-  CONTENT_GRID_DIMENSION * span + (span - 1) * CONTENT_GRID_GAP;
-
 /**
  * Variables specific to dark mode. Anything that appears here needs to have
  * something defined in `lightModeVariables` and vice versa.
@@ -52,14 +43,13 @@ const lightModeVariables = css`
 const AppStyle = createGlobalStyle`
   :root {
       /* These are Pico overrides */
-      --border-radius: 1rem;
-      
-      /* Below here are new variables */
-      --content-grid-dimension-em: ${CONTENT_GRID_DIMENSION}em;
-      --content-grid-gap-em: ${CONTENT_GRID_GAP}em;
+      --border-radius: 3em;
 
       /* We disable all transitions when changing color schemes, except if this is used */
       --transition-always-enabled: 0.2s ease-in-out;
+
+      /* Used for small buttons/etc */
+      --font-size-small: 0.8rem;
   }
 
   // When a page/component is set to light or the root has no dark theme applied

--- a/src/components/AppStyle.tsx
+++ b/src/components/AppStyle.tsx
@@ -1,4 +1,5 @@
 import '@picocss/pico/css/pico.min.css';
+import { ANIMATE_ATTRIBUTE } from 'hooks/useColorScheme';
 import 'mapbox-gl/dist/mapbox-gl.css';
 import { createGlobalStyle, css } from 'styled-components';
 
@@ -57,6 +58,8 @@ const AppStyle = createGlobalStyle`
       --content-grid-dimension-em: ${CONTENT_GRID_DIMENSION}em;
       --content-grid-gap-em: ${CONTENT_GRID_GAP}em;
 
+      /* We disable all transitions when changing color schemes, except if this is used */
+      --transition-always-enabled: 0.2s ease-in-out;
   }
 
   // When a page/component is set to light or the root has no dark theme applied
@@ -75,6 +78,11 @@ const AppStyle = createGlobalStyle`
     :root:not([data-theme='light']) {
       ${darkModeVariables};
     }
+  }
+
+  // Disable all animations if this is true
+  :root[${ANIMATE_ATTRIBUTE}='false'] {
+    --transition: 0s;
   }
 `;
 

--- a/src/components/ContentCard.tsx
+++ b/src/components/ContentCard.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'api/contentful/generated/api.generated';
 import styled, { css } from 'styled-components';
-import { cardSizeInEm } from './AppStyle';
+import { cardSize } from './ContentGrid';
 import ContentWrappingLink from './ContentWrappingLink';
 import Stack from './Stack';
 
@@ -69,16 +69,16 @@ const HiddenElement = styled.span`
 export const OverlayStack = styled(Stack).attrs({ $alignItems: 'center', $gap: '8px' })`
   overflow: hidden;
   position: absolute;
-  bottom: 0.5em;
-  left: 0.5em;
+  bottom: 1rem;
+  left: 1rem;
   background: var(--contrast-overlay);
   color: var(--contrast-overlay-inverse);
-  padding: 0.5em 0.75em;
-  border-radius: 2em;
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--border-radius);
   box-shadow: 0 0 4px rgba(0, 0, 0, 0.1), 0 0 8px rgba(0, 0, 0, 0.16);
 
   transition: transform var(--transition);
-  transform: translateX(calc(2em - 100%));
+  transform: translateX(calc((var(--border-radius) / 2) - 100%));
   &:hover {
     transform: initial;
     ${HiddenElement} {
@@ -94,6 +94,7 @@ const Card = styled.article<CardProps>`
   border: var(--border-width) solid var(--secondary-focus);
   margin: inherit;
   padding: 0;
+  will-change: transform;
   ${({ $isClickable }) =>
     $isClickable &&
     css`
@@ -115,14 +116,14 @@ const Card = styled.article<CardProps>`
 
   ${({ $hSpan }) => css`
     @media (min-width: 768px) {
-      width: ${cardSizeInEm($hSpan)}em;
+      width: ${cardSize($hSpan)};
       grid-column-start: span ${$hSpan};
     }
   `};
   ${({ $vSpan }) =>
     css`
       @media (min-width: 768px) {
-        height: ${cardSizeInEm($vSpan)}em;
+        height: ${cardSize($vSpan)};
       }
       grid-row-start: span ${$vSpan};
     `}

--- a/src/components/ContentGrid.tsx
+++ b/src/components/ContentGrid.tsx
@@ -1,5 +1,17 @@
 import styled from 'styled-components';
 
+// In rem, how big each card in the content grid is
+const CONTENT_GRID_DIMENSION = 16;
+
+// In rem, how big the gap between cards is
+const CONTENT_GRID_GAP = 3.75;
+
+/**
+ * Creates a card size in rem from a span
+ */
+export const cardSize = (span = 1) =>
+  `${CONTENT_GRID_DIMENSION * span + (span - 1) * CONTENT_GRID_GAP}rem`;
+
 /**
  * Auto fits densely to properly fill in all gaps at every size. Use
  * of auto on smallest screens means the items will fill the screen instead
@@ -7,14 +19,16 @@ import styled from 'styled-components';
  * widths for our columns to allow 3 or more on bigger screens
  */
 const Grid = styled.div`
+  --content-grid-dimension: ${CONTENT_GRID_DIMENSION}rem;
+  --content-grid-gap: ${CONTENT_GRID_GAP}rem;
   display: grid;
-  gap: var(--content-grid-gap-em);
+  gap: var(--content-grid-gap);
   grid-template-columns: repeat(auto-fit, auto);
   grid-auto-flow: dense;
   justify-content: center;
 
   @media (min-width: 768px) {
-    grid-template-columns: repeat(auto-fit, var(--content-grid-dimension-em));
+    grid-template-columns: repeat(auto-fit, var(--content-grid-dimension));
   }
 `;
 

--- a/src/components/homepage/ColorSchemeToggleCard.tsx
+++ b/src/components/homepage/ColorSchemeToggleCard.tsx
@@ -14,8 +14,13 @@ const Card = styled(ContentCard)`
   gap: var(--stack-gap);
 `;
 
-// Magic value to place the switch exactly in the center of the card by offsetting the button height + spacing up
+/**
+ * Magic value to place the switch exactly in the center of the card by
+ * offsetting the button height + spacing up. Makes sure transitions are
+ * always enabled too, so switching color scheme does actually animate.
+ */
 const ContentStack = styled(Stack)`
+  --transition: var(--transition-always-enabled);
   margin-top: calc(var(--stack-gap) + 2.5em);
 `;
 

--- a/src/components/homepage/ColorSchemeToggleCard.tsx
+++ b/src/components/homepage/ColorSchemeToggleCard.tsx
@@ -21,7 +21,8 @@ const Card = styled(ContentCard)`
  */
 const ContentStack = styled(Stack)`
   --transition: var(--transition-always-enabled);
-  margin-top: calc(var(--stack-gap) + 2.5em);
+  position: relative;
+  margin: 4rem 0;
 `;
 
 // Provides color scheme specific variable names for the switch - unknown is basically just server-rendered
@@ -63,14 +64,19 @@ const ColorSchemeSwitch = styled.input.attrs({ role: 'switch', type: 'checkbox' 
 
 // Inline button that's not very prominent
 const Button = styled.button<{ $visible: boolean }>`
-  --border-radius: 2em;
-  --form-element-spacing-vertical: 0.25em;
-  --form-element-spacing-horizontal: 0.75em;
-  font-size: 0.75em;
-  display: inline-flex;
-  gap: 0.5em;
+  --form-element-spacing-vertical: 0.5rem;
+  --form-element-spacing-horizontal: 1rem;
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 1rem;
+  margin: 0 auto;
+  font-size: var(--font-size-small);
   width: fit-content;
   transition: opacity var(--transition);
+  @media (min-width: 768px) {
+    bottom: 2rem;
+  }
   && {
     ${({ $visible }) =>
       css`

--- a/src/components/homepage/IntroCard.tsx
+++ b/src/components/homepage/IntroCard.tsx
@@ -20,18 +20,16 @@ const ImageCard = styled(ContentCard)`
 `;
 
 const TextCard = styled(ContentCard)`
+  overflow: visible;
   display: flex;
   flex-direction: column;
   align-items: center;
-  & h1 {
-    --typography-spacing-vertical: 1.5rem;
-  }
-  & p {
-    font-size: 0.9em;
-  }
   background: none;
   border: none;
   box-shadow: none;
+  & h1 {
+    --typography-spacing-vertical: 1.5rem;
+  }
 `;
 
 /**

--- a/src/components/homepage/MapCard.tsx
+++ b/src/components/homepage/MapCard.tsx
@@ -8,9 +8,13 @@ const Card = styled(ContentCard)`
   min-height: 200px;
 `;
 
+// Make sure the map is also rounded and Mapbox logo doesn't get cut off
 const StyledMap = styled(MapGL)`
   & .mapboxgl-canvas {
     border-radius: var(--border-radius);
+  }
+  & .mapboxgl-ctrl {
+    margin: 1.5rem;
   }
 `;
 

--- a/src/hooks/useColorScheme.ts
+++ b/src/hooks/useColorScheme.ts
@@ -15,6 +15,9 @@ export type SetColorScheme = (value: ColorScheme | null) => void;
 // Name of the attribute for theme we add on `html`
 const THEME_ATTRIBUTE = 'data-theme';
 
+// If this is true, we disable animations
+export const ANIMATE_ATTRIBUTE = 'data-animations-enabled';
+
 // The media query we'd like to match
 const PREFERS_DARK = '(prefers-color-scheme: dark)';
 
@@ -39,15 +42,21 @@ const generateMediaEventListener = (
 };
 
 /**
- * Modifies the document's `data-theme` attribute to change the theme itself
+ * Modifies the document's `data-theme` attribute to change the theme itself.
+ * Also disables animations around it, so colors don't animate their change.
+ * Only the color scheme switcher should be an exception to that.
  */
 const updateThemeAttribute = (scheme: ColorScheme, isSystemScheme: boolean) => {
   const htmlElement = document.documentElement;
+  htmlElement.setAttribute(ANIMATE_ATTRIBUTE, 'false');
   if (isSystemScheme) {
     htmlElement.removeAttribute(THEME_ATTRIBUTE);
-    return;
+  } else {
+    htmlElement.setAttribute(THEME_ATTRIBUTE, scheme);
   }
-  document.documentElement.setAttribute(THEME_ATTRIBUTE, scheme);
+
+  // Make sure to turn on animations non-synchronously
+  requestAnimationFrame(() => htmlElement.setAttribute(ANIMATE_ATTRIBUTE, 'true'));
 };
 
 /**


### PR DESCRIPTION
# Description of changes

1. Via css class, all animations disabled when swapping color schemes, until next animation frame
2. All cards are way rounder and less sharp
3. Fewer magic numbers overall
4. Better centering for the color scheme card specifically
5. Mapbox logo now sits fully within the bounds of the card it's in