### PR TITLE
fix: use right env variable for version

### DIFF
--- a/src/api/server/fetchGithubRepoVersion.ts
+++ b/src/api/server/fetchGithubRepoVersion.ts
@@ -24,7 +24,7 @@ const QUERY = gql`
  * to run on client, but it'll gracefully fallback to the fallback.
  */
 const fetchGithubRepoVersion = async () => {
-  const commitSha = process.env.VERCEL_GIT_COMMIT_SHA;
+  const commitSha = process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA;
   if (!commitSha && !process.env.NODE_ENV) {
     // Fallback for browser only
     return undefined;


### PR DESCRIPTION
Oops, was too zealous in removing the NEXT_PUBLIC_ prefix

Fixes #321 