### PR TITLE
fix: attempt to use correct versions for Sentry releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,14 +18,21 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: yarn release
+      - uses: actions-ecosystem/action-get-latest-tag@v1
+        name: Get latest version tag
+        with:
+          semver_only: true
+        id: latest-version-tag
       - name: Redeploy on Vercel using latest version
+        if: ${{ steps.latest-version-tag.outputs.tag != '' }}
         run: |
           prodRun=""
           if [[ ${GITHUB_REF} == "refs/heads/main" ]]; then
             prodRun="--prod"
           fi
-          npx vercel --token ${VERCEL_DEPLOY_TOKEN} $prodRun --build-env NEXT_PUBLIC_VERSION=${GITHUB_SHA} --build-env NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA=${GITHUB_SHA} --env NEXT_PUBLIC_VERSION=${GITHUB_SHA} --env NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA=${GITHUB_SHA}
+          npx vercel --token ${VERCEL_DEPLOY_TOKEN} $prodRun --build-env NEXT_PUBLIC_VERSION=${GITHUB_SHA} --build-env NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA=${GITHUB_SHA} --env NEXT_PUBLIC_VERSION=${LATEST_TAG} --env NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA=${GITHUB_SHA}
         env:
+          LATEST_TAG: ${{ steps.latest-version-tag.outputs.tag }}
           VERCEL_DEPLOY_TOKEN: ${{ secrets.VERCEL_DEPLOY_TOKEN }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}

--- a/next.config.js
+++ b/next.config.js
@@ -40,6 +40,7 @@ if (process.env.NODE_ENV === 'development') {
   // Add silent sentry on develop and make sure it's always a dry run
   module.exports = withNextBundleAnalyzer(
     withSentryConfig(nextConfig, {
+      release: process.env.NEXT_PUBLIC_APP_VERSION,
       silent: true,
       dryRun: true,
     }),
@@ -48,9 +49,10 @@ if (process.env.NODE_ENV === 'development') {
   // For prod, dry run if it's running locally/appears local
   module.exports = withNextBundleAnalyzer(
     withSentryConfig(nextConfig, {
+      release: process.env.NEXT_PUBLIC_APP_VERSION,
       dryRun:
         // If not deployed on a real branch or the db url points to something local, we know we're running a production build locally
-        ['vX.Y.Z', 'LOCAL'].includes(process.env.NEXT_PUBLIC_APP_VERSION) ||
+        'vX.Y.Z'.includes(process.env.NEXT_PUBLIC_APP_VERSION) ||
         process.env?.DATABASE_URL?.includes('127.0.0.1'),
     }),
   );

--- a/scripts/getVersion.ts
+++ b/scripts/getVersion.ts
@@ -5,7 +5,7 @@ import fetchGithubRepoVersion from '../src/api/server/fetchGithubRepoVersion';
  * right data, then writes it to STDOUT for later use.
  */
 const getVersion = async () => {
-  const version = (await fetchGithubRepoVersion()) ?? 'LOCAL';
+  const version = (await fetchGithubRepoVersion()) ?? 'vX.Y.Z';
   process.stdout.write(version);
 };
 

--- a/src/helpers/sentryInit.js
+++ b/src/helpers/sentryInit.js
@@ -35,7 +35,7 @@ const sentryInit = () =>
 
     // Make sure we don't enable sending events on local builds or builds where we have no real version set
     enabled:
-      !['vX.Y.Z', 'LOCAL'].includes(String(process.env.NEXT_PUBLIC_APP_VERSION)) &&
+      !'vX.Y.Z'.includes(String(process.env.NEXT_PUBLIC_APP_VERSION)) &&
       !process.env?.DATABASE_URL?.includes('127.0.0.1'),
 
     /**


### PR DESCRIPTION
# Description of changes

Uses a Github action to grab latest tag + uses the version string in the release field to attempt to always use the version for Sentry release. Therefore we won't create duplicates/"different" releases for the same version