### PR TITLE
Bump Github actions versions

### DIFF
--- a/.github/workflows/autochecks.yml
+++ b/.github/workflows/autochecks.yml
@@ -19,13 +19,16 @@ jobs:
       format: ${{ steps.changes.outputs.format }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v2
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 7
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
-      - uses: pnpm/action-setup@v2.2.2
+          cache: 'pnpm'
       - run: pnpm install
       - name: ${{ matrix.command }}
         run: NODE_OPTIONS=--max_old_space_size=8192 pnpm turbo ${{ matrix.command }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,11 +9,16 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 7
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
-      - uses: pnpm/action-setup@v2.2.2
+          cache: 'pnpm'
       - run: pnpm install
       - name: Release new repo version
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -3,17 +3,14 @@
 .turbo
 
 # dependencies
-/node_modules
-
-# testing
-/coverage
+node_modules
 
 # next.js
-/.next/
-/out/
+.next
+out
 
 # production
-/build
+build
 
 # misc
 .DS_Store
@@ -31,4 +28,4 @@ tsconfig.tsbuildinfo
 .eslintcache
 
 # Generated files
-src/api/server/generated
+*/api/server/generated

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,5 +3,5 @@
 .vscode/
 .vercel/
 .turbo/
-node_modules/
+node_modules
 pnpm-lock.yaml

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,5 +37,12 @@
     ]
   },
   "include": ["src", "scripts", "eslint-plugin-dg", "config"],
-  "exclude": ["node_modules", "src/api/server/generated", "**/migrations/*"]
+  "exclude": [
+    "node_modules",
+    "**/*/dist",
+    "**/*/build",
+    "**/*/.next",
+    "**/api/server/generated",
+    "**/migrations"
+  ]
 }


### PR DESCRIPTION
## What changed? Why?

Just changes some ignore files for workspaces, plus bumps some versions for Github Actions so that they can better cache I think