### PR TITLE
fix: add backup image behind map to make it appear to load faster

### DIFF
--- a/src/api/server/fetchContentfulLocation.ts
+++ b/src/api/server/fetchContentfulLocation.ts
@@ -22,6 +22,9 @@ const QUERY = gql`
         height
       }
     }
+    asset(id: "5PrFVu1gJBLhgJGixRL4Wc") {
+      url
+    }
   }
 `;
 
@@ -31,7 +34,7 @@ const QUERY = gql`
 const fetchContentfulLocation = async (): Promise<MapLocation | null> => {
   const data = await contentfulClient.request<MyLocationQuery>(QUERY);
   const location = data?.contentTypeLocation;
-  if (!location) {
+  if (!location || !data?.asset?.url) {
     return null;
   }
   const zoomLevels = location.zoomLevels?.filter(isDefinedItem)?.map(Number) ?? [];
@@ -46,6 +49,7 @@ const fetchContentfulLocation = async (): Promise<MapLocation | null> => {
     initialZoom: location.initialZoom,
     image: location.image,
     zoomLevels,
+    backupImageUrl: data.asset.url,
   };
 };
 

--- a/src/api/types/MapLocation.ts
+++ b/src/api/types/MapLocation.ts
@@ -1,3 +1,4 @@
+import { Asset } from 'api/types/generated/contentfulApi.generated';
 import type { MyLocationQuery } from 'api/types/generated/fetchContentfulLocation.generated';
 
 /**
@@ -11,4 +12,10 @@ export type MapLocation = Pick<
    * Converts zoom levels to a number array
    */
   zoomLevels: Array<number>;
+
+  /**
+   * An image that should be used to show a backup image before
+   * the MapboxGL package loads
+   */
+  backupImageUrl: Asset['url'];
 };

--- a/src/api/types/generated/fetchContentfulLocation.generated.ts
+++ b/src/api/types/generated/fetchContentfulLocation.generated.ts
@@ -19,4 +19,5 @@ export type MyLocationQuery = {
           | undefined;
       }
     | undefined;
+  readonly asset: { readonly url: string | undefined } | undefined;
 };

--- a/src/components/homepage/MapCard.tsx
+++ b/src/components/homepage/MapCard.tsx
@@ -20,15 +20,21 @@ const MIN_DIMENSION = 320;
 const EXPANDED_HEIGHT = 600;
 
 // Dynamically imported for loading speed
-const Map = dynamic(import('components/maps/Map'));
-const Marker = dynamic(import('components/maps/Marker'));
-const Control = dynamic(import('components/maps/Control'));
+const Map = dynamic(() => import('components/maps/Map'), { ssr: false });
+const Marker = dynamic(() => import('components/maps/Marker'), { ssr: false });
+const Control = dynamic(() => import('components/maps/Control'), { ssr: false });
 
 // Changes between two min heights
-const Card = styled(ContentCard)<{ $height: number }>`
+const Card = styled(ContentCard)<{ $height: number; $backgroundImageUrl?: string }>`
+  border: 1px solid var(--background-color);
   ${({ $height }) =>
     css`
       min-height: ${$height}px;
+    `}
+  ${({ $backgroundImageUrl }) =>
+    $backgroundImageUrl &&
+    css`
+      background-image: url('${$backgroundImageUrl}');
     `}
 `;
 
@@ -69,7 +75,11 @@ const MapCard = ({ gridWidth }: Props) => {
   }, [gridWidth, isExpanded]);
 
   return (
-    <Card onExpansion={!isExpanded ? setIsExpanded : undefined} $height={height}>
+    <Card
+      onExpansion={!isExpanded ? setIsExpanded : undefined}
+      $height={height}
+      $backgroundImageUrl={location?.backupImageUrl}
+    >
       <Wrapper $maxWidth={gridWidth ?? 0}>
         {location?.point && (
           <Map location={location} viewState={viewState}>


### PR DESCRIPTION
# Description of changes
Fixes #339 so we show our map images faster, at the expense of loading one extra image