### PR TITLE
fix: remove Inter, no jitter on expanding cards, apply color schemes better

### DIFF
--- a/src/components/AppStyle.tsx
+++ b/src/components/AppStyle.tsx
@@ -41,6 +41,11 @@ const lightModeVariables = css`
  * Applies styles to the full app
  */
 const AppStyle = createGlobalStyle`
+  // Apply changes from theme faster
+  body {
+    background: var(--background-color);
+  }
+  
   :root {
       /* These are Pico overrides */
       --border-radius: 2.5em;

--- a/src/components/ContentGrid.tsx
+++ b/src/components/ContentGrid.tsx
@@ -39,6 +39,16 @@ const Grid = styled.div`
 `;
 
 /**
+ * Swaps pointer events between being disabled and auto on the children
+ */
+const changePointerEvents = (isOn: boolean) => (animatedChildren: HTMLElement[]) => {
+  animatedChildren.forEach((child) => {
+    // eslint-disable-next-line no-param-reassign
+    child.style.pointerEvents = isOn ? 'auto' : 'none';
+  });
+};
+
+/**
  * Displays all our content in a grid - on the client it uses `animate-css-grid`
  * for nice animations when items change in size, which we do when expanding cards.
  */
@@ -57,6 +67,8 @@ const ContentGrid = ({ children }: Pick<React.ComponentProps<'div'>, 'children'>
         stagger: 10,
         duration: GRID_ANIMATION_DURATION,
         easing: 'backOut',
+        onStart: changePointerEvents(false),
+        onEnd: changePointerEvents(true),
       });
     }
   };

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -8,31 +8,30 @@ import Stack from './Stack';
 
 /**
  * Aspect ratio'd 1:1 circle. Big, bold, and squished text for use as
- * logo, with Inter font (loaded on all pages via document.tsx). Has
- * background on scroll + scales down a bit.
+ * logo. Has background on scroll + scales down a bit.
  */
 const LogoText = styled.article<{ $isScrolled: boolean }>`
   --padding: 1.5rem;
   --margin: 1rem;
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu,
-    Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
   font-size: 2.5rem;
-  font-variation-settings: 'wght' 800;
+  font-variation-settings: 'wght' 800, 'wdth' 120;
   letter-spacing: -0.12em;
 
+  overflow: visible;
   display: flex;
   align-items: center;
   justify-content: center;
   border-radius: 50%;
   vertical-align: middle;
   line-height: 1;
-  margin: var(--margin) calc(-1 * var(--padding));
+  margin: var(--margin) -0.5rem;
   padding: var(--padding);
   pointer-events: auto;
   transform-origin: top left;
   transition: box-shadow var(--transition), transform var(--transition),
     background-color var(--transition);
   will-change: transform;
+  color: #16ac7e;
 
   &:before {
     content: '';
@@ -81,7 +80,7 @@ const Logo = () => {
       </Link>
     );
   return (
-    <Stack $gap="1.5rem" $alignItems="center" $justifyContent="spaceAround">
+    <Stack $gap="1rem" $alignItems="center" $justifyContent="spaceAround">
       <LogoText $isScrolled={isScrolled}>{linkedLogoText}</LogoText>
       <SpacedScrollIndicator $isScrolled={isScrolled} />
     </Stack>

--- a/src/components/Meta.tsx
+++ b/src/components/Meta.tsx
@@ -93,6 +93,7 @@ const Meta = ({ title, description }: Props) => {
       <title>{title ? `Dylan Gattey - ${title}` : 'Dylan Gattey'}</title>
       {truncatedDescription && <meta name="description" content={truncatedDescription} />}
       <link key="favicon" rel="icon" href="/favicon.ico" />
+      <meta name="theme-color" content="var(--background-color)" />
       <meta
         key="msapplication-TileColor"
         name="msapplication-TileColor"

--- a/src/components/layouts/PageLayout.tsx
+++ b/src/components/layouts/PageLayout.tsx
@@ -2,6 +2,7 @@ import { FetcherKey, PartialFallback } from 'api/useData';
 import Footer from 'components/Footer';
 import Header from 'components/Header';
 import ScrollIndicatorContext from 'components/ScrollIndicatorContext';
+import useColorScheme from 'hooks/useColorScheme';
 import useShowScrollIndicator from 'hooks/useShowScrollIndicator';
 import { useRef } from 'react';
 import { SWRConfig } from 'swr';
@@ -21,9 +22,10 @@ type Props<Key extends FetcherKey> = Pick<React.ComponentProps<'div'>, 'children
 /**
  * Basic page layout for every page. Has a sticky, contained header above
  * the main (contained) content, with a (contained) footer below. No wrapper
- * around all items to save on divs.
+ * around all items to save on divs. Ensures color scheme is applied.
  */
 const PageLayout = <Key extends FetcherKey>({ children, fallback }: Props<Key>) => {
+  useColorScheme();
   const headerSizingRef = useRef<HTMLDivElement>(null);
   const { ref, isIndicatorShown } = useShowScrollIndicator(
     headerSizingRef.current?.getBoundingClientRect().height ?? 0,

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,30 +1,10 @@
-import NextDocument, { DocumentContext, Head, Html, Main, NextScript } from 'next/document';
+import NextDocument, { DocumentContext } from 'next/document';
 import { ServerStyleSheet } from 'styled-components';
 
 /**
- * Used to add styled-components styles to server-rendered pages + load Inter for
- * the logo on all pages.
+ * Used to add styled-components styles to server-rendered pages.
  */
 export default class Document extends NextDocument {
-  render() {
-    return (
-      <Html lang="en">
-        <Head>
-          <link rel="preconnect" href="https://fonts.googleapis.com" />
-          <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
-          <link
-            href="https://fonts.googleapis.com/css2?family=Inter:wght@800&display=swap"
-            rel="stylesheet"
-          />
-        </Head>
-        <body>
-          <Main />
-          <NextScript />
-        </body>
-      </Html>
-    );
-  }
-
   static async getInitialProps(ctx: DocumentContext) {
     const sheet = new ServerStyleSheet();
     const originalRenderPage = ctx.renderPage;


### PR DESCRIPTION
# Description of changes

1. Disable/reenable pointer events on all expanding cards - makes the jitters disappear!
2. Apply color scheme to all pages via hook in PageLayout
3. Remove Inter + make logo more interesting, as it's silly to load that font for one tiny use
4. Make mobile browsers apply background color changes more consistently via var usage

Fixes #301 , fixes #307