### PR TITLE
fix: silence some sentry errors + open links in new tabs

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -54,6 +54,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@sentry/cli", "npm:2.0.4"],\
             ["@sentry/integrations", "npm:6.19.7"],\
             ["@sentry/nextjs", "virtual:76f771601b124a7dfdd081dc93ab70f3ebcf38d24b116fcea6a8b98778652f1f02bdc2695315e10c1d59fab15e410158648f9f32211c761bb97c28a110c96f33#npm:6.19.7"],\
+            ["@sentry/types", "npm:6.19.7"],\
             ["@stylelint/postcss-css-in-js", "virtual:76f771601b124a7dfdd081dc93ab70f3ebcf38d24b116fcea6a8b98778652f1f02bdc2695315e10c1d59fab15e410158648f9f32211c761bb97c28a110c96f33#npm:0.38.0"],\
             ["@types/mapbox-gl", "npm:2.7.1"],\
             ["@types/node", "npm:16.11.33"],\
@@ -6768,6 +6769,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@sentry/cli", "npm:2.0.4"],\
             ["@sentry/integrations", "npm:6.19.7"],\
             ["@sentry/nextjs", "virtual:76f771601b124a7dfdd081dc93ab70f3ebcf38d24b116fcea6a8b98778652f1f02bdc2695315e10c1d59fab15e410158648f9f32211c761bb97c28a110c96f33#npm:6.19.7"],\
+            ["@sentry/types", "npm:6.19.7"],\
             ["@stylelint/postcss-css-in-js", "virtual:76f771601b124a7dfdd081dc93ab70f3ebcf38d24b116fcea6a8b98778652f1f02bdc2695315e10c1d59fab15e410158648f9f32211c761bb97c28a110c96f33#npm:0.38.0"],\
             ["@types/mapbox-gl", "npm:2.7.1"],\
             ["@types/node", "npm:16.11.33"],\

--- a/next.config.js
+++ b/next.config.js
@@ -37,19 +37,21 @@ const withNextBundleAnalyzer = require('@next/bundle-analyzer')({
 });
 
 if (process.env.NODE_ENV === 'development') {
-  // Add bundle analysis + silent sentry on develop
+  // Add silent sentry on develop and make sure it's always a dry run
   module.exports = withNextBundleAnalyzer(
     withSentryConfig(nextConfig, {
       silent: true,
+      dryRun: true,
     }),
   );
 } else {
-  // Dry run if we're running with an invalid version
+  // For prod, dry run if it's running locally/appears local
   module.exports = withNextBundleAnalyzer(
     withSentryConfig(nextConfig, {
       dryRun:
-        // These are the fallbacks when we can't find an app version, like it's not deployed on a real branch
-        ['vX.Y.Z', 'LOCAL'].includes(process.env.NEXT_PUBLIC_APP_VERSION),
+        // If not deployed on a real branch or the db url points to something local, we know we're running a production build locally
+        ['vX.Y.Z', 'LOCAL'].includes(process.env.NEXT_PUBLIC_APP_VERSION) ||
+        process.env?.DATABASE_URL?.includes('127.0.0.1'),
     }),
   );
 }

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@next/bundle-analyzer": "^12.1.6",
     "@semantic-release/changelog": "^6.0.1",
     "@sentry/cli": "^2.0.4",
+    "@sentry/types": "^6.19.7",
     "@stylelint/postcss-css-in-js": "^0.38.0",
     "@types/mapbox-gl": "^2.7.1",
     "@types/node": "^16.11.33",

--- a/src/components/ContentWrappingLink.tsx
+++ b/src/components/ContentWrappingLink.tsx
@@ -17,7 +17,9 @@ const ContentWrappingLink = ({ link, children }: Props) => {
   }
   return (
     <NextLink passHref href={link.url}>
-      <a href={link.url}>{children}</a>
+      <a href={link.url} target="_blank" rel="noreferrer">
+        {children}
+      </a>
     </NextLink>
   );
 };

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -24,7 +24,7 @@ const Footer = () => {
   const { data: footerLinks } = useData('footer');
   const listedLinkElements = footerLinks?.map((link) => (
     <li key={link.url}>
-      <Link {...link} />
+      <Link {...link} isExternal={link.url?.startsWith('http')} />
     </li>
   ));
   return (

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -27,6 +27,12 @@ type Props = Pick<LinkProps, 'title' | 'url' | 'icon'> &
      * Defaults to `text` when there's no icon, or `icon` when one is specified
      */
     layout?: Layout;
+
+    /**
+     * Defaults to false, but can be set to true to add target="_blank" and
+     * rel="noreferrer"
+     */
+    isExternal?: boolean;
   };
 
 // Used a few times, required layout
@@ -81,7 +87,7 @@ const tooltip = ({ title, layout }: SubProps) =>
  * or defaults to `icon` if one is specified, otherwise `text`. Returns
  * null if no link at all.
  */
-const Link = ({ title, url, icon, layout: rawLayout, className, children }: Props) => {
+const Link = ({ title, url, icon, layout: rawLayout, className, children, isExternal }: Props) => {
   const layout = rawLayout ?? (icon && !children ? 'icon' : 'text');
   if (!url) {
     return null;
@@ -91,7 +97,11 @@ const Link = ({ title, url, icon, layout: rawLayout, className, children }: Prop
   const iconElement = createIconElement({ title, icon, layout });
   return (
     <NextLink href={url} passHref>
-      <StyledLink className={className} data-tooltip={tooltip({ title, icon, layout })}>
+      <StyledLink
+        className={className}
+        data-tooltip={tooltip({ title, icon, layout })}
+        {...(isExternal ? { target: '_blank', rel: 'noreferrer' } : {})}
+      >
         {layout === 'empty' ? null : children ?? iconElement ?? title}
       </StyledLink>
     </NextLink>

--- a/src/components/homepage/StravaCard.tsx
+++ b/src/components/homepage/StravaCard.tsx
@@ -47,7 +47,8 @@ const Stat = styled(Text)`
   margin-bottom: 0.25rem;
 `;
 
-const PlainLink = styled.a`
+// Opens link in new tab
+const ExternalLink = styled.a.attrs({ target: '_blank', rel: 'noreferrer' })`
   color: inherit;
 `;
 
@@ -98,13 +99,13 @@ const StravaCard = () => {
             </StatusText>
           )}
           {activity.name && (
-            <PlainLink href={url}>
+            <ExternalLink href={url}>
               <Text>{activity.name}</Text>
-            </PlainLink>
+            </ExternalLink>
           )}
           {activity.description && (
             <Description>
-              <PlainLink href={url}>{activity.description}</PlainLink>
+              <ExternalLink href={url}>{activity.description}</ExternalLink>
             </Description>
           )}
         </Group>

--- a/src/components/spotify/AlbumImage.tsx
+++ b/src/components/spotify/AlbumImage.tsx
@@ -50,7 +50,13 @@ const AlbumImage = ({ name, album }: Props) => {
     </ImageContainer>
   ) : null;
 
-  return albumLink ? <FlexedLink {...albumLink}>{imageComponent}</FlexedLink> : imageComponent;
+  return albumLink ? (
+    <FlexedLink isExternal {...albumLink}>
+      {imageComponent}
+    </FlexedLink>
+  ) : (
+    imageComponent
+  );
 };
 
 export default AlbumImage;

--- a/src/components/spotify/ArtistList.tsx
+++ b/src/components/spotify/ArtistList.tsx
@@ -55,7 +55,13 @@ const ArtistList = ({ artists }: Props) => {
         const link = artistLink(artist);
         return (
           <React.Fragment key={artist.id}>
-            {link ? <PlainLink {...link}>{artist.name}</PlainLink> : artist.name}
+            {link ? (
+              <PlainLink isExternal {...link}>
+                {artist.name}
+              </PlainLink>
+            ) : (
+              artist.name
+            )}
             <span>{separator({ index, fullList: artists })}</span>
           </React.Fragment>
         );

--- a/src/components/spotify/Logo.tsx
+++ b/src/components/spotify/Logo.tsx
@@ -19,7 +19,7 @@ const BigLogoLink = styled(Link)`
 const Logo = ({ name, external_urls }: Props) => {
   const link = useLinkWithName('Spotify', { title: name, url: external_urls.spotify });
   return link ? (
-    <BigLogoLink {...link}>
+    <BigLogoLink {...link} isExternal>
       <FaIcon icon={faSpotify} />
     </BigLogoLink>
   ) : null;

--- a/src/components/spotify/TrackTitle.tsx
+++ b/src/components/spotify/TrackTitle.tsx
@@ -15,7 +15,13 @@ const PlainLink = styled(Link)`
  */
 const TrackTitle = ({ name, external_urls }: Props) => {
   const link = useLinkWithName('Spotify', { title: name, url: external_urls.spotify });
-  return link ? <PlainLink {...link}>{name}</PlainLink> : <span>name</span>;
+  return link ? (
+    <PlainLink isExternal {...link}>
+      {name}
+    </PlainLink>
+  ) : (
+    <span>name</span>
+  );
 };
 
 export default TrackTitle;

--- a/src/helpers/sentryInit.js
+++ b/src/helpers/sentryInit.js
@@ -7,14 +7,55 @@ import * as Sentry from '@sentry/nextjs';
 
 const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;
 
+const IGNORED_ERROR_MESSAGES = [
+  /**
+   * We don't include Mapbox GL JS CSS files, but we include custom CSS that's what we
+   * use to make sure our bundle size is smaller
+   */
+  'appears to be missing CSS declarations for Mapbox GL JS',
+];
+
+/**
+ * Makes sure we have pleasant typing on our init function from Sentry
+ * @type {{ init: import('@sentry/nextjs')['init']}}
+ */
+const { init } = Sentry;
+
 /**
  * Initializes Sentry wherever this is called from
  */
 const sentryInit = () =>
-  Sentry.init({
+  init({
     dsn: SENTRY_DSN,
 
     tracesSampleRate: 1.0,
+
+    // Always ignore localhost
+    denyUrls: [/localhost/],
+
+    // Make sure we don't enable sending events on local builds or builds where we have no real version set
+    enabled:
+      !['vX.Y.Z', 'LOCAL'].includes(String(process.env.NEXT_PUBLIC_APP_VERSION)) &&
+      !process.env?.DATABASE_URL?.includes('127.0.0.1'),
+
+    /**
+     * Filters out certain Sentry errors we don't care about
+     */
+    beforeSend: (event, hint) => {
+      const error = hint?.originalException;
+      const errorMessage = (typeof error !== 'string' && error?.message) || undefined;
+      const message = errorMessage ?? hint?.syntheticException?.message;
+
+      // Ignore certain types of error messages
+      if (
+        message &&
+        IGNORED_ERROR_MESSAGES.some((ignoredMessage) => message.includes(ignoredMessage))
+      ) {
+        return null;
+      }
+
+      return event;
+    },
 
     integrations: [
       // Rewrites console.x into messages!

--- a/yarn.lock
+++ b/yarn.lock
@@ -2440,7 +2440,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/types@npm:6.19.7":
+"@sentry/types@npm:6.19.7, @sentry/types@npm:^6.19.7":
   version: 6.19.7
   resolution: "@sentry/types@npm:6.19.7"
   checksum: f46ef74a33376ad6ea9b128115515c58eb9369d89293c60aa67abca26b5d5d519aa4d0a736db56ae0d75ffd816643d62187018298523cbc2e6c2fb3a6b2a9035
@@ -5045,6 +5045,7 @@ __metadata:
     "@sentry/cli": ^2.0.4
     "@sentry/integrations": ^6.19.7
     "@sentry/nextjs": ^6.19.7
+    "@sentry/types": ^6.19.7
     "@stylelint/postcss-css-in-js": ^0.38.0
     "@types/mapbox-gl": ^2.7.1
     "@types/node": ^16.11.33


### PR DESCRIPTION
# Description of changes

Make sure we drop errors on localhost or if we have no version set + stop releases in that state too. Also opens links in new tabs.