### PR TITLE
Fix package fork of `dotenv-mono` I deleted

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "@contentful/rich-text-react-renderer": "15.17.2",
     "@contentful/rich-text-types": "16.3.0",
-    "db": "workspace:*",
     "@emotion/cache": "11.11.0",
     "@emotion/react": "11.11.1",
     "@emotion/styled": "11.11.0",
@@ -25,7 +24,8 @@
     "@mui/material": "5.14.9",
     "@next/bundle-analyzer": "13.4.19",
     "animate-css-grid": "1.5.1",
-    "dotenv-mono": "github:dgattey/dotenv-mono#dgattey--fix-priority",
+    "db": "workspace:*",
+    "dotenv-mono": "github:marcocesarato/dotenv-mono#v1.3.12",
     "graphql": "16.8.0",
     "graphql-request": "6.1.0",
     "lucide-react": "0.277.0",

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
   "private": true,
   "scripts": {
     "preinstall": "npx only-allow pnpm",
-    "postinstall": "[ $CI -ne 1 ] && true || lefthook install"
+    "postinstall": "lefthook install"
   },
   "dependencies": {
-    "dotenv-mono": "github:dgattey/dotenv-mono#dgattey--fix-priority",
+    "dotenv-mono": "github:marcocesarato/dotenv-mono#v1.3.12",
     "lefthook": "1.4.11"
   },
   "devDependencies": {

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -12,7 +12,7 @@
     "@graphql-codegen/near-operation-file-preset": "2.5.0",
     "@graphql-codegen/typescript": "4.0.1",
     "@graphql-codegen/typescript-operations": "4.0.1",
-    "dotenv-mono": "github:dgattey/dotenv-mono#dgattey--fix-priority",
+    "dotenv-mono": "github:marcocesarato/dotenv-mono#v1.3.12",
     "eslint-config-dg": "workspace:*",
     "tsconfig": "workspace:*",
     "typescript": "5.2.2"

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -12,7 +12,7 @@
     "lint:types": "tsc"
   },
   "dependencies": {
-    "dotenv-mono": "github:dgattey/dotenv-mono#dgattey--fix-priority",
+    "dotenv-mono": "github:marcocesarato/dotenv-mono#v1.3.12",
     "mysql2": "3.6.1",
     "sequelize": "6.33.0",
     "sequelize-typescript": "2.1.5"

--- a/packages/shared-core/package.json
+++ b/packages/shared-core/package.json
@@ -12,7 +12,7 @@
     "@graphql-codegen/near-operation-file-preset": "2.5.0",
     "@graphql-codegen/typescript": "4.0.1",
     "@graphql-codegen/typescript-operations": "4.0.1",
-    "dotenv-mono": "github:dgattey/dotenv-mono#dgattey--fix-priority",
+    "dotenv-mono": "github:marcocesarato/dotenv-mono#v1.3.12",
     "eslint-config-dg": "workspace:*",
     "tsconfig": "workspace:*",
     "typescript": "5.2.2"

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@graphql-codegen/cli": "5.0.0",
     "cmd-ts": "0.13.0",
-    "dotenv-mono": "github:dgattey/dotenv-mono#dgattey--fix-priority",
+    "dotenv-mono": "github:marcocesarato/dotenv-mono#v1.3.12",
     "eslint-config-dg": "workspace:*",
     "node-fetch": "3.3.2",
     "shared-core": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       dotenv-mono:
-        specifier: github:dgattey/dotenv-mono#dgattey--fix-priority
-        version: github.com/dgattey/dotenv-mono/653223d8ba5a69a8ef0a3d67133551672b9068f6
+        specifier: github:marcocesarato/dotenv-mono#v1.3.12
+        version: github.com/marcocesarato/dotenv-mono/5b0f6ed57156025046f72f2e83dc3186a5bed877
       lefthook:
         specifier: 1.4.11
         version: 1.4.11
@@ -73,8 +73,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/db
       dotenv-mono:
-        specifier: github:dgattey/dotenv-mono#dgattey--fix-priority
-        version: github.com/dgattey/dotenv-mono/653223d8ba5a69a8ef0a3d67133551672b9068f6
+        specifier: github:marcocesarato/dotenv-mono#v1.3.12
+        version: github.com/marcocesarato/dotenv-mono/5b0f6ed57156025046f72f2e83dc3186a5bed877
       graphql:
         specifier: 16.8.0
         version: 16.8.0
@@ -161,8 +161,8 @@ importers:
         specifier: 4.0.1
         version: 4.0.1(graphql@16.8.0)
       dotenv-mono:
-        specifier: github:dgattey/dotenv-mono#dgattey--fix-priority
-        version: github.com/dgattey/dotenv-mono/653223d8ba5a69a8ef0a3d67133551672b9068f6
+        specifier: github:marcocesarato/dotenv-mono#v1.3.12
+        version: github.com/marcocesarato/dotenv-mono/5b0f6ed57156025046f72f2e83dc3186a5bed877
       eslint-config-dg:
         specifier: workspace:*
         version: link:../eslint-config-dg
@@ -176,8 +176,8 @@ importers:
   packages/db:
     dependencies:
       dotenv-mono:
-        specifier: github:dgattey/dotenv-mono#dgattey--fix-priority
-        version: github.com/dgattey/dotenv-mono/653223d8ba5a69a8ef0a3d67133551672b9068f6
+        specifier: github:marcocesarato/dotenv-mono#v1.3.12
+        version: github.com/marcocesarato/dotenv-mono/5b0f6ed57156025046f72f2e83dc3186a5bed877
       mysql2:
         specifier: 3.6.1
         version: 3.6.1
@@ -249,8 +249,8 @@ importers:
         specifier: 4.0.1
         version: 4.0.1(graphql@16.8.0)
       dotenv-mono:
-        specifier: github:dgattey/dotenv-mono#dgattey--fix-priority
-        version: github.com/dgattey/dotenv-mono/653223d8ba5a69a8ef0a3d67133551672b9068f6
+        specifier: github:marcocesarato/dotenv-mono#v1.3.12
+        version: github.com/marcocesarato/dotenv-mono/5b0f6ed57156025046f72f2e83dc3186a5bed877
       eslint-config-dg:
         specifier: workspace:*
         version: link:../eslint-config-dg
@@ -272,8 +272,8 @@ importers:
         specifier: 0.13.0
         version: 0.13.0
       dotenv-mono:
-        specifier: github:dgattey/dotenv-mono#dgattey--fix-priority
-        version: github.com/dgattey/dotenv-mono/653223d8ba5a69a8ef0a3d67133551672b9068f6
+        specifier: github:marcocesarato/dotenv-mono#v1.3.12
+        version: github.com/marcocesarato/dotenv-mono/5b0f6ed57156025046f72f2e83dc3186a5bed877
       eslint-config-dg:
         specifier: workspace:*
         version: link:../eslint-config-dg
@@ -9738,10 +9738,10 @@ packages:
     resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
     dev: false
 
-  github.com/dgattey/dotenv-mono/653223d8ba5a69a8ef0a3d67133551672b9068f6:
-    resolution: {tarball: https://codeload.github.com/dgattey/dotenv-mono/tar.gz/653223d8ba5a69a8ef0a3d67133551672b9068f6}
+  github.com/marcocesarato/dotenv-mono/5b0f6ed57156025046f72f2e83dc3186a5bed877:
+    resolution: {tarball: https://codeload.github.com/marcocesarato/dotenv-mono/tar.gz/5b0f6ed57156025046f72f2e83dc3186a5bed877}
     name: dotenv-mono
-    version: 1.3.11
+    version: 1.3.12
     prepare: true
     requiresBuild: true
     dependencies:


### PR DESCRIPTION
Followup to #396 

## What changed? Why?
Just swapped where we're pulling the `dotenv-mono` repo from - not official repo since he didn't publish yet but instead from a tag.