### PR TITLE
fix: swap to SSR to provide accurate urls for meta + image tags + attempt to fix render mismatch

### DIFF
--- a/src/components/Meta.tsx
+++ b/src/components/Meta.tsx
@@ -1,6 +1,5 @@
 import Head from 'next/head';
-import { useRouter } from 'next/router';
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 
 interface Props {
   /**
@@ -12,6 +11,11 @@ interface Props {
    * Description shown to Google/others
    */
   description?: string;
+
+  /**
+   * Current page URL, from serverside props
+   */
+  pageUrl: string;
 }
 
 /**
@@ -24,7 +28,6 @@ const MAX_DESC_LENGTH = 300;
 const APP_THEME_COLOR = '#16ac7e';
 const APP_BACKGROUND_COLOR = '#ffffff';
 const SITE_NAME = 'Dylan Gattey';
-const BASE_URL = 'https://dylangattey.com';
 const OG_IMAGE_URL = 'https://og.dylangattey.com';
 const GRAPH_PREFIXES = ['og', 'twitter'] as const;
 
@@ -95,9 +98,7 @@ const graphMetaItems = (graph: Graph) =>
 /**
  * Populates the `<head>` of a given page from the title/description here
  */
-const Meta = ({ title, description }: Props) => {
-  const { asPath } = useRouter();
-  const [graphItems, setGraphItems] = useState<ReturnType<typeof graphMetaItems> | null>(null);
+const Meta = ({ title, description, pageUrl }: Props) => {
   const truncatedDescription =
     description && description.length > MAX_DESC_LENGTH
       ? `${description.slice(0, MAX_DESC_LENGTH)}...`
@@ -106,18 +107,6 @@ const Meta = ({ title, description }: Props) => {
 
   // Construct url with encoded periods too to not confuse the parser
   const imageTitle = title ? encodeURIComponent(title).replace(/\./g, '%2E') : '%20';
-
-  // This is within an effect so that we don't have mismatched props due to `asPath` between client/server
-  useEffect(() => {
-    setGraphItems(
-      graphMetaItems({
-        title: title ?? SITE_NAME,
-        description: truncatedDescription,
-        url: `${BASE_URL}${asPath}`,
-        image: `${OG_IMAGE_URL}/${imageTitle}?md=true`,
-      }),
-    );
-  }, [asPath, imageTitle, title, truncatedDescription]);
 
   return (
     <Head>
@@ -129,7 +118,12 @@ const Meta = ({ title, description }: Props) => {
       {truncatedDescription && (
         <meta key="description" name="description" content={truncatedDescription} />
       )}
-      {graphItems}
+      {graphMetaItems({
+        title: title ?? SITE_NAME,
+        description: truncatedDescription,
+        url: pageUrl,
+        image: `${OG_IMAGE_URL}/${imageTitle}?md=true`,
+      })}
       <link key="favicon" rel="icon" href="/favicon.ico" />
       <meta key="theme-color" name="theme-color" content="var(--background-color)" />
       <meta

--- a/src/components/homepage/Homepage.tsx
+++ b/src/components/homepage/Homepage.tsx
@@ -3,6 +3,7 @@ import ContentGrid from 'components/ContentGrid';
 import Meta from 'components/Meta';
 import useGridAnimation from 'hooks/useGridAnimation';
 import React, { useMemo, useRef } from 'react';
+import type { Page } from 'types/Page';
 import ColorSchemeToggleCard from './ColorSchemeToggleCard';
 import IntroCard from './IntroCard';
 import MapCard from './MapCard';
@@ -15,7 +16,7 @@ import StravaCard from './StravaCard';
  * interspersed with `introBlock` data, and dark/light mode
  * toggle.
  */
-const Homepage = () => {
+const Homepage = ({ pageUrl }: Pick<Page, 'pageUrl'>) => {
   const { data: projects } = useData('projects');
   const { data: introBlock } = useData('intro');
 
@@ -47,7 +48,7 @@ const Homepage = () => {
 
   return (
     <>
-      <Meta title="Engineer. Problem Solver." description={firstParagraph} />
+      <Meta pageUrl={pageUrl} title="Engineer. Problem Solver." description={firstParagraph} />
       <ContentGrid gridRef={gridRef}>
         {otherCards.map(({ index, card }, arrayIndex) => {
           const nextItem = otherCards[arrayIndex + 1];

--- a/src/components/layouts/ErrorLayout.tsx
+++ b/src/components/layouts/ErrorLayout.tsx
@@ -2,19 +2,21 @@ import { ErrorPageFallback } from 'api/fetchFallback';
 import Meta from 'components/Meta';
 import NextLink from 'next/link';
 import styled from 'styled-components';
+import { Page } from 'types/Page';
 import PageLayout from './PageLayout';
 
-type Props = Pick<React.ComponentProps<'div'>, 'children'> & {
-  /**
-   * Provides SWR with fallback version/header/footer data
-   */
-  fallback: ErrorPageFallback;
+type Props = Pick<React.ComponentProps<'div'>, 'children'> &
+  Pick<Page, 'pageUrl'> & {
+    /**
+     * Provides SWR with fallback version/header/footer data
+     */
+    fallback: ErrorPageFallback;
 
-  /**
-   * The numeric code for the error's status
-   */
-  statusCode: number;
-};
+    /**
+     * The numeric code for the error's status
+     */
+    statusCode: number;
+  };
 
 const Button = styled.a.attrs({ role: 'button' })``;
 
@@ -27,11 +29,11 @@ const Container = styled.section`
  * Basic page layout for error pages. Max-width'd content, left aligned,
  * with a go home button at the bottom
  */
-const ErrorLayout = ({ children, fallback, statusCode }: Props) => {
+const ErrorLayout = ({ children, fallback, statusCode, pageUrl }: Props) => {
   const pageTitle = statusCode === 404 ? 'Oops! Page not found' : `Error code ${statusCode}`;
   return (
-    <PageLayout fallback={fallback}>
-      <Meta title={pageTitle} description="An error occurred" />
+    <PageLayout fallback={fallback} pageUrl={pageUrl}>
+      <Meta pageUrl={pageUrl} title={pageTitle} description="An error occurred" />
       <Container>
         {children}
         <NextLink passHref href="/">

--- a/src/components/layouts/PageLayout.tsx
+++ b/src/components/layouts/PageLayout.tsx
@@ -1,5 +1,4 @@
 import type { EndpointKey } from 'api/endpoints';
-import type { PartialFallback } from 'api/fetchFallback';
 import ColorSchemeContext from 'components/ColorSchemeContext';
 import Footer from 'components/Footer';
 import Header from 'components/Header';
@@ -9,25 +8,19 @@ import useColorScheme from 'hooks/useColorScheme';
 import useShowScrollIndicator from 'hooks/useShowScrollIndicator';
 import { useRef } from 'react';
 import { SWRConfig } from 'swr';
+import type { Page } from 'types/Page';
 
 /**
  * We have props that dictate a fallback for SWRConfig, plus children
  */
-type Props<Key extends EndpointKey> = Pick<React.ComponentProps<'div'>, 'children'> & {
-  /**
-   * Fallback data to show, meaning the page must fetch this data in
-   * `getStaticProps` and pass it here using props on the page
-   * component itself.
-   */
-  fallback: PartialFallback<Key>;
-};
+type Props<Key extends EndpointKey> = Pick<React.ComponentProps<'div'>, 'children'> & Page<Key>;
 
 /**
  * Basic page layout for every page. Has a sticky, contained header above
  * the main (contained) content, with a (contained) footer below. No wrapper
  * around all items to save on divs. Ensures color scheme is applied.
  */
-const PageLayout = <Key extends EndpointKey>({ children, fallback }: Props<Key>) => {
+const PageLayout = <Key extends EndpointKey>({ children, fallback, pageUrl }: Props<Key>) => {
   const colorSchemeData = useColorScheme();
   const headerSizingRef = useRef<HTMLDivElement>(null);
   const { ref, isIndicatorShown } = useShowScrollIndicator(
@@ -35,7 +28,7 @@ const PageLayout = <Key extends EndpointKey>({ children, fallback }: Props<Key>)
   );
   return (
     <SWRConfig value={{ fallback }}>
-      <Meta />
+      <Meta pageUrl={pageUrl} />
       <ColorSchemeContext.Provider value={colorSchemeData}>
         <ScrollIndicatorContext.Provider value={isIndicatorShown}>
           <Header headerRef={headerSizingRef} />

--- a/src/components/privacy/Privacy.tsx
+++ b/src/components/privacy/Privacy.tsx
@@ -3,6 +3,7 @@ import Meta from 'components/Meta';
 import RichText from 'components/RichText';
 import React from 'react';
 import styled from 'styled-components';
+import type { Page } from 'types/Page';
 
 const SingleColumn = styled(RichText)`
   max-width: 35em;
@@ -13,7 +14,7 @@ const SingleColumn = styled(RichText)`
 /**
  * Shows the privacy policy on a page alone
  */
-const Privacy = () => {
+const Privacy = ({ pageUrl }: Pick<Page, 'pageUrl'>) => {
   const { data: privacyTextBlock } = useData('privacy');
   if (!privacyTextBlock?.content) {
     return null;
@@ -27,7 +28,7 @@ const Privacy = () => {
 
   return (
     <>
-      <Meta title="Privacy Policy" description={privacyDescription} />
+      <Meta pageUrl={pageUrl} title="Privacy Policy" description={privacyDescription} />
       <SingleColumn {...privacyTextBlock.content} />
     </>
   );

--- a/src/helpers/getPageUrl.ts
+++ b/src/helpers/getPageUrl.ts
@@ -1,0 +1,14 @@
+import type { GetServerSidePropsContext } from 'next';
+
+/**
+ * Used to grab the page url from serverside props using host/resolved url
+ */
+const getPageUrl = (context: GetServerSidePropsContext) => {
+  const { host } = context.req.headers;
+  if (!context.req.headers.host) {
+    throw TypeError('No host to use as URL');
+  }
+  return `${host}${context.resolvedUrl}`;
+};
+
+export default getPageUrl;

--- a/src/hooks/useRelativeTimeFormat.ts
+++ b/src/hooks/useRelativeTimeFormat.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 type DateConstructorValue = Date | string | number | null | undefined;
 
@@ -82,16 +82,18 @@ const overriddenFormatString = ({ unit, amount }: RelativeTime) => {
 
 /**
  * Used to create a "6 hours ago" or "last week" type string using
- * native date formatting.
+ * native date formatting. Makes sure to return a string on first
+ * render and return the relative time format with an effect to avoid
+ * server/client rendering differences
  */
 const useRelativeTimeFormat = (fromDate: DateConstructorValue, toDate?: DateConstructorValue) => {
   const formatter = useMemo(() => new Intl.RelativeTimeFormat('en', { numeric: 'auto' }), []);
   const elapsedMs = numericDate(fromDate) - numericDate(toDate);
+  const [formattedValue, setFormattedValue] = useState<string>('recently');
 
-  // Kept memoized for perf
-  const formattedValue = useMemo(() => {
+  useEffect(() => {
     const relativeTime = relativeTimeFromMs(elapsedMs, formatter);
-    return overriddenFormatString(relativeTime) ?? relativeTime.formatted;
+    setFormattedValue(overriddenFormatString(relativeTime) ?? relativeTime.formatted);
   }, [elapsedMs, formatter]);
 
   return formattedValue;

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,12 +1,13 @@
 import fetchFallback from 'api/fetchFallback';
 import ErrorLayout from 'components/layouts/ErrorLayout';
+import type { GetStaticProps } from 'next/types';
 import React from 'react';
 import { Contents, Props } from './_error';
 
 /**
  * If this is on the server, it'll provide a response to use for a status code
  */
-export const getStaticProps = async () => {
+export const getStaticProps: GetStaticProps = async () => {
   const data = await fetchFallback(['version', 'footer']);
   return {
     props: {
@@ -20,8 +21,8 @@ export const getStaticProps = async () => {
 /**
  * Error page, for 404s specifically
  */
-const Error404Page = ({ fallback }: Props) => (
-  <ErrorLayout fallback={fallback} statusCode={404}>
+const Error404Page = ({ fallback, pageUrl }: Props) => (
+  <ErrorLayout fallback={fallback} statusCode={404} pageUrl={pageUrl}>
     <Contents statusCode={404} />
   </ErrorLayout>
 );

--- a/src/pages/_error.tsx
+++ b/src/pages/_error.tsx
@@ -31,6 +31,11 @@ export type Props = HasStatusCode & {
    * The error object, for later use
    */
   err: NextPageContext['err'];
+
+  /**
+   * Current page url
+   */
+  pageUrl: string;
 };
 
 export type ErrorWithCode = Error & HasStatusCode;
@@ -53,6 +58,7 @@ export const getStaticProps = async (context: NextPageContext) => {
   const props: Props = {
     ...errorProps,
     statusCode,
+    pageUrl: '',
     fallback: {
       ...data,
     },
@@ -109,13 +115,13 @@ export const Contents = ({ statusCode }: HasStatusCode) => {
 /**
  * Generic error page, for 404s//500s/etc
  */
-const ErrorPage = ({ statusCode, fallback, hasStaticPropsRun, err }: Props) => {
+const ErrorPage = ({ statusCode, fallback, hasStaticPropsRun, err, pageUrl }: Props) => {
   if (!hasStaticPropsRun && err) {
     // Workaround for https://github.com/vercel/next.js/issues/8592
     Sentry.captureException(err);
   }
   return (
-    <ErrorLayout fallback={fallback} statusCode={statusCode ?? 500}>
+    <ErrorLayout pageUrl={pageUrl} fallback={fallback} statusCode={statusCode ?? 500}>
       <Contents statusCode={statusCode} />
     </ErrorLayout>
   );

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,22 +1,18 @@
-import type { PartialFallback } from 'api/fetchFallback';
 import fetchFallback from 'api/fetchFallback';
 import Homepage from 'components/homepage/Homepage';
 import PageLayout from 'components/layouts/PageLayout';
-import { GetStaticProps, InferGetStaticPropsType } from 'next/types';
+import getPageUrl from 'helpers/getPageUrl';
+import type { GetServerSideProps } from 'next/types';
 import React from 'react';
+import type { Page } from 'types/Page';
 
-interface Props {
-  /**
-   * Provides SWR with fallback version data
-   */
-  fallback: PartialFallback<'projects' | 'intro' | 'location' | 'latest/activity' | 'latest/track'>;
-}
+type Props = Page<'projects' | 'intro' | 'location' | 'latest/activity' | 'latest/track'>;
 
 /**
- * Grabs all data necessary to render all components on the homepage to
- * provide a fallback for the server side rendering done elsewhere.
+ * Grabs fallback data + page url
  */
-export const getStaticProps: GetStaticProps<Props> = async () => {
+export const getServerSideProps: GetServerSideProps<Props> = async (context) => {
+  const pageUrl = getPageUrl(context);
   const data = await fetchFallback([
     'version',
     'footer',
@@ -28,6 +24,7 @@ export const getStaticProps: GetStaticProps<Props> = async () => {
   ]);
   return {
     props: {
+      pageUrl,
       fallback: {
         ...data,
       },
@@ -38,9 +35,9 @@ export const getStaticProps: GetStaticProps<Props> = async () => {
 /**
  * Fallback for all data used in Homepage + its descendents, plus the homepage itself.
  */
-const Home = ({ fallback }: InferGetStaticPropsType<typeof getStaticProps>) => (
-  <PageLayout fallback={fallback}>
-    <Homepage />
+const Home = ({ fallback, pageUrl }: Props) => (
+  <PageLayout fallback={fallback} pageUrl={pageUrl}>
+    <Homepage pageUrl={pageUrl} />
   </PageLayout>
 );
 

--- a/src/pages/privacy.tsx
+++ b/src/pages/privacy.tsx
@@ -1,25 +1,22 @@
-import type { PartialFallback } from 'api/fetchFallback';
 import fetchFallback from 'api/fetchFallback';
 import PageLayout from 'components/layouts/PageLayout';
 import Privacy from 'components/privacy/Privacy';
-import { GetStaticProps, InferGetStaticPropsType } from 'next/types';
+import { GetServerSideProps } from 'next/types';
 import React from 'react';
+import type { Page } from 'types/Page';
+import getPageUrl from '../helpers/getPageUrl';
 
-interface Props {
-  /**
-   * Provides SWR with fallback version data
-   */
-  fallback: PartialFallback<'privacy'>;
-}
+type Props = Page<'privacy'>;
 
 /**
- * Grabs all data necessary to render all components on the privacy page to
- * provide a fallback for the server side rendering done elsewhere.
+ * Grabs fallback data + page url
  */
-export const getStaticProps: GetStaticProps<Props> = async () => {
+export const getServerSideProps: GetServerSideProps<Props> = async (context) => {
+  const pageUrl = getPageUrl(context);
   const data = await fetchFallback(['footer', 'version', 'privacy']);
   return {
     props: {
+      pageUrl,
       fallback: {
         ...data,
       },
@@ -30,9 +27,9 @@ export const getStaticProps: GetStaticProps<Props> = async () => {
 /**
  * Fallback for all data used in privacy page + its descendents
  */
-const PrivacyPage = ({ fallback }: InferGetStaticPropsType<typeof getStaticProps>) => (
-  <PageLayout fallback={fallback}>
-    <Privacy />
+const PrivacyPage = ({ fallback, pageUrl }: Props) => (
+  <PageLayout fallback={fallback} pageUrl={pageUrl}>
+    <Privacy pageUrl={pageUrl} />
   </PageLayout>
 );
 

--- a/src/types/Page.ts
+++ b/src/types/Page.ts
@@ -1,0 +1,17 @@
+import type { EndpointKey } from 'api/endpoints';
+import type { PartialFallback } from 'api/fetchFallback';
+
+/**
+ * Types a Page itself (in pages directory)
+ */
+export type Page<Key extends EndpointKey = 'version'> = {
+  /**
+   * Provides SWR with fallback version data
+   */
+  fallback: PartialFallback<Key>;
+
+  /**
+   * Full page url for use in Meta
+   */
+  pageUrl: string;
+};


### PR DESCRIPTION
# Description of changes

1. Tries to fix render mismatch with timestamps set via useEffect
2. Adds images into meta by swapping to SSR and not using an effect. If it's slow I can hardcode the urls and swap back to static rendering

Followup to #318 