### PR TITLE
[Releases] fixing syntax for env variables

### DIFF
--- a/.github/workflows/autochecks.yml
+++ b/.github/workflows/autochecks.yml
@@ -10,6 +10,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+
 jobs:
   autocheck:
     timeout-minutes: 6

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,6 +21,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,5 +1,10 @@
 name: Dependabot Automerge
 on: pull_request
+
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+
 jobs:
   worker:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,14 +59,14 @@ jobs:
         run: npm install --global vercel@latest
       - name: Pull Vercel Environment Information
         if: ${{ steps.latest-version-tag.outputs.tag != '' }}
-        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel pull --yes --environment=production --token=${VERCEL_TOKEN}
       - name: Build Project Artifacts with latest version
         if: ${{ steps.latest-version-tag.outputs.tag != '' }}
         run: |
           echo "Latest tag: ${LATEST_TAG}"
-          vercel build --prod --token=${{ secrets.VERCEL_TOKEN }} NEXT_PUBLIC_APP_VERSION="${LATEST_TAG}" -e NEXT_PUBLIC_APP_VERSION="${LATEST_TAG}"
+          vercel build --prod --token=${VERCEL_TOKEN} NEXT_PUBLIC_APP_VERSION="${LATEST_TAG}" -e NEXT_PUBLIC_APP_VERSION="${LATEST_TAG}"
         env:
           LATEST_TAG: ${{ steps.latest-version-tag.outputs.tag }}
       - name: Deploy Project Artifacts to Vercel
         if: ${{ steps.latest-version-tag.outputs.tag != '' }}
-        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel deploy --prebuilt --prod --token=${VERCEL_TOKEN}

--- a/turbo.json
+++ b/turbo.json
@@ -54,7 +54,8 @@
       "persistent": true
     },
     "build": {
-      "dependsOn": ["^build", "topo", "lint", "lint:types", "format"]
+      "dependsOn": ["^build", "topo", "lint", "lint:types", "format"],
+      "outputs": [".next/**", "!.next/cache/**"]
     },
     "build:analyze": {
       "dependsOn": ["^build", "topo"],


### PR DESCRIPTION
Followup to #405 

## What changed? Why?
I think env syntax was off and turbo tokens and team were added to all workflows