### PR TITLE
Smaller images (1.2mb -> 260kb), color scheme correctly shows init state

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "sequelize-typescript": "2.1.5",
     "sharp": "0.31.2",
     "swr": "1.3.0",
+    "use-breakpoint": "3.0.5",
     "webpack": "5.75.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,7 @@ importers:
       swr: 1.3.0
       tsm: 2.3.0
       typescript: 4.9.3
+      use-breakpoint: 3.0.5
       webpack: 5.75.0
     dependencies:
       '@contentful/rich-text-react-renderer': 15.16.2_biqbaboplfbrettd7655fr4n2y
@@ -103,6 +104,7 @@ importers:
       sequelize-typescript: 2.1.5_aiyi63tymuoswvw7q5qly6smra
       sharp: 0.31.2
       swr: 1.3.0_react@18.2.0
+      use-breakpoint: 3.0.5_biqbaboplfbrettd7655fr4n2y
       webpack: 5.75.0
     devDependencies:
       '@graphql-codegen/cli': 2.15.0_tvkadjl7ayclhi6f3ud5lprnka
@@ -8241,6 +8243,17 @@ packages:
   /url-join/4.0.1:
     resolution: {integrity: sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==}
     dev: true
+
+  /use-breakpoint/3.0.5_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-zr5g7sLDx3Q1pFUIcpmvqy6rijlDx1U+hpU+kEpkiUtpgarhl+OZpvVx8UA0oV9ecjsING1V5q34B3jgs0/C2w==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+    dev: false
 
   /util-deprecate/1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}

--- a/src/api/server/fetchContentfulIntroBlock.ts
+++ b/src/api/server/fetchContentfulIntroBlock.ts
@@ -1,7 +1,11 @@
 import { isTextBlock } from 'api/parsers';
 import type { IntroBlockQuery } from 'api/types/generated/fetchContentfulIntroBlock.generated';
+import { PROJECT_MAX_IMAGE_DIMENSION } from 'constants/imageSizes';
 import { gql } from 'graphql-request';
 import { contentfulClient } from './networkClients/contentfulClient';
+
+// Account for pixel density
+const IMAGE_SIZE = PROJECT_MAX_IMAGE_DIMENSION * 2;
 
 /**
  * Grabs the contentful sections with the title of header. Should
@@ -10,7 +14,11 @@ import { contentfulClient } from './networkClients/contentfulClient';
 const QUERY = gql`
   query IntroBlock {
     asset(id: "1P5peDFKfzDHjWd6mcytc8") {
-      url
+      url(transform: {
+        width: ${IMAGE_SIZE}
+        height: ${IMAGE_SIZE}
+        format: WEBP
+      })
       width
       height
       title

--- a/src/api/server/fetchContentfulLocation.ts
+++ b/src/api/server/fetchContentfulLocation.ts
@@ -1,8 +1,15 @@
 import { isDefinedItem } from 'api/parsers';
 import type { MyLocationQuery } from 'api/types/generated/fetchContentfulLocation.generated';
 import type { MapLocation } from 'api/types/MapLocation';
+import { MAP_MARKER_IMAGE_SIZE, PROJECT_MAX_IMAGE_DIMENSION } from 'constants/imageSizes';
 import { gql } from 'graphql-request';
 import { contentfulClient } from './networkClients/contentfulClient';
+
+// To account for pixel density, we need double the size!
+const IMAGE_SIZE = MAP_MARKER_IMAGE_SIZE * 2;
+
+// The preview image is a standard project size
+const PREVIEW_IMAGE_SIZE = PROJECT_MAX_IMAGE_DIMENSION * 2;
 
 /**
  * Grabs the home location using a known id for it
@@ -17,16 +24,30 @@ const QUERY = gql`
       initialZoom
       zoomLevels
       image {
-        url
+        url(transform: { 
+          width: ${IMAGE_SIZE}, 
+          height: ${IMAGE_SIZE},
+          format: WEBP
+        })
         width
         height
       }
     }
     lightImage: asset(id: "5PrFVu1gJBLhgJGixRL4Wc") {
-      url
+      url(transform: { 
+          width: ${PREVIEW_IMAGE_SIZE}, 
+          height: ${PREVIEW_IMAGE_SIZE},
+          quality: 80,
+          format: WEBP
+        })
     }
     darkImage: asset(id: "6bRgM9lkcceJQOE0jSOEfu") {
-      url
+      url(transform: { 
+          width: ${PREVIEW_IMAGE_SIZE}, 
+          height: ${PREVIEW_IMAGE_SIZE},
+          quality: 80,
+          format: WEBP
+        })
     }
   }
 `;

--- a/src/api/server/fetchContentfulPrivacyBlock.ts
+++ b/src/api/server/fetchContentfulPrivacyBlock.ts
@@ -35,7 +35,7 @@ const QUERY = gql`
                 sys {
                   id
                 }
-                url
+                url(transform: { width: 640, height: 640, format: WEBP })
                 title
                 width
                 height

--- a/src/api/server/fetchContentfulProjects.ts
+++ b/src/api/server/fetchContentfulProjects.ts
@@ -18,7 +18,7 @@ const QUERY = gql`
         }
         layout
         thumbnail {
-          url
+          url(transform: { quality: 90, format: WEBP })
           width
           height
         }

--- a/src/components/ColorSchemeContext.tsx
+++ b/src/components/ColorSchemeContext.tsx
@@ -5,8 +5,10 @@ import { createContext } from 'react';
  * Provides app-wide color scheme data with dummy data to start it out
  */
 export const ColorSchemeContext = createContext<ReturnType<typeof useColorScheme>>({
-  colorScheme: 'light',
-  isInitializedWithSystemScheme: false,
-  isSystemScheme: false,
-  updatePreferredScheme: () => false,
+  colorScheme: {
+    mode: 'light',
+    isInitialized: false,
+    isCustomized: false,
+  },
+  updatePreferredMode: () => false,
 });

--- a/src/components/RichText.tsx
+++ b/src/components/RichText.tsx
@@ -4,6 +4,7 @@ import { BLOCKS, INLINES } from '@contentful/rich-text-types';
 import { isDefinedItem, isLink, isProject } from 'api/parsers';
 import type { Asset, Entry, TextBlockContent } from 'api/types/generated/contentfulApi.generated';
 import { ProjectCard } from 'components/homepage/ProjectCard';
+import { PROJECT_MAX_IMAGE_DIMENSION } from 'constants/imageSizes';
 import { Image } from './Image';
 import { Link } from './Link';
 
@@ -57,7 +58,16 @@ function AssetElement({ data, assetMap }: { data: NodeData; assetMap: Map<string
     return null;
   }
   const asset = assetMap.get(data.target.sys.id);
-  return asset ? <Image {...asset} alt={asset.title ?? 'Image title'} /> : null;
+  return asset ? (
+    <Image
+      {...asset}
+      alt={asset.title ?? 'Image title'}
+      sizes={{
+        // We don't have any images to test this with, but it should be big enough for most cases...
+        extraLarge: PROJECT_MAX_IMAGE_DIMENSION,
+      }}
+    />
+  ) : null;
 }
 
 /**

--- a/src/components/homepage/ColorSchemeIcon.tsx
+++ b/src/components/homepage/ColorSchemeIcon.tsx
@@ -1,29 +1,21 @@
-import type { ColorScheme, SetColorScheme } from 'hooks/useColorScheme';
+import type { ColorSchemeMode } from 'hooks/useColorScheme';
 import { Moon, Sun } from 'lucide-react';
 import styled from '@emotion/styled';
 import { css } from '@emotion/react';
+import { ColorSchemeContext } from 'components/ColorSchemeContext';
+import { useContext } from 'react';
 
-interface Props {
+interface ColorSchemeIconProps {
   /**
-   * The color to switch to on click
+   * The color scheme mode to switch to on click
    */
-  scheme: ColorScheme;
-
-  /**
-   * If there's a theme and we want to allow clicks
-   */
-  hasTheme: boolean;
-
-  /**
-   * Function to change the user preferred scheme
-   */
-  updatePreferredScheme: SetColorScheme;
+  mode: ColorSchemeMode;
 }
 
 /**
  * Tooltips for the different states
  */
-const TOOLTIPS: Record<ColorScheme, string> = {
+const TOOLTIPS: Record<ColorSchemeMode, string> = {
   dark: 'Lights out',
   light: 'Sunny days!',
 } as const;
@@ -31,7 +23,7 @@ const TOOLTIPS: Record<ColorScheme, string> = {
 /**
  * Maps color scheme to icon element
  */
-const COLORED_ICONS: Record<ColorScheme, JSX.Element> = {
+const COLORED_ICONS: Record<ColorSchemeMode, JSX.Element> = {
   dark: <Moon color="var(--secondary)" size="1em" />,
   light: <Sun color="var(--yellow)" size="1em" />,
 };
@@ -39,7 +31,7 @@ const COLORED_ICONS: Record<ColorScheme, JSX.Element> = {
 /**
  * Uncolored icons for use elsewhere
  */
-export const ICONS: Record<ColorScheme, JSX.Element> = {
+export const ICONS: Record<ColorSchemeMode, JSX.Element> = {
   dark: <Moon size="1em" />,
   light: <Sun size="1em" />,
 };
@@ -71,14 +63,15 @@ const IconWrapper = styled.span<{ $disabled: boolean }>`
  * Creates an icon that is clickable to update to a preferred color scheme
  * if we have one that's set already. Otherwise, renders a disabled icon.
  */
-export function ColorSchemeIcon({ scheme, hasTheme, updatePreferredScheme }: Props) {
+export function ColorSchemeIcon({ mode }: ColorSchemeIconProps) {
+  const { colorScheme, updatePreferredMode } = useContext(ColorSchemeContext);
   return (
     <IconWrapper
-      $disabled={!hasTheme}
-      onClick={hasTheme ? () => updatePreferredScheme(scheme) : undefined}
-      data-tooltip={hasTheme ? TOOLTIPS[scheme] : undefined}
+      $disabled={!colorScheme.isInitialized}
+      onClick={colorScheme.isInitialized ? () => updatePreferredMode(mode) : undefined}
+      data-tooltip={colorScheme.isInitialized ? TOOLTIPS[mode] : undefined}
     >
-      {COLORED_ICONS[scheme]}
+      {COLORED_ICONS[mode]}
     </IconWrapper>
   );
 }

--- a/src/components/homepage/ColorSchemeToggleCard.tsx
+++ b/src/components/homepage/ColorSchemeToggleCard.tsx
@@ -1,7 +1,7 @@
 import { ColorSchemeContext } from 'components/ColorSchemeContext';
 import { ContentCard } from 'components/ContentCard';
 import { Stack } from 'components/Stack';
-import { ColorScheme } from 'hooks/useColorScheme';
+import { ColorSchemeMode } from 'hooks/useColorScheme';
 import { useContext } from 'react';
 import styled from '@emotion/styled';
 import { css } from '@emotion/react';
@@ -29,16 +29,16 @@ const ContentStack = styled(Stack)`
 `;
 
 // Provides color scheme specific variable names for the switch - unknown is basically just server-rendered
-const SWITCH_COLOR_SCHEME_CSS: Record<ColorScheme | 'unknown', string> = {
+const SWITCH_COLOR_SCHEME_CSS: Record<ColorSchemeMode | 'unknown', string> = {
   unknown: '--secondary',
   light: '--yellow',
   dark: '--navy',
 };
 
-// Combo of CSS + $colorScheme to set two separate states, using a lot of Pico CSS switch variables
-const ColorSchemeSwitch = styled.input<{ $colorScheme: ColorScheme | null }>(
-  ({ $colorScheme }) => css`
-    --switch-background-color: var(${SWITCH_COLOR_SCHEME_CSS[$colorScheme ?? 'unknown']});
+// Combo of CSS + color scheme mode to set two separate states, using a lot of Pico CSS switch variables
+const ColorSchemeSwitch = styled.input<{ $colorSchemeMode: ColorSchemeMode | null }>(
+  ({ $colorSchemeMode }) => css`
+    --switch-background-color: var(${SWITCH_COLOR_SCHEME_CSS[$colorSchemeMode ?? 'unknown']});
     && {
       --border-width: 6px;
       --switch-height: 2em;
@@ -89,48 +89,35 @@ const Button = styled.button<{ $visible: boolean }>`
 
 /**
  * Provides the ability to toggle the page's color scheme between
- * system, light, and dark. Prerendered, `colorScheme` is `light`
- * and `isSystemScheme` is true.
+ * system, light, and dark. Prerendered, `mode` is `light`.
  */
 export function ColorSchemeToggleCard() {
-  const {
-    colorScheme,
-    isSystemScheme,
-    isInitializedWithSystemScheme: hasTheme,
-    updatePreferredScheme,
-  } = useContext(ColorSchemeContext);
-  const setInvertedScheme = () => updatePreferredScheme(colorScheme === 'dark' ? 'light' : 'dark');
-  const clearSavedScheme = () => updatePreferredScheme(null);
+  const { colorScheme, updatePreferredMode } = useContext(ColorSchemeContext);
+  const setInvertedScheme = () =>
+    updatePreferredMode(colorScheme.mode === 'dark' ? 'light' : 'dark');
+  const clearSavedMode = () => updatePreferredMode(null);
 
   return (
     <Card>
       <div>
         <ContentStack $gap="1em">
-          <ColorSchemeIcon
-            scheme="light"
-            hasTheme={hasTheme}
-            updatePreferredScheme={updatePreferredScheme}
-          />
+          <ColorSchemeIcon mode="light" />
           <ColorSchemeSwitch
-            disabled={!hasTheme}
-            $colorScheme={!hasTheme ? null : colorScheme}
+            disabled={!colorScheme.isInitialized}
+            $colorSchemeMode={colorScheme.isInitialized ? colorScheme.mode : null}
             onChange={setInvertedScheme}
-            checked={hasTheme && colorScheme === 'dark'}
+            checked={colorScheme.isInitialized && colorScheme.mode === 'dark'}
             role="switch"
             type="checkbox"
           />
-          <ColorSchemeIcon
-            scheme="dark"
-            hasTheme={hasTheme}
-            updatePreferredScheme={updatePreferredScheme}
-          />
+          <ColorSchemeIcon mode="dark" />
         </ContentStack>
         <Button
           role="button"
           className="secondary outline"
-          disabled={isSystemScheme}
-          onClick={clearSavedScheme}
-          $visible={!isSystemScheme}
+          disabled={!colorScheme.isCustomized}
+          onClick={clearSavedMode}
+          $visible={colorScheme.isCustomized}
         >
           <small>Reset to system theme</small>
         </Button>

--- a/src/components/homepage/IntroCard.tsx
+++ b/src/components/homepage/IntroCard.tsx
@@ -6,6 +6,7 @@ import { RichText } from 'components/RichText';
 import { useLinkWithName } from 'hooks/useLinkWithName';
 import { useState } from 'react';
 import styled from '@emotion/styled';
+import { PROJECT_IMAGE_SIZES, PROJECT_MAX_IMAGE_DIMENSION } from 'constants/imageSizes';
 
 const ImageCard = styled(ContentCard)`
   @media (max-width: 767.96px) {
@@ -61,9 +62,12 @@ export function IntroCard() {
       >
         <HoverableContainer isHovered={isHovered}>
           <Image
-            {...introBlock.image}
+            url={introBlock.image.url}
+            width={PROJECT_MAX_IMAGE_DIMENSION}
+            height={PROJECT_MAX_IMAGE_DIMENSION}
             alt={introBlock.image.title ?? 'Introduction image'}
             priority
+            sizes={PROJECT_IMAGE_SIZES}
           />
         </HoverableContainer>
       </ImageCard>

--- a/src/components/homepage/MapPreviewCard.tsx
+++ b/src/components/homepage/MapPreviewCard.tsx
@@ -19,9 +19,11 @@ export function MapPreviewCard({ turnOnAnimation }: MapPreviewCardProps) {
   const { data: location } = useData('location');
   const { colorScheme } = useContext(ColorSchemeContext);
   const [showFullMapComponent, setShowFullMapComponent] = useState(false);
+
   const backgroundImageUrl =
-    (colorScheme === 'light' ? location?.backupImageUrls.light : location?.backupImageUrls.dark) ??
-    null;
+    (colorScheme.mode === 'light'
+      ? location?.backupImageUrls.light
+      : location?.backupImageUrls.dark) ?? null;
 
   // Loads the full map card on hover
   const previewCard = (

--- a/src/components/homepage/ProjectCard.tsx
+++ b/src/components/homepage/ProjectCard.tsx
@@ -3,16 +3,22 @@ import type { ContentCardProps } from 'components/ContentCard';
 import { ContentCard } from 'components/ContentCard';
 import { cardSize } from 'components/ContentGrid';
 import { HoverableContainer } from 'components/HoverableContainer';
-import { Image } from 'components/Image';
 import { useState } from 'react';
 import styled from '@emotion/styled';
+import {
+  BREAKPOINTS_MIN_SIZES,
+  PROJECT_2X_IMAGE_SIZES,
+  PROJECT_IMAGE_SIZES,
+} from 'constants/imageSizes';
+import useBreakpoint from 'use-breakpoint';
+import { Image } from 'components/Image';
 
 type Props = Project & Pick<ContentCardProps, 'turnOnAnimation'>;
 
 // Ensure on mobile, all cards are uniform height (small in height)
 const Card = styled(ContentCard)`
   @media (max-width: 767.99px) {
-    max-height: ${cardSize(0.67)};
+    max-height: ${cardSize(1)};
   }
 `;
 
@@ -23,6 +29,9 @@ export function ProjectCard({ title, layout, link, thumbnail, turnOnAnimation }:
   const verticalSpan = layout === 'tall' ? 2 : 1;
   const horizontalSpan = layout === 'wide' ? 2 : 1;
   const [isHovered, setIsHovered] = useState(false);
+  const { breakpoint } = useBreakpoint(BREAKPOINTS_MIN_SIZES, 'large');
+  const width =
+    horizontalSpan === 1 ? PROJECT_IMAGE_SIZES[breakpoint] : PROJECT_2X_IMAGE_SIZES[breakpoint];
 
   return (
     <Card
@@ -36,7 +45,17 @@ export function ProjectCard({ title, layout, link, thumbnail, turnOnAnimation }:
     >
       {thumbnail && (
         <HoverableContainer isHovered={isHovered}>
-          <Image {...thumbnail} alt={title ?? 'Project image'} />
+          <Image
+            url={thumbnail.url}
+            width={width}
+            height={
+              verticalSpan === 1
+                ? PROJECT_IMAGE_SIZES[breakpoint]
+                : PROJECT_2X_IMAGE_SIZES[breakpoint]
+            }
+            alt={title ?? 'Project image'}
+            sizes={PROJECT_IMAGE_SIZES}
+          />
         </HoverableContainer>
       )}
     </Card>

--- a/src/components/maps/Map.tsx
+++ b/src/components/maps/Map.tsx
@@ -153,7 +153,7 @@ export function Map({ location, children, isExpanded, isLoaded, setMapHasLoaded 
         interactive
         pitchWithRotate={false}
         touchPitch={false}
-        mapStyle={colorScheme === 'dark' ? DARK_STYLE : LIGHT_STYLE}
+        mapStyle={colorScheme.mode === 'dark' ? DARK_STYLE : LIGHT_STYLE}
         styleDiffing={false}
         mapboxAccessToken={process.env.NEXT_PUBLIC_MAPBOX_TOKEN}
         onLoad={setMapHasLoaded}

--- a/src/components/maps/Marker.tsx
+++ b/src/components/maps/Marker.tsx
@@ -2,10 +2,11 @@ import type { MapLocation } from 'api/types/MapLocation';
 import { Image } from 'components/Image';
 import { Marker as MapMarker } from 'react-map-gl';
 import styled from '@emotion/styled';
+import { MAP_MARKER_IMAGE_SIZE } from 'constants/imageSizes';
 
 const DIMENSION = 100;
 const RADIUS = DIMENSION / 2;
-const IMAGE_DIMENSION = DIMENSION * 0.85;
+const IMAGE_DIMENSION = MAP_MARKER_IMAGE_SIZE;
 
 // Required point, optional image
 type MarkerProps = Pick<MapLocation, 'point'> & Partial<Pick<MapLocation, 'image'>>;
@@ -51,6 +52,10 @@ export function Marker({ point, image }: MarkerProps) {
             height={IMAGE_DIMENSION}
             url={image.url}
             alt={`${point?.latitude} ${point?.longitude}`}
+            sizes={{
+              // Constant size, no need to resize
+              extraLarge: IMAGE_DIMENSION,
+            }}
           />
         </ImageContainer>
       )}

--- a/src/components/spotify/AlbumImage.tsx
+++ b/src/components/spotify/AlbumImage.tsx
@@ -6,10 +6,10 @@ import styled from '@emotion/styled';
 
 type Props = Track;
 
-// In px, the image size we want from the API. See the types for options
-const API_IMAGE_SIZE = 300;
+// In px, the max image size we want from the API. We should have this be as big as it supports, as Next can resize down.
+const API_IMAGE_SIZE = 640;
 
-// In px, how big our rendered image is at maximum
+// In px, how big our rendered image is. Next resizes the API image to this constant size.
 const IMAGE_SIZE = 150;
 
 // Slightly un-rounds the corners + makes sure it's the right size
@@ -40,7 +40,13 @@ export function AlbumImage({ name, album }: Props) {
   const albumImage = album.images.find((image) => image?.width === API_IMAGE_SIZE);
   const imageComponent = albumImage ? (
     <ImageContainer>
-      <Image alt={name} {...albumImage} width={IMAGE_SIZE} height={IMAGE_SIZE} />
+      <Image
+        alt={name}
+        {...albumImage}
+        width={IMAGE_SIZE}
+        height={IMAGE_SIZE}
+        sizes={{ extraLarge: 150 }}
+      />
     </ImageContainer>
   ) : null;
 

--- a/src/constants/imageSizes.ts
+++ b/src/constants/imageSizes.ts
@@ -1,0 +1,62 @@
+/**
+ * The max widths at each breakpoint
+ */
+export const BREAKPOINT_MAX_SIZES = {
+  extraTiny: 340,
+  tiny: 576,
+  small: 768,
+  medium: 992,
+  large: 1200,
+};
+
+/**
+ * Breakpoints from min width up - same data, just remapped
+ */
+export const BREAKPOINTS_MIN_SIZES = {
+  extraTiny: 0,
+  tiny: BREAKPOINT_MAX_SIZES.extraTiny - 1,
+  small: BREAKPOINT_MAX_SIZES.tiny - 1,
+  medium: BREAKPOINT_MAX_SIZES.small - 1,
+  large: BREAKPOINT_MAX_SIZES.medium - 1,
+  extraLarge: BREAKPOINT_MAX_SIZES.large - 1,
+};
+
+/**
+ * We use this both to request data and display it on map, and we
+ * have a constant size for the map marker.
+ */
+export const MAP_MARKER_IMAGE_SIZE = 85;
+
+/**
+ * Currently, the largest image we ever try to display for a
+ * project's square image is 328x328px. This is still the max
+ * dimension for a non-square image on its shorter axis.
+ */
+export const PROJECT_MAX_IMAGE_DIMENSION = 330;
+
+/**
+ * These sizes connect breakpoints with the standard
+ * 1x image width up from that breakpoint to the next one.
+ * If sizing of the project cards change, this will need to!
+ */
+export const PROJECT_IMAGE_SIZES = {
+  extraTiny: 340,
+  tiny: 543,
+  small: 510,
+  medium: 297,
+  large: 313.5,
+  extraLarge: PROJECT_MAX_IMAGE_DIMENSION,
+} as const;
+
+/**
+ * These sizes connect breakpoints with the size of a two-wide
+ * project at that breakpoint.
+ */
+export const PROJECT_2X_IMAGE_SIZES = {
+  extraTiny: 340,
+  tiny: 543,
+  small: 510,
+  medium: 657,
+  large: 693.5,
+  extraLarge: 730,
+} as const;


### PR DESCRIPTION
# Description of changes

Fully taking advantage of Next's image sizing for way better load sizes on mobile/desktop, plus color scheme now init properly.