### PR TITLE
feat: fully interactive, client-only map with home image overlay

### DIFF
--- a/src/api/contentful/generated/api.generated.ts
+++ b/src/api/contentful/generated/api.generated.ts
@@ -203,11 +203,19 @@ export type AssetFilter = {
 
 export type AssetLinkingCollections = {
   readonly bookCollection: Maybe<BookCollection>;
+  readonly contentTypeLocationCollection: Maybe<ContentTypeLocationCollection>;
   readonly entryCollection: Maybe<EntryCollection>;
   readonly projectCollection: Maybe<ProjectCollection>;
 };
 
 export type AssetLinkingCollectionsBookCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']>;
+  locale: InputMaybe<Scalars['String']>;
+  preview: InputMaybe<Scalars['Boolean']>;
+  skip?: InputMaybe<Scalars['Int']>;
+};
+
+export type AssetLinkingCollectionsContentTypeLocationCollectionArgs = {
   limit?: InputMaybe<Scalars['Int']>;
   locale: InputMaybe<Scalars['String']>;
   preview: InputMaybe<Scalars['Boolean']>;
@@ -393,10 +401,24 @@ export type BookOrder =
 /** All info needed to render a map with a pin for the given location [See type definition](https://app.contentful.com/spaces/nb3rzo39eupw/content_types/location) */
 export type ContentTypeLocation = Entry & {
   readonly contentfulMetadata: ContentfulMetadata;
+  readonly image: Maybe<Asset>;
+  readonly initialZoom: Maybe<Scalars['Float']>;
   readonly linkedFrom: Maybe<ContentTypeLocationLinkingCollections>;
   readonly point: Maybe<Location>;
   readonly slug: Maybe<Scalars['String']>;
   readonly sys: Sys;
+  readonly zoomLevels: Maybe<ReadonlyArray<Maybe<Scalars['String']>>>;
+};
+
+/** All info needed to render a map with a pin for the given location [See type definition](https://app.contentful.com/spaces/nb3rzo39eupw/content_types/location) */
+export type ContentTypeLocationImageArgs = {
+  locale: InputMaybe<Scalars['String']>;
+  preview: InputMaybe<Scalars['Boolean']>;
+};
+
+/** All info needed to render a map with a pin for the given location [See type definition](https://app.contentful.com/spaces/nb3rzo39eupw/content_types/location) */
+export type ContentTypeLocationInitialZoomArgs = {
+  locale: InputMaybe<Scalars['String']>;
 };
 
 /** All info needed to render a map with a pin for the given location [See type definition](https://app.contentful.com/spaces/nb3rzo39eupw/content_types/location) */
@@ -414,6 +436,11 @@ export type ContentTypeLocationSlugArgs = {
   locale: InputMaybe<Scalars['String']>;
 };
 
+/** All info needed to render a map with a pin for the given location [See type definition](https://app.contentful.com/spaces/nb3rzo39eupw/content_types/location) */
+export type ContentTypeLocationZoomLevelsArgs = {
+  locale: InputMaybe<Scalars['String']>;
+};
+
 export type ContentTypeLocationCollection = {
   readonly items: ReadonlyArray<Maybe<ContentTypeLocation>>;
   readonly limit: Scalars['Int'];
@@ -425,6 +452,16 @@ export type ContentTypeLocationFilter = {
   readonly AND: InputMaybe<ReadonlyArray<InputMaybe<ContentTypeLocationFilter>>>;
   readonly OR: InputMaybe<ReadonlyArray<InputMaybe<ContentTypeLocationFilter>>>;
   readonly contentfulMetadata: InputMaybe<ContentfulMetadataFilter>;
+  readonly image_exists: InputMaybe<Scalars['Boolean']>;
+  readonly initialZoom: InputMaybe<Scalars['Float']>;
+  readonly initialZoom_exists: InputMaybe<Scalars['Boolean']>;
+  readonly initialZoom_gt: InputMaybe<Scalars['Float']>;
+  readonly initialZoom_gte: InputMaybe<Scalars['Float']>;
+  readonly initialZoom_in: InputMaybe<ReadonlyArray<InputMaybe<Scalars['Float']>>>;
+  readonly initialZoom_lt: InputMaybe<Scalars['Float']>;
+  readonly initialZoom_lte: InputMaybe<Scalars['Float']>;
+  readonly initialZoom_not: InputMaybe<Scalars['Float']>;
+  readonly initialZoom_not_in: InputMaybe<ReadonlyArray<InputMaybe<Scalars['Float']>>>;
   readonly point_exists: InputMaybe<Scalars['Boolean']>;
   readonly point_within_circle: InputMaybe<Scalars['Circle']>;
   readonly point_within_rectangle: InputMaybe<Scalars['Rectangle']>;
@@ -436,6 +473,10 @@ export type ContentTypeLocationFilter = {
   readonly slug_not_contains: InputMaybe<Scalars['String']>;
   readonly slug_not_in: InputMaybe<ReadonlyArray<InputMaybe<Scalars['String']>>>;
   readonly sys: InputMaybe<SysFilter>;
+  readonly zoomLevels_contains_all: InputMaybe<ReadonlyArray<InputMaybe<Scalars['String']>>>;
+  readonly zoomLevels_contains_none: InputMaybe<ReadonlyArray<InputMaybe<Scalars['String']>>>;
+  readonly zoomLevels_contains_some: InputMaybe<ReadonlyArray<InputMaybe<Scalars['String']>>>;
+  readonly zoomLevels_exists: InputMaybe<Scalars['Boolean']>;
 };
 
 export type ContentTypeLocationLinkingCollections = {
@@ -450,6 +491,8 @@ export type ContentTypeLocationLinkingCollectionsEntryCollectionArgs = {
 };
 
 export type ContentTypeLocationOrder =
+  | 'initialZoom_ASC'
+  | 'initialZoom_DESC'
   | 'slug_ASC'
   | 'slug_DESC'
   | 'sys_firstPublishedAt_ASC'

--- a/src/api/contentful/generated/fetchMyLocation.generated.ts
+++ b/src/api/contentful/generated/fetchMyLocation.generated.ts
@@ -5,8 +5,17 @@ export type MyLocationQueryVariables = Types.Exact<{ [key: string]: never }>;
 export type MyLocationQuery = {
   readonly contentTypeLocation:
     | {
+        readonly initialZoom: number | undefined;
+        readonly zoomLevels: ReadonlyArray<string | undefined> | undefined;
         readonly point:
           | { readonly lat: number | undefined; readonly lon: number | undefined }
+          | undefined;
+        readonly image:
+          | {
+              readonly url: string | undefined;
+              readonly width: number | undefined;
+              readonly height: number | undefined;
+            }
           | undefined;
       }
     | undefined;

--- a/src/components/AppStyle.tsx
+++ b/src/components/AppStyle.tsx
@@ -16,7 +16,8 @@ const darkModeVariables = css`
     0 0.125rem 4rem rgba(0, 0, 0, 0.12), 0 0 0 0.125rem rgba(0, 0, 0, 0.036);
 
   --yellow: yellow;
-  --navy: #0a6280;
+  --map-marker: rgba(58, 123, 172, 0.5);
+  --map-marker-border: rgba(166, 189, 206, 0.5);
 `;
 
 /**
@@ -31,8 +32,9 @@ const lightModeVariables = css`
   --card-hovered-box-shadow: 0 0.125rem 2rem rgba(27, 40, 50, 0.04),
     0 0.125rem 4rem rgba(27, 40, 50, 0.08), 0 0 0 0.125rem rgba(27, 40, 50, 0.024);
 
-  --yellow: rgb(222, 197, 29);
-  --navy: #0a6280;
+  --yellow: #dec51d;
+  --map-marker: rgba(58, 123, 172, 0.25);
+  --map-marker-border: rgba(139, 185, 220, 0.75);
 `;
 
 /**
@@ -48,6 +50,8 @@ const AppStyle = createGlobalStyle`
 
       /* Used for small buttons/etc */
       --font-size-small: 0.8rem;
+
+    --navy: #186891;
   }
 
   // When a page/component is set to light or the root has no dark theme applied

--- a/src/components/maps/Map.tsx
+++ b/src/components/maps/Map.tsx
@@ -1,0 +1,123 @@
+import type { MyLocationQuery } from 'api/contentful/generated/fetchMyLocation.generated';
+import useColorScheme from 'hooks/useColorScheme';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Map as MapGL, MapRef, ViewState } from 'react-map-gl';
+import styled from 'styled-components';
+
+/**
+ * Represents a location along with some metadata
+ */
+export type MapLocation = Pick<
+  NonNullable<MyLocationQuery['contentTypeLocation']>,
+  'point' | 'initialZoom' | 'image'
+> & {
+  /**
+   * Converts zoom levels to a number array
+   */
+  zoomLevels: Array<number>;
+};
+
+interface Size {
+  /**
+   * Full width of the component this map sits in, if known
+   */
+  width: number;
+
+  /**
+   * Full height of the component this map sits in, if known
+   */
+  height: number;
+}
+
+// The actual state for the map
+type MapViewState = ViewState & Size;
+
+export type Props = {
+  /**
+   * Where we're centered and zoomed
+   */
+  location: MapLocation | null;
+
+  /**
+   * Provides state for the map
+   */
+  viewState: Pick<MapViewState, 'width' | 'height'> & Partial<Pick<MapViewState, 'padding'>>;
+
+  /**
+   * If children exist, they need to be real elements.
+   * Use this to pass layers and features.
+   */
+  children?: React.ReactElement | Array<React.ReactElement> | null;
+};
+
+const LIGHT_STYLE = 'mapbox://styles/dylangattey/ckyfpsonl01w014q8go5wvnh2';
+const DARK_STYLE = 'mapbox://styles/dylangattey/ckylbbyzc0ok916jx0bvos03d';
+
+// This wrapper ensures mapbox css is taken care of
+const Wrapper = styled.div`
+  position: relative;
+  height: 100%;
+  width: 100%;
+  & .mapboxgl-ctrl {
+    margin: 2rem;
+  }
+`;
+
+/**
+ * Uses Mapbox to show a canvas-based map of my current location.
+ */
+const Map = ({ location, viewState: outsideViewState, children }: Props) => {
+  const mapRef = useRef<MapRef>(null);
+  const { colorScheme } = useColorScheme();
+  const size = useMemo(
+    () => ({
+      width: outsideViewState.width,
+      height: outsideViewState.height,
+    }),
+    [outsideViewState.height, outsideViewState.width],
+  );
+
+  // This will be used to set zoom levels, eventually
+  const [viewState, setViewState] = useState<MapViewState>({
+    ...size,
+    latitude: location?.point?.lat ?? 0,
+    longitude: location?.point?.lon ?? 0,
+    zoom: location?.initialZoom ?? 0,
+    padding: outsideViewState.padding ?? { left: 0, right: 0, top: 0, bottom: 0 },
+    bearing: 0,
+    pitch: 0,
+  });
+  const zoomLevels = location?.zoomLevels ?? [];
+  const minZoom = zoomLevels[0];
+  const maxZoom = zoomLevels[zoomLevels.length - 1];
+
+  // Updates the view state when a parent changes it
+  useEffect(() => {
+    setViewState((currentState) => ({ ...currentState, ...outsideViewState }));
+  }, [outsideViewState]);
+
+  return (
+    <Wrapper>
+      <MapGL
+        ref={mapRef}
+        viewState={viewState}
+        minZoom={minZoom}
+        maxZoom={maxZoom}
+        attributionControl={false}
+        logoPosition="bottom-right"
+        interactive
+        pitchWithRotate={false}
+        touchPitch={false}
+        onZoom={(event) => setViewState({ ...event.viewState, ...size })}
+        onDrag={(event) => setViewState({ ...event.viewState, ...size })}
+        onRotate={(event) => setViewState({ ...event.viewState, ...size })}
+        mapStyle={colorScheme === 'dark' ? DARK_STYLE : LIGHT_STYLE}
+        mapboxAccessToken={process.env.NEXT_PUBLIC_MAPBOX_TOKEN}
+      >
+        {children}
+      </MapGL>
+    </Wrapper>
+  );
+};
+
+export default Map;

--- a/src/components/maps/Marker.tsx
+++ b/src/components/maps/Marker.tsx
@@ -1,0 +1,32 @@
+import { Marker as MapMarker } from 'react-map-gl';
+import styled from 'styled-components';
+import type { MapLocation } from './Map';
+
+const DIMENSION = 100;
+const RADIUS = DIMENSION / 2;
+
+// Required point, optional image
+type Props = Pick<MapLocation, 'point'> & Partial<Pick<MapLocation, 'image'>>;
+
+/**
+ * Creates a circle to show
+ */
+const AreaIndicator = styled.circle.attrs({ r: RADIUS, cx: RADIUS, cy: RADIUS })`
+  fill: var(--map-marker);
+  stroke: var(--map-marker-border);
+  stroke-width: 1px;
+`;
+
+/**
+ * Creates a standard map marker, centered on a point
+ */
+const Marker = ({ point, image }: Props) => (
+  <MapMarker latitude={point?.lat} longitude={point?.lon}>
+    <svg width={DIMENSION} height={DIMENSION}>
+      <AreaIndicator />
+      {image && <image width={DIMENSION} height={DIMENSION} href={image.url} />}
+    </svg>
+  </MapMarker>
+);
+
+export default Marker;


### PR DESCRIPTION
# Description of changes
1. Map now in its own file, not used in server rendering
2. Marker added for putting an image on a map, and used for home location
3. Map is interactive again, with ability to pan/zoom/rotate/etc
4. Zoom levels for min/max zoom now used! Pulled from Contentful
5. Dark and light map styles, but only swap on page load, not when the color scheme toggle is used

Fixes #277 and #288 