### PR TITLE
Optimizes usage of Github Actions

### DIFF
--- a/.github/workflows/autochecks.yml
+++ b/.github/workflows/autochecks.yml
@@ -30,7 +30,7 @@ jobs:
           node-version-file: .node-version
           cache: 'pnpm'
       - name: Get pnpm store directory
-        shell: zsh
+        shell: bash
         run: |
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
       - uses: actions/cache@v3

--- a/.github/workflows/autochecks.yml
+++ b/.github/workflows/autochecks.yml
@@ -23,10 +23,19 @@ jobs:
         with:
           fetch-depth: 0
       - uses: pnpm/action-setup@v2
+        with:
+          run_install: false
       - uses: actions/setup-node@v3
         with:
           node-version-file: .node-version
           cache: 'pnpm'
+      - uses: actions/cache@v3
+        name: Setup pnpm cache
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
       - run: pnpm install
       - name: ${{ matrix.command }}
         run: NODE_OPTIONS=--max_old_space_size=8192 pnpm turbo ${{ matrix.command }}

--- a/.github/workflows/autochecks.yml
+++ b/.github/workflows/autochecks.yml
@@ -29,6 +29,10 @@ jobs:
         with:
           node-version-file: .node-version
           cache: 'pnpm'
+      - name: Get pnpm store directory
+        shell: zsh
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
       - uses: actions/cache@v3
         name: Setup pnpm cache
         with:

--- a/.github/workflows/autochecks.yml
+++ b/.github/workflows/autochecks.yml
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   autocheck:
+    timeout-minutes: 6
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -60,6 +61,7 @@ jobs:
 
   # If anything is output, fails this job!
   fail-on-diff:
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     needs: autocheck
     if: ${{ needs.autocheck.outputs.lint || needs.autocheck.outputs.linttypes || needs.autocheck.outputs.format }}

--- a/.github/workflows/autochecks.yml
+++ b/.github/workflows/autochecks.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   autocheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,6 +17,10 @@ on:
   schedule:
     - cron: '45 18 * * 6'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           node-version-file: .node-version
           cache: 'pnpm'
       - name: Get pnpm store directory
-        shell: zsh
+        shell: bash
         run: |
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
       - uses: actions/cache@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,10 @@ jobs:
         with:
           node-version-file: .node-version
           cache: 'pnpm'
+      - name: Get pnpm store directory
+        shell: zsh
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
       - uses: actions/cache@v3
         name: Setup pnpm cache
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ concurrency:
 
 jobs:
   release:
+    timeout-minutes: 10
     name: Release
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,19 @@ jobs:
         with:
           fetch-depth: 0
       - uses: pnpm/action-setup@v2
+        with:
+          run_install: false
       - uses: actions/setup-node@v3
         with:
           node-version-file: .node-version
           cache: 'pnpm'
+      - uses: actions/cache@v3
+        name: Setup pnpm cache
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
       - run: pnpm install
       - name: Release new repo version
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   release:
     name: Release


### PR DESCRIPTION
Closes DG-93

## What changed? Why?
Adds caching + timeouts into Github actions! Best practices, minus the file filter since I don't have a good way of doing that right now. Probably need to separate jobs out per file and only install node/etc if needed?