### PR TITLE
Add basic turbo config, but don't enable running in repo yet

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "semantic-release": "19.0.5",
     "sequelize-cli": "6.5.2",
     "tsm": "2.3.0",
+    "turbo": "1.6.3",
     "typescript": "4.9.3"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,6 +67,7 @@ importers:
       sharp: 0.31.2
       swr: 1.3.0
       tsm: 2.3.0
+      turbo: 1.6.3
       typescript: 4.9.3
       use-breakpoint: 3.0.5
       webpack: 5.75.0
@@ -137,6 +138,7 @@ importers:
       semantic-release: 19.0.5
       sequelize-cli: 6.5.2
       tsm: 2.3.0
+      turbo: 1.6.3
       typescript: 4.9.3
 
   src/api/server/generated:
@@ -7967,6 +7969,67 @@ packages:
     dependencies:
       safe-buffer: 5.2.1
     dev: false
+
+  /turbo-darwin-64/1.6.3:
+    resolution: {integrity: sha512-QmDIX0Yh1wYQl0bUS0gGWwNxpJwrzZU2GIAYt3aOKoirWA2ecnyb3R6ludcS1znfNV2MfunP+l8E3ncxUHwtjA==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /turbo-darwin-arm64/1.6.3:
+    resolution: {integrity: sha512-75DXhFpwE7CinBbtxTxH08EcWrxYSPFow3NaeFwsG8aymkWXF+U2aukYHJA6I12n9/dGqf7yRXzkF0S/9UtdyQ==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /turbo-linux-64/1.6.3:
+    resolution: {integrity: sha512-O9uc6J0yoRPWdPg9THRQi69K6E2iZ98cRHNvus05lZbcPzZTxJYkYGb5iagCmCW/pq6fL4T4oLWAd6evg2LGQA==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /turbo-linux-arm64/1.6.3:
+    resolution: {integrity: sha512-dCy667qqEtZIhulsRTe8hhWQNCJO0i20uHXv7KjLHuFZGCeMbWxB8rsneRoY+blf8+QNqGuXQJxak7ayjHLxiA==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /turbo-windows-64/1.6.3:
+    resolution: {integrity: sha512-lKRqwL3mrVF09b9KySSaOwetehmGknV9EcQTF7d2dxngGYYX1WXoQLjFP9YYH8ZV07oPm+RUOAKSCQuDuMNhiA==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /turbo-windows-arm64/1.6.3:
+    resolution: {integrity: sha512-BXY1sDPEA1DgPwuENvDCD8B7Hb0toscjus941WpL8CVd10hg9pk/MWn9CNgwDO5Q9ks0mw+liDv2EMnleEjeNA==}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /turbo/1.6.3:
+    resolution: {integrity: sha512-FtfhJLmEEtHveGxW4Ye/QuY85AnZ2ZNVgkTBswoap7UMHB1+oI4diHPNyqrQLG4K1UFtCkjOlVoLsllUh/9QRw==}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      turbo-darwin-64: 1.6.3
+      turbo-darwin-arm64: 1.6.3
+      turbo-linux-64: 1.6.3
+      turbo-linux-arm64: 1.6.3
+      turbo-windows-64: 1.6.3
+      turbo-windows-arm64: 1.6.3
+    dev: true
 
   /type-check/0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "globalDependencies": [
+    ".env*",
+    "config/database.config.js",
+    "config/eslint.config.js",
+    "config/lint-staged.config.mjs",
+    ".node-version",
+    ".npmrc",
+    ".sequelizerc",
+    ".pretterrc.js",
+    ".pretterignore",
+    "codegen.js",
+    "next.config.js",
+    "tsconfig.json"
+  ],
+  "globalEnv": [
+    "NEXT_PUBLIC_MAPBOX_TOKEN",
+    "CONTENTFUL_SPACE_ID",
+    "CONTENTFUL_ACCESS_TOKEN",
+    "GITHUB_AUTHENTICATION_TOKEN",
+    "CONTENTFUL_SPACE_ID",
+    "DATABASE_URL",
+    "WEBHOOK_CALLBACK_URL",
+    "STRAVA_CLIENT_ID",
+    "STRAVA_CLIENT_SECRET",
+    "STRAVA_TOKEN_NAME",
+    "STRAVA_VERIFY_TOKEN",
+    "SPOTIFY_CLIENT_ID",
+    "SPOTIFY_CLIENT_SECRET",
+    "SENTRY_AUTH_TOKEN",
+    "NEXT_PUBLIC_SENTRY_DSN"
+  ],
+  "pipeline": {
+    "dev": {
+      "inputs": ["src/**/*"],
+      "cache": false
+    },
+    "build": {
+      "outputs": [".next/**"]
+    },
+    "build:analyze": {
+      "outputs": [".next/**"]
+    },
+    "serve": {
+      "dependsOn": ["build"],
+      "cache": false
+    },
+    "release": {
+      "dependsOn": ["build", "lint", "lint:styles", "lint:types", "format"],
+      "cache": false
+    },
+    "format": {},
+    "lint": {
+      "outputs": []
+    },
+    "lint:types": {
+      "outputs": []
+    },
+    "codegen": {
+      "cache": false,
+      "inputs": ["src/api/server/*"],
+      "outputs": ["src/api/types/generated/*"]
+    },
+    "db": {
+      "cache": false
+    },
+    "db:migrate": {
+      "cache": false
+    },
+    "db:migrate:status": {
+      "cache": false
+    },
+    "db:migrate:undo": {
+      "cache": false
+    },
+    "db:generate": {
+      "cache": false
+    },
+    "db:connect": {
+      "cache": false
+    },
+    "webhooks": {
+      "cache": false
+    },
+    "webhooks:local": {
+      "cache": false
+    },
+    "webhooks:create": {
+      "cache": false
+    },
+    "webhooks:list": {
+      "cache": false
+    },
+    "webhooks:delete": {
+      "cache": false
+    },
+    "clean": {
+      "cache": false
+    }
+  }
+}


### PR DESCRIPTION
Closes DG-47

## What changed? Why?

Adds a basic turbo config for all tasks as authored, but requires using them with `pnpm turbo dev db:connect` (for example) right now. Will do the actual migration to using it when I finish DG-59