### PR TITLE
[Actions + releases] speed up checkout and use v4, and make sure all commits are releases

### DIFF
--- a/.github/workflows/autochecks.yml
+++ b/.github/workflows/autochecks.yml
@@ -29,9 +29,7 @@ jobs:
       format: ${{ steps.changes.outputs.format }}
 
     steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2
         with:
           run_install: false

--- a/.github/workflows/autochecks.yml
+++ b/.github/workflows/autochecks.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   autocheck:
-    timeout-minutes: 6
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -28,26 +28,15 @@ jobs:
       linttypes: ${{ steps.changes.outputs.linttypes }}
       format: ${{ steps.changes.outputs.format }}
 
+    name: ${{ matrix.command }}
+
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2
-        with:
-          run_install: false
       - uses: actions/setup-node@v3
         with:
           node-version-file: .node-version
           cache: 'pnpm'
-      - name: Get pnpm store directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-      - uses: actions/cache@v3
-        name: Setup pnpm cache
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
       - run: pnpm install
       - name: ${{ matrix.command }}
         run: NODE_OPTIONS=--max_old_space_size=8192 pnpm turbo ${{ matrix.command }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,8 +40,7 @@ jobs:
         language: ['javascript']
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2
         with:
           run_install: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-# Releases a new version on a push to main
+# Releases a new version on a push to main + redeploys on Vercel with that version
 name: Release
 on:
   push:
@@ -18,34 +18,36 @@ concurrency:
 
 jobs:
   release:
-    timeout-minutes: 10
-    name: Release
+    timeout-minutes: 5
+    name: 'Release new version'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2
-        with:
-          run_install: false
       - uses: actions/setup-node@v3
         with:
           node-version-file: .node-version
           cache: 'pnpm'
-      - name: Get pnpm store directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-      - uses: actions/cache@v3
-        name: Setup pnpm cache
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
       - run: pnpm install
       - name: Release new repo version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm turbo release
+
+  redeploy:
+    timeout-minutes: 5
+    name: 'Redeploy with new version'
+    runs-on: ubuntu-latest
+    needs: [release]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: .node-version
+          cache: 'pnpm'
+      - run: pnpm install
+
       - uses: actions-ecosystem/action-get-latest-tag@v1
         name: Get latest version tag
         with:

--- a/.releaserc
+++ b/.releaserc
@@ -6,31 +6,22 @@
     [
       "@semantic-release/commit-analyzer",
       {
-        "preset": "angular",
         "releaseRules": [
           {
-            "type": "chore",
-            "release": "patch"
-          },
-          {
-            "type": "build",
-            "release": "patch"
-          },
-          {
-            "type": "test",
-            "release": "patch"
-          },
-          {
-            "type": "ci",
-            "release": "patch"
-          },
-          {
-            "type": "fix",
-            "release": "patch"
+            "message": "*breaking*",
+            "release": "major"
           },
           {
             "type": "feat",
             "release": "minor"
+          },
+          {
+            "message": "*feat*",
+            "release": "minor"
+          },
+          {
+            "subject": "*",
+            "release": "patch"
           }
         ],
         "parserOpts": {


### PR DESCRIPTION
Closes DG-128

## What changed? Why?
I don't actually need fetch depth anymore - there's a Github Action that fetches tags, so we don't need local tags which is I think what the fetch depth was doing. Hopefully this + v4 instead of v3 speeds it up a bit.

Also modifies names of some jobs, splits release job into two, and makes sure _all_ commits become releases with patch for all