### PR TITLE
feat: fix mobile cards + faster resizing + dark/light map backup images

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,12 @@
+version: '2'
+
+# Only the customized checks
+checks:
+  method-lines:
+    config:
+      # This is a lot bigger than default because it includes functional components in typescript
+      threshold: 80
+  complex-logic:
+    config:
+      # Doubles the complexity since 4 is rather low as a default
+      threshold: 8

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,7 +1,36 @@
 version: '2'
 
-# Only the customized checks
 checks:
+  argument-count:
+    enabled: true
+    config:
+      threshold: 4
+  complex-logic:
+    enabled: true
+    config:
+      threshold: 4
+  file-lines:
+    enabled: true
+    config:
+      threshold: 250
+  method-count:
+    enabled: true
+    config:
+      threshold: 20
+  nested-control-flow:
+    enabled: true
+    config:
+      threshold: 4
+  return-statements:
+    enabled: true
+    config:
+      threshold: 4
+  similar-code:
+    enabled: true
+  identical-code:
+    enabled: true
+
+  # Only the customized checks
   method-lines:
     config:
       # This is a lot bigger than default because it includes functional components in typescript
@@ -10,3 +39,23 @@ checks:
     config:
       # Triples the complexity since 5 is rather low as a default
       threshold: 12
+
+# Customized to include .yarn/.pnp/generated/type files
+exclude_patterns:
+  - 'config/'
+  - 'db/'
+  - 'dist/'
+  - 'features/'
+  - '**/node_modules/'
+  - 'script/'
+  - '**/spec/'
+  - '**/test/'
+  - '**/tests/'
+  - 'Tests/'
+  - '**/vendor/'
+  - '**/*_test.go'
+  - '**/*.d.ts'
+  - '**/*generated*'
+  - '**/generated'
+  - '.yarn'
+  - '.pnp*'

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -6,7 +6,7 @@ checks:
     config:
       # This is a lot bigger than default because it includes functional components in typescript
       threshold: 80
-  complex-logic:
+  method-complexity:
     config:
-      # Doubles the complexity since 4 is rather low as a default
-      threshold: 8
+      # Triples the complexity since 5 is rather low as a default
+      threshold: 12

--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -25,7 +25,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['**/*.{ts,tsx}'],
+      files: ['**/*.{ts,tsx,js,jsx}'],
       customSyntax: '@stylelint/postcss-css-in-js',
     },
   ],

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -2,28 +2,6 @@
 // The config you add here will be used whenever a page is visited.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
-import {
-  CaptureConsole as CaptureConsoleIntegration,
-  ExtraErrorData as ExtraErrorDataIntegration,
-  Offline as OfflineIntegration,
-} from '@sentry/integrations';
-import * as Sentry from '@sentry/nextjs';
+import sentryInit from './src/helpers/sentryInit';
 
-const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;
-
-Sentry.init({
-  dsn: SENTRY_DSN,
-
-  tracesSampleRate: 1.0,
-
-  integrations: [
-    // Rewrites console.x into messages!
-    new CaptureConsoleIntegration(),
-
-    // Captures events that happen offline and replays them when back online
-    new OfflineIntegration(),
-
-    // Adds extra non-native data on Errors to Sentry
-    new ExtraErrorDataIntegration(),
-  ],
-});
+sentryInit();

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -2,28 +2,6 @@
 // The config you add here will be used whenever the server handles a request.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
-import {
-  CaptureConsole as CaptureConsoleIntegration,
-  ExtraErrorData as ExtraErrorDataIntegration,
-  Offline as OfflineIntegration,
-} from '@sentry/integrations';
-import * as Sentry from '@sentry/nextjs';
+import sentryInit from './src/helpers/sentryInit';
 
-const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;
-
-Sentry.init({
-  dsn: SENTRY_DSN,
-
-  tracesSampleRate: 1.0,
-
-  integrations: [
-    // Rewrites console.x into messages!
-    new CaptureConsoleIntegration(),
-
-    // Captures events that happen offline and replays them when back online
-    new OfflineIntegration(),
-
-    // Adds extra non-native data on Errors to Sentry
-    new ExtraErrorDataIntegration(),
-  ],
-});
+sentryInit();

--- a/src/api/server/fetchContentfulLocation.ts
+++ b/src/api/server/fetchContentfulLocation.ts
@@ -22,7 +22,10 @@ const QUERY = gql`
         height
       }
     }
-    asset(id: "5PrFVu1gJBLhgJGixRL4Wc") {
+    lightImage: asset(id: "5PrFVu1gJBLhgJGixRL4Wc") {
+      url
+    }
+    darkImage: asset(id: "6bRgM9lkcceJQOE0jSOEfu") {
       url
     }
   }
@@ -34,7 +37,7 @@ const QUERY = gql`
 const fetchContentfulLocation = async (): Promise<MapLocation | null> => {
   const data = await contentfulClient.request<MyLocationQuery>(QUERY);
   const location = data?.contentTypeLocation;
-  if (!location || !data?.asset?.url) {
+  if (!location || !data?.lightImage?.url || !data?.darkImage?.url) {
     return null;
   }
   const zoomLevels = location.zoomLevels?.filter(isDefinedItem)?.map(Number) ?? [];
@@ -49,7 +52,7 @@ const fetchContentfulLocation = async (): Promise<MapLocation | null> => {
     initialZoom: location.initialZoom,
     image: location.image,
     zoomLevels,
-    backupImageUrl: data.asset.url,
+    backupImageUrls: { light: data.lightImage.url, dark: data.darkImage.url },
   };
 };
 

--- a/src/api/types/MapLocation.ts
+++ b/src/api/types/MapLocation.ts
@@ -14,8 +14,8 @@ export type MapLocation = Pick<
   zoomLevels: Array<number>;
 
   /**
-   * An image that should be used to show a backup image before
-   * the MapboxGL package loads
+   * Dark and light mode images that should be used to show a backup
+   * screenshot of the map before the MapboxGL package loads
    */
-  backupImageUrl: Asset['url'];
+  backupImageUrls: { light: Asset['url']; dark: Asset['url'] };
 };

--- a/src/api/types/generated/fetchContentfulLocation.generated.ts
+++ b/src/api/types/generated/fetchContentfulLocation.generated.ts
@@ -19,5 +19,6 @@ export type MyLocationQuery = {
           | undefined;
       }
     | undefined;
-  readonly asset: { readonly url: string | undefined } | undefined;
+  readonly lightImage: { readonly url: string | undefined } | undefined;
+  readonly darkImage: { readonly url: string | undefined } | undefined;
 };

--- a/src/components/ContentCard.tsx
+++ b/src/components/ContentCard.tsx
@@ -1,14 +1,18 @@
 import type { Link } from 'api/types/generated/contentfulApi.generated';
 import truncated from 'helpers/truncated';
+import { GRID_ANIMATION_DURATION } from 'hooks/useGridAnimation';
 import React, { ReactElement, useState } from 'react';
 import styled, { css } from 'styled-components';
-import { cardSize, GRID_ANIMATION_DURATION } from './ContentGrid';
+import { cardSize } from './ContentGrid';
 import ContentWrappingLink from './ContentWrappingLink';
 
 // Special requirements for children here
 type Children = ReactElement | null | undefined;
 
-type Props = Pick<React.ComponentProps<'article'>, 'className' | 'onMouseOver' | 'onMouseOut'> & {
+export type Props = Pick<
+  React.ComponentProps<'article'>,
+  'className' | 'onMouseOver' | 'onMouseOut'
+> & {
   /**
    * How many columns the card spans, defaults to 1
    */
@@ -40,6 +44,12 @@ type Props = Pick<React.ComponentProps<'article'>, 'className' | 'onMouseOver' |
    * Children must exist!
    */
   children: Children;
+
+  /**
+   * Function that starts an animation when the card is expanded
+   * and removes the animation once finished.
+   */
+  turnOnAnimation?: () => void;
 };
 
 type LinkWrappedChildrenProps = Pick<Props, 'link' | 'children'> & {
@@ -183,6 +193,7 @@ const ContentCard = ({
   onExpansion,
   onMouseOver,
   onMouseOut,
+  turnOnAnimation,
 }: Props) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const expandOnClick = !!onExpansion;
@@ -190,6 +201,7 @@ const ContentCard = ({
   // Swaps the expansion variable and calls the user callback
   const toggleExpansion = onExpansion
     ? () => {
+        turnOnAnimation?.();
         setIsExpanded(!isExpanded);
         onExpansion(!isExpanded);
       }

--- a/src/components/ContentCard.tsx
+++ b/src/components/ContentCard.tsx
@@ -146,9 +146,9 @@ const Card = styled.article<CardProps>`
     $vSpan &&
     css`
       @media (min-width: 768px) {
+        grid-row: span ${$vSpan};
         height: ${cardSize($vSpan)};
       }
-      grid-row: span ${$vSpan};
     `}
 `;
 

--- a/src/components/ContentGrid.tsx
+++ b/src/components/ContentGrid.tsx
@@ -1,8 +1,12 @@
-import React, { useEffect, useRef } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 
-// In ms, how long to animate grid items
-export const GRID_ANIMATION_DURATION = 300;
+type Props = Pick<React.ComponentProps<'div'>, 'children'> & {
+  /**
+   * A ref to assign to the main grid, for use in animating
+   */
+  gridRef: React.RefObject<HTMLDivElement>;
+};
 
 // In rem, how big each card in the content grid is
 const CONTENT_GRID_DIMENSION = 16.5;
@@ -49,60 +53,9 @@ const Grid = styled.div`
 `;
 
 /**
- * Swaps pointer events between being disabled and auto on the children to
- * avoid slowdowns as the browser tries to compute a hover effect as it
- * animates.
- */
-const changePointerEvents = (isOn: boolean) => (animatedChildren: HTMLElement[]) => {
-  animatedChildren.forEach((child) => {
-    // eslint-disable-next-line no-param-reassign
-    child.style.pointerEvents = isOn ? 'auto' : 'none';
-  });
-};
-
-/**
  * Displays all our content in a grid - on the client it uses `animate-css-grid`
  * for nice animations when items change in size, which we do when expanding cards.
  */
-const ContentGrid = ({ children }: Pick<React.ComponentProps<'div'>, 'children'>) => {
-  const gridRef = useRef<HTMLDivElement>(null);
-  const hasBeenAnimated = useRef(false);
-
-  /**
-   * Uses refs so we can be sure that we wrap the grid with animations exactly once.
-   * Imports the animation library (and this is called from an effect) so we don't
-   * do that on the server where it's unneeded.
-   */
-  const importAnimationLibAndWrapGrid = async () => {
-    if (!gridRef.current) {
-      hasBeenAnimated.current = false;
-      return;
-    }
-    if (hasBeenAnimated.current) {
-      return;
-    }
-    hasBeenAnimated.current = true;
-    try {
-      const { wrapGrid } = await import('animate-css-grid');
-
-      wrapGrid(gridRef.current, {
-        stagger: 10,
-        duration: GRID_ANIMATION_DURATION,
-        easing: 'backOut',
-        onStart: changePointerEvents(false),
-        onEnd: changePointerEvents(true),
-      });
-    } catch {
-      hasBeenAnimated.current = false;
-    }
-  };
-
-  // Make sure we import the animation lib and wrap the grid with animations once
-  useEffect(() => {
-    (() => importAnimationLibAndWrapGrid())();
-  }, []);
-
-  return <Grid ref={gridRef}>{children}</Grid>;
-};
+const ContentGrid = ({ children, gridRef }: Props) => <Grid ref={gridRef}>{children}</Grid>;
 
 export default ContentGrid;

--- a/src/components/ContentGrid.tsx
+++ b/src/components/ContentGrid.tsx
@@ -38,7 +38,7 @@ export const cardSize = (span = 1) => `${cardSizeRaw(span)}rem`;
  */
 const Grid = styled.div`
   --content-grid-dimension: ${CONTENT_GRID_DIMENSION}rem;
-  --content-grid-gap: ${CONTENT_GRID_GAP}rem;
+  --content-grid-gap: 2rem;
   display: grid;
   gap: var(--content-grid-gap);
   grid-template-columns: 1fr;
@@ -47,6 +47,7 @@ const Grid = styled.div`
   position: relative;
 
   @media (min-width: 768px) {
+    --content-grid-gap: ${CONTENT_GRID_GAP}rem;
     grid-template-columns: repeat(auto-fit, var(--content-grid-dimension));
     grid-auto-rows: minmax(var(--content-grid-dimension), auto);
   }

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -35,6 +35,10 @@ const LogoText = styled.article<{ $isScrolled: boolean }>`
   border: 2px solid transparent;
   z-index: 1;
 
+  @media (max-width: 767.96px) {
+    --margin: 0.5rem;
+  }
+
   &:before {
     content: '';
     float: left;

--- a/src/components/Meta.tsx
+++ b/src/components/Meta.tsx
@@ -18,58 +18,48 @@ const APP_THEME_COLOR = '#16ac7e';
 const APP_BACKGROUND_COLOR = '#ffffff';
 
 /**
+ * Helps reduce duplication for creation of link elements
+ */
+const linkFromSize = (size: string, fileType: string, rel = 'icon') => (
+  <link
+    key={`${size}${fileType}`}
+    rel={rel}
+    href={`/icons/${fileType}-${size}.png`}
+    sizes={`${size}x${size}`}
+  />
+);
+
+/**
+ * Helps reduce duplication for creation of meta elements
+ */
+const metaFromSize = (size: string, fileType: string, name: string) => (
+  <meta key={`${size}${fileType}`} name={name} content={`/icons/${fileType}-${size}.png`} />
+);
+
+/**
  * Organizes and maps icon file sizes/names to their created elements - keep this
  * up to date with everything in public/icons/*.png
  */
 const ICONS = {
   generic: {
     variants: [32, 144, 192, 228],
-    element: (size: string) => (
-      <link
-        key={`${size}generic`}
-        rel="icon"
-        href={`/icons/favicon-${size}.png`}
-        sizes={`${size}x${size}`}
-      />
-    ),
+    element: (size: string) => linkFromSize(size, 'favicon'),
   },
   android: {
     variants: [96, 128, 144, 192, 196, 512],
-    element: (size: string) => (
-      <link
-        key={`${size}android`}
-        rel="icon"
-        href={`/icons/prerounded-${size}.png`}
-        sizes={`${size}x${size}`}
-      />
-    ),
+    element: (size: string) => linkFromSize(size, 'prerounded'),
   },
   ios: {
     variants: [57, 76, 120, 152, 167, 180, 512, 1024],
-    element: (size: string) => (
-      <link
-        key={`${size}ios`}
-        rel="apple-touch-icon"
-        href={`/icons/touch-icon-${size}.png`}
-        sizes={`${size}x${size}`}
-      />
-    ),
+    element: (size: string) => linkFromSize(size, 'touch-icon', 'apple-touch-icon'),
   },
   windows: {
     variants: [144],
-    element: (size: string) => (
-      <meta
-        key={`${size}windows`}
-        name="msapplication-TileImage"
-        content={`/icons/favicon-${size}.png`}
-      />
-    ),
+    element: (size: string) => metaFromSize(size, 'favicon', 'msapplication-TileImage'),
   },
   thumbnail: {
     variants: [152],
-    element: (size: string) => (
-      <meta key={`${size}thumb`} name="thumbnail" content={`/icons/touch-icon-${size}.png`} />
-    ),
+    element: (size: string) => metaFromSize(size, 'touch-icon', 'thumbnail'),
   },
   mask: {
     variants: ['safari-pinned-tab.svg'],

--- a/src/components/homepage/Homepage.tsx
+++ b/src/components/homepage/Homepage.tsx
@@ -1,6 +1,7 @@
 import useData from 'api/useData';
 import ContentGrid from 'components/ContentGrid';
-import React, { useMemo } from 'react';
+import useGridAnimation from 'hooks/useGridAnimation';
+import React, { useMemo, useRef } from 'react';
 import ColorSchemeToggleCard from './ColorSchemeToggleCard';
 import HomepageMeta from './HomepageMeta';
 import IntroCard from './IntroCard';
@@ -17,14 +18,20 @@ import StravaCard from './StravaCard';
 const Homepage = () => {
   const { data: projects } = useData('projects');
 
+  // For animating grid items
+  const gridRef = useRef<HTMLDivElement | null>(null);
+  const turnOnAnimation = useGridAnimation(gridRef);
+
   const projectCards =
-    projects?.map((project) => <ProjectCard key={project.title} {...project} />) ?? [];
+    projects?.map((project) => (
+      <ProjectCard key={project.title} {...project} turnOnAnimation={turnOnAnimation} />
+    )) ?? [];
 
   // These index into projectCards to splice in other cards
   const otherCards = useMemo(
     () => [
       { index: 0, card: <IntroCard key="intro" /> },
-      { index: 0, card: <MapCard key="map" /> },
+      { index: 0, card: <MapCard key="map" turnOnAnimation={turnOnAnimation} /> },
       { index: 2, card: <SpotifyCard key="spotify" /> },
       { index: 3, card: <ColorSchemeToggleCard key="color" /> },
       { index: 6, card: <StravaCard key="strava" /> },
@@ -35,7 +42,7 @@ const Homepage = () => {
   return (
     <>
       <HomepageMeta />
-      <ContentGrid>
+      <ContentGrid gridRef={gridRef}>
         {otherCards.map(({ index, card }, arrayIndex) => {
           const nextItem = otherCards[arrayIndex + 1];
           return [card, ...projectCards.slice(index, nextItem?.index)];

--- a/src/components/homepage/IntroCard.tsx
+++ b/src/components/homepage/IntroCard.tsx
@@ -1,5 +1,5 @@
 import useData from 'api/useData';
-import ContentCard from 'components/ContentCard';
+import ContentCard, { OverlayContainer } from 'components/ContentCard';
 import { cardSizeInPx } from 'components/ContentGrid';
 import HoverableContainer from 'components/HoverableContainer';
 import Image from 'components/Image';
@@ -10,11 +10,15 @@ import styled from 'styled-components';
 
 const ImageCard = styled(ContentCard)`
   @media (max-width: 767.96px) {
-    --size: 18em;
+    --size: 14em;
     justify-self: center;
     width: var(--size);
     height: var(--size);
     border-radius: calc(var(--size) / 2);
+
+    ${OverlayContainer} {
+      visibility: hidden;
+    }
   }
 `;
 

--- a/src/components/homepage/MapCard.tsx
+++ b/src/components/homepage/MapCard.tsx
@@ -1,10 +1,12 @@
 import useData from 'api/useData';
+import type { Props as ContentCardProps } from 'components/ContentCard';
 import ContentCard from 'components/ContentCard';
 import { Expand, X } from 'lucide-react';
 import dynamic from 'next/dynamic';
 import { useState } from 'react';
 import styled, { css } from 'styled-components';
 
+type Props = Pick<ContentCardProps, 'turnOnAnimation'>;
 interface IsExpanded {
   $isExpanded: boolean;
 }
@@ -52,7 +54,7 @@ const ExpandButton = styled(Control)`
 /**
  * Shows a canvas-based map of my current location.
  */
-const MapCard = () => {
+const MapCard = ({ turnOnAnimation }: Props) => {
   const { data: location } = useData('location');
   const [isExpanded, setIsExpanded] = useState(false);
 
@@ -61,6 +63,7 @@ const MapCard = () => {
       $isExpanded={isExpanded}
       onExpansion={!isExpanded ? setIsExpanded : undefined}
       $backgroundImageUrl={location?.backupImageUrl}
+      turnOnAnimation={turnOnAnimation}
     >
       {location?.point && (
         <Map location={location} isExpanded={isExpanded}>

--- a/src/components/homepage/MapCard.tsx
+++ b/src/components/homepage/MapCard.tsx
@@ -1,7 +1,7 @@
 import useData from 'api/useData';
 import type { Props as ContentCardProps } from 'components/ContentCard';
 import ContentCard from 'components/ContentCard';
-import { Expand, X } from 'lucide-react';
+import { Maximize2, Minimize2 } from 'lucide-react';
 import dynamic from 'next/dynamic';
 import { useState } from 'react';
 import styled, { css } from 'styled-components';
@@ -28,8 +28,8 @@ const Card = styled(ContentCard)<{ $backgroundImageUrl?: string } & IsExpanded>`
   ${({ $isExpanded }) => css`
     min-height: ${$isExpanded ? EXPANDED_HEIGHT : MIN_DIMENSION}px;
     @media (max-width: 767.99px) {
-      height: 400px;
-      min-height: 400px;
+      min-height: ${$isExpanded ? 360 : 200}px;
+      height: ${$isExpanded ? 360 : 200}px;
     }
   `}
   ${({ $backgroundImageUrl }) =>
@@ -37,18 +37,9 @@ const Card = styled(ContentCard)<{ $backgroundImageUrl?: string } & IsExpanded>`
     css`
       background-image: url('${$backgroundImageUrl}');
       background-repeat: no-repeat;
+      background-position: center;
       background-size: cover;
     `}
-`;
-const HIDDEN_ON_MOBILE = css`
-  visibility: hidden;
-  @media (min-width: 768px) {
-    visibility: visible;
-  }
-`;
-
-const ExpandButton = styled(Control)`
-  ${HIDDEN_ON_MOBILE}
 `;
 
 /**
@@ -67,12 +58,12 @@ const MapCard = ({ turnOnAnimation }: Props) => {
     >
       {location?.point && (
         <Map location={location} isExpanded={isExpanded}>
-          <ExpandButton
+          <Control
             onClick={isExpanded ? () => setIsExpanded(false) : undefined}
             position="top-right"
           >
-            {isExpanded ? <X size="1em" /> : <Expand size="1em" />}
-          </ExpandButton>
+            {isExpanded ? <Minimize2 size="1em" /> : <Maximize2 size="1em" />}
+          </Control>
           <Marker key="home" point={location.point} image={location.image} />
         </Map>
       )}

--- a/src/components/homepage/MapCard.tsx
+++ b/src/components/homepage/MapCard.tsx
@@ -1,9 +1,10 @@
 import useData from 'api/useData';
+import ColorSchemeContext from 'components/ColorSchemeContext';
 import type { Props as ContentCardProps } from 'components/ContentCard';
 import ContentCard from 'components/ContentCard';
 import { Maximize2, Minimize2 } from 'lucide-react';
 import dynamic from 'next/dynamic';
-import { useState } from 'react';
+import { useContext, useState } from 'react';
 import styled, { css } from 'styled-components';
 
 type Props = Pick<ContentCardProps, 'turnOnAnimation'>;
@@ -48,16 +49,25 @@ const Card = styled(ContentCard)<{ $backgroundImageUrl?: string } & IsExpanded>`
 const MapCard = ({ turnOnAnimation }: Props) => {
   const { data: location } = useData('location');
   const [isExpanded, setIsExpanded] = useState(false);
+  const [hasMapLoaded, setHasMapLoaded] = useState(false);
+  const { colorScheme } = useContext(ColorSchemeContext);
+  const backgroundImageUrl =
+    colorScheme === 'light' ? location?.backupImageUrls.light : location?.backupImageUrls.dark;
 
   return (
     <Card
       $isExpanded={isExpanded}
       onExpansion={!isExpanded ? setIsExpanded : undefined}
-      $backgroundImageUrl={location?.backupImageUrl}
+      $backgroundImageUrl={!hasMapLoaded ? backgroundImageUrl : undefined}
       turnOnAnimation={turnOnAnimation}
     >
       {location?.point && (
-        <Map location={location} isExpanded={isExpanded}>
+        <Map
+          location={location}
+          isExpanded={isExpanded}
+          isLoaded={hasMapLoaded}
+          setMapHasLoaded={() => setHasMapLoaded(true)}
+        >
           <Control
             onClick={isExpanded ? () => setIsExpanded(false) : undefined}
             position="top-right"

--- a/src/components/homepage/ProjectCard.tsx
+++ b/src/components/homepage/ProjectCard.tsx
@@ -1,16 +1,17 @@
 import type { Project } from 'api/types/generated/contentfulApi.generated';
+import type { Props as ContentCardProps } from 'components/ContentCard';
 import ContentCard from 'components/ContentCard';
 import { cardSizeInPx } from 'components/ContentGrid';
 import HoverableContainer from 'components/HoverableContainer';
 import Image from 'components/Image';
 import { useState } from 'react';
 
-type Props = Project;
+type Props = Project & Pick<ContentCardProps, 'turnOnAnimation'>;
 
 /**
  * Uses the `ContentCard` to show a project's details
  */
-const ProjectCard = ({ title, layout, link, thumbnail }: Props) => {
+const ProjectCard = ({ title, layout, link, thumbnail, turnOnAnimation }: Props) => {
   const verticalSpan = layout === 'tall' ? 2 : 1;
   const horizontalSpan = layout === 'wide' ? 2 : 1;
   const [isHovered, setIsHovered] = useState(false);
@@ -23,6 +24,7 @@ const ProjectCard = ({ title, layout, link, thumbnail }: Props) => {
       overlay={title}
       onMouseOver={() => setIsHovered(true)}
       onMouseOut={() => setIsHovered(false)}
+      turnOnAnimation={turnOnAnimation}
     >
       {thumbnail && (
         <HoverableContainer isHovered={isHovered}>

--- a/src/components/homepage/ProjectCard.tsx
+++ b/src/components/homepage/ProjectCard.tsx
@@ -1,12 +1,25 @@
 import type { Project } from 'api/types/generated/contentfulApi.generated';
 import type { Props as ContentCardProps } from 'components/ContentCard';
 import ContentCard from 'components/ContentCard';
-import { cardSizeInPx } from 'components/ContentGrid';
+import { cardSize, cardSizeInPx } from 'components/ContentGrid';
 import HoverableContainer from 'components/HoverableContainer';
 import Image from 'components/Image';
 import { useState } from 'react';
+import styled from 'styled-components';
 
 type Props = Project & Pick<ContentCardProps, 'turnOnAnimation'>;
+
+// Makes sure our images take up full size of parent - this seems to be best way to do it right now
+const ProjectImage = styled(Image)`
+  position: fixed !important;
+`;
+
+// Ensure on mobile, all cards are uniform height (small in height)
+const Card = styled(ContentCard)`
+  @media (max-width: 767.99px) {
+    height: ${cardSize(0.67)};
+  }
+`;
 
 /**
  * Uses the `ContentCard` to show a project's details
@@ -17,7 +30,7 @@ const ProjectCard = ({ title, layout, link, thumbnail, turnOnAnimation }: Props)
   const [isHovered, setIsHovered] = useState(false);
 
   return (
-    <ContentCard
+    <Card
       verticalSpan={verticalSpan}
       horizontalSpan={horizontalSpan}
       link={link}
@@ -28,7 +41,7 @@ const ProjectCard = ({ title, layout, link, thumbnail, turnOnAnimation }: Props)
     >
       {thumbnail && (
         <HoverableContainer isHovered={isHovered}>
-          <Image
+          <ProjectImage
             {...thumbnail}
             alt={title}
             width={cardSizeInPx(horizontalSpan)}
@@ -36,7 +49,7 @@ const ProjectCard = ({ title, layout, link, thumbnail, turnOnAnimation }: Props)
           />
         </HoverableContainer>
       )}
-    </ContentCard>
+    </Card>
   );
 };
 

--- a/src/components/maps/Map.tsx
+++ b/src/components/maps/Map.tsx
@@ -1,6 +1,6 @@
 import type { MapLocation } from 'api/types/MapLocation';
 import ColorSchemeContext from 'components/ColorSchemeContext';
-import { useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { useContext, useEffect, useMemo, useRef } from 'react';
 import { AttributionControl, Map as MapGL, MapRef } from 'react-map-gl';
 import styled, { css } from 'styled-components';
 import StandardControls from './StandardControls';
@@ -21,6 +21,16 @@ export type Props = {
    * Use this to pass layers and features.
    */
   children?: React.ReactElement | Array<React.ReactElement> | null;
+
+  /**
+   * If the map itself has loaded (controlled via state above)
+   */
+  isLoaded: boolean;
+
+  /**
+   * Set that the map has loaded properly
+   */
+  setMapHasLoaded: () => void;
 };
 
 const LIGHT_STYLE = 'mapbox://styles/dylangattey/ckyfpsonl01w014q8go5wvnh2?optimize=true';
@@ -106,9 +116,8 @@ const Wrapper = styled.div<{ $isLoaded: boolean }>`
 /**
  * Uses Mapbox to show a canvas-based map of my current location.
  */
-const Map = ({ location, children, isExpanded }: Props) => {
+const Map = ({ location, children, isExpanded, isLoaded, setMapHasLoaded }: Props) => {
   const mapRef = useRef<MapRef>(null);
-  const [isLoaded, setIsLoaded] = useState(false);
   const { colorScheme } = useContext(ColorSchemeContext);
 
   // Ensures we resize when expanding/collapsing so we repaint - needs both resizes to ensure it's done properly
@@ -146,7 +155,7 @@ const Map = ({ location, children, isExpanded }: Props) => {
         mapStyle={colorScheme === 'dark' ? DARK_STYLE : LIGHT_STYLE}
         styleDiffing={false}
         mapboxAccessToken={process.env.NEXT_PUBLIC_MAPBOX_TOKEN}
-        onLoad={() => setIsLoaded(true)}
+        onLoad={setMapHasLoaded}
         reuseMaps
       >
         {isExpanded && <AttributionControl position="bottom-right" />}

--- a/src/helpers/sentryInit.js
+++ b/src/helpers/sentryInit.js
@@ -1,0 +1,31 @@
+import {
+  CaptureConsole as CaptureConsoleIntegration,
+  ExtraErrorData as ExtraErrorDataIntegration,
+  Offline as OfflineIntegration,
+} from '@sentry/integrations';
+import * as Sentry from '@sentry/nextjs';
+
+const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;
+
+/**
+ * Initializes Sentry wherever this is called from
+ */
+const sentryInit = () =>
+  Sentry.init({
+    dsn: SENTRY_DSN,
+
+    tracesSampleRate: 1.0,
+
+    integrations: [
+      // Rewrites console.x into messages!
+      new CaptureConsoleIntegration(),
+
+      // Captures events that happen offline and replays them when back online
+      new OfflineIntegration(),
+
+      // Adds extra non-native data on Errors to Sentry
+      new ExtraErrorDataIntegration(),
+    ],
+  });
+
+export default sentryInit;

--- a/src/hooks/useGridAnimation.ts
+++ b/src/hooks/useGridAnimation.ts
@@ -1,0 +1,95 @@
+import type { WrapGridArguments } from 'animate-css-grid/dist/types';
+import { useCallback, useEffect, useRef } from 'react';
+
+// In ms, how long to animate grid items
+export const GRID_ANIMATION_DURATION = 300;
+
+/**
+ * Swaps pointer events between being disabled and auto on the children to
+ * avoid slowdowns as the browser tries to compute a hover effect as it
+ * animates.
+ */
+const changePointerEvents = (isOn: boolean) => (animatedChildren: HTMLElement[]) => {
+  animatedChildren.forEach((child) => {
+    // eslint-disable-next-line no-param-reassign
+    child.style.pointerEvents = isOn ? 'auto' : 'none';
+  });
+};
+
+/**
+ * Hook used to dynamically import the `animate-css-grid` library
+ * and animate a ref when necessary.
+ */
+const useGridAnimation = (gridRef: React.RefObject<HTMLDivElement>) => {
+  const hasImportedLib = useRef(false);
+  const wrapGridRef = useRef<
+    | ((container: HTMLElement, args: WrapGridArguments | undefined) => { unwrapGrid: () => void })
+    | null
+  >(null);
+  const unwrapGridRef = useRef<(() => void) | null>(null);
+
+  /**
+   * Uses refs so we can be sure that we wrap the grid with animations exactly once.
+   * Imports the animation library (and this is called from an effect) so we don't
+   * do that on the server where it's unneeded.
+   */
+  const importLibrary = useCallback(async () => {
+    if (!gridRef.current) {
+      hasImportedLib.current = false;
+      return;
+    }
+    if (hasImportedLib.current) {
+      return;
+    }
+    hasImportedLib.current = true;
+    try {
+      if (wrapGridRef.current) {
+        return;
+      }
+      const { wrapGrid } = await import('animate-css-grid');
+      wrapGridRef.current = wrapGrid;
+    } catch {
+      hasImportedLib.current = false;
+    }
+  }, [gridRef]);
+
+  /**
+   * Simply stops the animation by removing the library's wrapper
+   * around the gridRef
+   */
+  const turnOffAnimation = () => {
+    unwrapGridRef.current?.();
+    unwrapGridRef.current = null;
+  };
+
+  /**
+   * Starts the animation by wrapping the grid in a mutation
+   * observer, and stopping the animation after it's been used
+   * once so that it's not on later.
+   */
+  const turnOnAnimation = () => {
+    if (!gridRef.current || !wrapGridRef.current) {
+      return;
+    }
+    const gridWrapResult = wrapGridRef.current(gridRef.current, {
+      stagger: 10,
+      duration: GRID_ANIMATION_DURATION,
+      easing: 'backOut',
+      onStart: changePointerEvents(false),
+      onEnd: () => {
+        changePointerEvents(true);
+        turnOffAnimation();
+      },
+    });
+    unwrapGridRef.current = gridWrapResult.unwrapGrid;
+  };
+
+  // Make sure we import the library to start with
+  useEffect(() => {
+    (() => importLibrary())();
+  }, [importLibrary]);
+
+  return turnOnAnimation;
+};
+
+export default useGridAnimation;

--- a/src/hooks/useGridAnimation.ts
+++ b/src/hooks/useGridAnimation.ts
@@ -76,8 +76,8 @@ const useGridAnimation = (gridRef: React.RefObject<HTMLDivElement>) => {
       duration: GRID_ANIMATION_DURATION,
       easing: 'backOut',
       onStart: changePointerEvents(false),
-      onEnd: () => {
-        changePointerEvents(true);
+      onEnd: (animatedChildren) => {
+        changePointerEvents(true)(animatedChildren);
         turnOffAnimation();
       },
     });


### PR DESCRIPTION
# Description of changes

1. Animations for expansion/collapse of map cards ONLY, not for resizing/etc for speed (no more slow resizing!!)
2. Mobile styling fixed, no more gaps, and regularly sized cards, not multiple spans
3. Dark AND light mode backup images for maps
4. CodeClimate config that reduces some repeated code