### PR TITLE
fix the release query from Github

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
             prodRun="--prod"
           fi
           echo "Latest tag: ${LATEST_TAG}"
-          npx vercel --token ${VERCEL_DEPLOY_TOKEN} $prodRun --build-env NEXT_PUBLIC_VERSION=${LATEST_TAG} --build-env NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA=${GITHUB_SHA} --env NEXT_PUBLIC_VERSION=${LATEST_TAG} --env NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA=${GITHUB_SHA}
+          npx vercel --token ${VERCEL_DEPLOY_TOKEN} $prodRun -b NEXT_PUBLIC_VERSION="${LATEST_TAG}" -b NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA="${GITHUB_SHA}" -e NEXT_PUBLIC_VERSION="${LATEST_TAG}" -e NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA="${GITHUB_SHA}"
         env:
           LATEST_TAG: ${{ steps.latest-version-tag.outputs.tag }}
           VERCEL_DEPLOY_TOKEN: ${{ secrets.VERCEL_DEPLOY_TOKEN }}

--- a/src/api/server/fetchGithubRepoVersion.ts
+++ b/src/api/server/fetchGithubRepoVersion.ts
@@ -26,6 +26,7 @@ const QUERY = gql`
 const fetchGithubRepoVersion = async () => {
   if (process.env.NEXT_PUBLIC_APP_VERSION && process.env.NEXT_PUBLIC_APP_VERSION.length) {
     // Quicker short circuit for when this value exists
+    console.log('Using NEXT_PUBLIC_APP_VERSION', process.env.NEXT_PUBLIC_APP_VERSION);
     return process.env.NEXT_PUBLIC_APP_VERSION;
   }
 
@@ -40,6 +41,14 @@ const fetchGithubRepoVersion = async () => {
   const filteredReleases =
     releases?.filter((release) => release?.tagCommit?.oid === commitSha?.trim()) ?? [];
   // If we have a release that matched, return it, otherwise a fallback
+  console.log(
+    'Fetched filtered releases',
+    filteredReleases[0]?.name,
+    'numReleases',
+    releases?.length,
+    'looking for',
+    commitSha?.trim(),
+  );
   return filteredReleases[0]?.name ?? 'vX.Y.Z';
 };
 

--- a/src/api/server/fetchGithubRepoVersion.ts
+++ b/src/api/server/fetchGithubRepoVersion.ts
@@ -5,7 +5,7 @@ import githubClient from './networkClients/githubClient';
 const QUERY = gql`
   query GithubRepoVersion {
     repository(name: "dg", owner: "dgattey") {
-      releases(last: 100) {
+      releases(first: 10, orderBy: { field: CREATED_AT, direction: DESC }) {
         nodes {
           name
           tagCommit {
@@ -26,7 +26,6 @@ const QUERY = gql`
 const fetchGithubRepoVersion = async () => {
   if (process.env.NEXT_PUBLIC_APP_VERSION && process.env.NEXT_PUBLIC_APP_VERSION.length) {
     // Quicker short circuit for when this value exists
-    console.log(`Using NEXT_PUBLIC_APP_VERSION! "${process.env.NEXT_PUBLIC_APP_VERSION}"`);
     return process.env.NEXT_PUBLIC_APP_VERSION;
   }
 
@@ -41,9 +40,6 @@ const fetchGithubRepoVersion = async () => {
   const filteredReleases =
     releases?.filter((release) => release?.tagCommit?.oid === commitSha?.trim()) ?? [];
   // If we have a release that matched, return it, otherwise a fallback
-  console.log(`Commit SHA: ${commitSha}, filtered releases: ${filteredReleases.length}`);
-  console.log(`All releases: ${JSON.stringify(releases, null, 2)}`);
-  console.log(`All filtered releases: ${JSON.stringify(filteredReleases, null, 2)}`);
   return filteredReleases[0]?.name ?? 'vX.Y.Z';
 };
 

--- a/src/api/server/fetchGithubRepoVersion.ts
+++ b/src/api/server/fetchGithubRepoVersion.ts
@@ -26,7 +26,7 @@ const QUERY = gql`
 const fetchGithubRepoVersion = async () => {
   if (process.env.NEXT_PUBLIC_APP_VERSION && process.env.NEXT_PUBLIC_APP_VERSION.length) {
     // Quicker short circuit for when this value exists
-    console.log('Using NEXT_PUBLIC_APP_VERSION', process.env.NEXT_PUBLIC_APP_VERSION);
+    console.log(`Using NEXT_PUBLIC_APP_VERSION! "${process.env.NEXT_PUBLIC_APP_VERSION}"`);
     return process.env.NEXT_PUBLIC_APP_VERSION;
   }
 
@@ -41,14 +41,9 @@ const fetchGithubRepoVersion = async () => {
   const filteredReleases =
     releases?.filter((release) => release?.tagCommit?.oid === commitSha?.trim()) ?? [];
   // If we have a release that matched, return it, otherwise a fallback
-  console.log(
-    'Fetched filtered releases',
-    filteredReleases[0]?.name,
-    'numReleases',
-    releases?.length,
-    'looking for',
-    commitSha?.trim(),
-  );
+  console.log(`Commit SHA: ${commitSha}, filtered releases: ${filteredReleases.length}`);
+  console.log(`All releases: ${JSON.stringify(releases, null, 2)}`);
+  console.log(`All filtered releases: ${JSON.stringify(filteredReleases, null, 2)}`);
   return filteredReleases[0]?.name ?? 'vX.Y.Z';
 };
 


### PR DESCRIPTION
# Description of changes

Looks like now that I've got over 100 releases, the query wasn't right. Changes it to order by creation time and trims down to the first 10 by creation time.