### PR TITLE
Full URL for OG images + better sizing

### DIFF
--- a/src/components/Meta.tsx
+++ b/src/components/Meta.tsx
@@ -24,7 +24,7 @@ type Graph = Record<string, string | undefined>;
 const MAX_DESC_LENGTH = 300;
 const SITE_NAME = 'Dylan Gattey';
 export const HOMEPAGE_TITLE = 'Engineer. Problem Solver.';
-const OG_IMAGE_URL = '/api/og';
+const OG_IMAGE_URL = 'https://dylangattey.com/api/og';
 const GRAPH_PREFIXES = ['og', 'twitter'] as const;
 
 /**

--- a/src/og/OpenGraphImage.tsx
+++ b/src/og/OpenGraphImage.tsx
@@ -38,6 +38,7 @@ export function OpenGraphImage({ text, subtitle }: { text: string; subtitle: str
         display: 'flex',
         flexDirection: 'column',
         padding: 64,
+        paddingTop: 96,
         height: '100%',
         width: '100%',
         background: COLORS.DARK.DEFAULT_BACKGROUND,


### PR DESCRIPTION
Followup to #389 

## What changed? Why?
Make sure we use full URL for the OG images with good sizes for Twitter too