### PR TITLE
fix: align release names + rename to dgattey + add docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Pretty standard Next app here. `/public` contains static files, `/src` contains 
 
 - [Prisma](https://www.prisma.io) and [PlanetScale](https://planetscale.com) power a distributed DB. This DB is used to persist auth tokens for Spotify/Strava beyond the lifetime of a deploy + refresh the token as needed. Prisma adds some nice typing but doesn't play nicely with Yarn PnP.
 
+- [Sentry](https://sentry.io) is used to capture errors + stack traces both serverside and clientside. Captures console logs too. Integrated with releases so we can see when problems start happening.
+
 ### API
 
 1. All endpoints are strongly typed + synced between Next client + server with `/src/api/endpoints.ts`. No endpoint should ever be used directly from client, but the types in this file can be used!

--- a/next.config.js
+++ b/next.config.js
@@ -28,7 +28,6 @@ const nextConfig = {
 
 // Release only when we have real version data
 module.exports = withSentryConfig(nextConfig, {
-  silent: true,
-  release: process.env.NEXT_PUBLIC_APP_VERSION,
+  release: `dg@${process.env.NEXT_PUBLIC_APP_VERSION}`,
   dryRun: process.env.NEXT_PUBLIC_APP_VERSION === 'vX.Y.Z',
 });

--- a/sentry.properties
+++ b/sentry.properties
@@ -1,4 +1,4 @@
 defaults.url=https://sentry.io/
-defaults.org=dylan-gattey
+defaults.org=dgattey
 defaults.project=dg
 cli.executable=$(yarn bin sentry-cli)


### PR DESCRIPTION
# Description of changes

1. Adds info to README about Sentry
2. Rename Sentry org to dgattey
3. Make releases dg@X throughout
4. Turns off silent mode so we can see logs in Vercel about what it's doing