### PR TITLE
fix: change log level to error/warn in dbClient + move 200 to end of webhooks API + update DATABASE_URL

### DIFF
--- a/src/api/server/networkClients/dbClient.ts
+++ b/src/api/server/networkClients/dbClient.ts
@@ -13,7 +13,7 @@ declare global {
 const dbClient =
   global.dbClient ||
   new PrismaClient({
-    log: ['query'],
+    log: ['error', 'warn'],
   });
 
 if (process.env.NODE_ENV !== 'production') {

--- a/src/pages/api/webhooks.ts
+++ b/src/pages/api/webhooks.ts
@@ -44,8 +44,6 @@ const handleWebhookEvent: AsyncProcessor = async (request, response) => {
     handleApiError(response, 'Bad Request', 400);
     return;
   }
-  // Strava requires a quick response, so make sure we respond, then process
-  response.status(200).end();
 
   const webhookEvent = request.body;
   switch (webhookEvent.object_type) {
@@ -57,6 +55,9 @@ const handleWebhookEvent: AsyncProcessor = async (request, response) => {
       await syncStravaWebhookUpdateWithDb(request.body);
     }
   }
+
+  // Make sure to respond to Strava with the result
+  response.status(200).end();
 };
 
 /**


### PR DESCRIPTION
Finally figured out webhook syncing woes I think. One clue was that Sentry wasn't even getting my console.logs, like something was just dying halfway through. I moved the return with 200 to the end of the API call, and I think it's fixed.

Pretty sure Next was just killing the Serverless function because I'd ended the response and it wasn't wanting to give it resources to continue. We'll see if that stays working.

Additionally changed log level for db things to error/warn so I should see those in Sentry. And, along with this, the DATABASE_URL env variable changed to pass only 1 simultaneous connection + 300 second timeout to hopefully help db connection pool issues more generally.

Fixes #330