### PR TITLE
[Releases] attempt a prebuilt deploy to fix release failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,13 @@ on:
     branches:
       - main
 
+env:
+  VERCEL_DEPLOY_TOKEN: ${{ secrets.VERCEL_DEPLOY_TOKEN }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -46,19 +53,20 @@ jobs:
         with:
           semver_only: true
         id: latest-version-tag
-      - name: Redeploy on Vercel using latest version
+
+      - name: Install Vercel CLI
+        if: ${{ steps.latest-version-tag.outputs.tag != '' }}
+        run: npm install --global vercel@latest
+      - name: Pull Vercel Environment Information
+        if: ${{ steps.latest-version-tag.outputs.tag != '' }}
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Build Project Artifacts with latest version
         if: ${{ steps.latest-version-tag.outputs.tag != '' }}
         run: |
-          prodRun=""
-          if [[ ${GITHUB_REF} == "refs/heads/main" ]]; then
-            prodRun="--prod"
-          fi
           echo "Latest tag: ${LATEST_TAG}"
-          npx vercel --token ${VERCEL_DEPLOY_TOKEN} $prodRun -b NEXT_PUBLIC_APP_VERSION="${LATEST_TAG}" -e NEXT_PUBLIC_APP_VERSION="${LATEST_TAG}"
+          vercel build --prod --token=${{ secrets.VERCEL_TOKEN }} NEXT_PUBLIC_APP_VERSION="${LATEST_TAG}" -e NEXT_PUBLIC_APP_VERSION="${LATEST_TAG}"
         env:
           LATEST_TAG: ${{ steps.latest-version-tag.outputs.tag }}
-          VERCEL_DEPLOY_TOKEN: ${{ secrets.VERCEL_DEPLOY_TOKEN }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-          TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+      - name: Deploy Project Artifacts to Vercel
+        if: ${{ steps.latest-version-tag.outputs.tag != '' }}
+        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
Closes DG-119

## What changed? Why?
Keeps building in the Github ecosystem instead of on Vercel to try to fix lefthook problems. Uses https://vercel.com/guides/how-can-i-use-github-actions-with-vercel to do so
