### PR TITLE
[Dependencies] upgrade to latest dotenv-mono

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -25,7 +25,7 @@
     "@next/bundle-analyzer": "13.5.4",
     "animate-css-grid": "1.5.1",
     "db": "workspace:*",
-    "dotenv-mono": "github:marcocesarato/dotenv-mono#v1.3.12",
+    "dotenv-mono": "1.3.12",
     "graphql": "16.8.1",
     "graphql-request": "6.1.0",
     "lucide-react": "0.284.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "postinstall": "lefthook install"
   },
   "dependencies": {
-    "dotenv-mono": "github:marcocesarato/dotenv-mono#v1.3.12",
+    "dotenv-mono": "1.3.12",
     "lefthook": "1.5.1",
     "vercel": "32.4.1"
   },

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -12,7 +12,7 @@
     "@graphql-codegen/near-operation-file-preset": "3.0.0",
     "@graphql-codegen/typescript": "4.0.1",
     "@graphql-codegen/typescript-operations": "4.0.1",
-    "dotenv-mono": "github:marcocesarato/dotenv-mono#v1.3.12",
+    "dotenv-mono": "1.3.12",
     "eslint-config-dg": "workspace:*",
     "tsconfig": "workspace:*",
     "typescript": "5.2.2"

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -12,7 +12,7 @@
     "lint:types": "tsc"
   },
   "dependencies": {
-    "dotenv-mono": "github:marcocesarato/dotenv-mono#v1.3.12",
+    "dotenv-mono": "1.3.12",
     "mysql2": "3.6.1",
     "sequelize": "6.33.0",
     "sequelize-typescript": "2.1.5"

--- a/packages/shared-core/package.json
+++ b/packages/shared-core/package.json
@@ -12,7 +12,7 @@
     "@graphql-codegen/near-operation-file-preset": "3.0.0",
     "@graphql-codegen/typescript": "4.0.1",
     "@graphql-codegen/typescript-operations": "4.0.1",
-    "dotenv-mono": "github:marcocesarato/dotenv-mono#v1.3.12",
+    "dotenv-mono": "1.3.12",
     "eslint-config-dg": "workspace:*",
     "tsconfig": "workspace:*",
     "typescript": "5.2.2"

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@graphql-codegen/cli": "5.0.0",
     "cmd-ts": "0.13.0",
-    "dotenv-mono": "github:marcocesarato/dotenv-mono#v1.3.12",
+    "dotenv-mono": "1.3.12",
     "eslint-config-dg": "workspace:*",
     "node-fetch": "3.3.2",
     "shared-core": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       dotenv-mono:
-        specifier: github:marcocesarato/dotenv-mono#v1.3.12
-        version: github.com/marcocesarato/dotenv-mono/5b0f6ed57156025046f72f2e83dc3186a5bed877
+        specifier: 1.3.12
+        version: 1.3.12
       lefthook:
         specifier: 1.5.1
         version: 1.5.1
@@ -76,8 +76,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/db
       dotenv-mono:
-        specifier: github:marcocesarato/dotenv-mono#v1.3.12
-        version: github.com/marcocesarato/dotenv-mono/5b0f6ed57156025046f72f2e83dc3186a5bed877
+        specifier: 1.3.12
+        version: 1.3.12
       graphql:
         specifier: 16.8.1
         version: 16.8.1
@@ -164,8 +164,8 @@ importers:
         specifier: 4.0.1
         version: 4.0.1(graphql@16.8.1)
       dotenv-mono:
-        specifier: github:marcocesarato/dotenv-mono#v1.3.12
-        version: github.com/marcocesarato/dotenv-mono/5b0f6ed57156025046f72f2e83dc3186a5bed877
+        specifier: 1.3.12
+        version: 1.3.12
       eslint-config-dg:
         specifier: workspace:*
         version: link:../eslint-config-dg
@@ -179,8 +179,8 @@ importers:
   packages/db:
     dependencies:
       dotenv-mono:
-        specifier: github:marcocesarato/dotenv-mono#v1.3.12
-        version: github.com/marcocesarato/dotenv-mono/5b0f6ed57156025046f72f2e83dc3186a5bed877
+        specifier: 1.3.12
+        version: 1.3.12
       mysql2:
         specifier: 3.6.1
         version: 3.6.1
@@ -252,8 +252,8 @@ importers:
         specifier: 4.0.1
         version: 4.0.1(graphql@16.8.1)
       dotenv-mono:
-        specifier: github:marcocesarato/dotenv-mono#v1.3.12
-        version: github.com/marcocesarato/dotenv-mono/5b0f6ed57156025046f72f2e83dc3186a5bed877
+        specifier: 1.3.12
+        version: 1.3.12
       eslint-config-dg:
         specifier: workspace:*
         version: link:../eslint-config-dg
@@ -275,8 +275,8 @@ importers:
         specifier: 0.13.0
         version: 0.13.0
       dotenv-mono:
-        specifier: github:marcocesarato/dotenv-mono#v1.3.12
-        version: github.com/marcocesarato/dotenv-mono/5b0f6ed57156025046f72f2e83dc3186a5bed877
+        specifier: 1.3.12
+        version: 1.3.12
       eslint-config-dg:
         specifier: workspace:*
         version: link:../eslint-config-dg
@@ -4781,6 +4781,12 @@ packages:
   /dotenv-expand@10.0.0:
     resolution: {integrity: sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==}
     engines: {node: '>=12'}
+
+  /dotenv-mono@1.3.12:
+    resolution: {integrity: sha512-R99hsNcLeF49ugu6xoecZBnZY3qM2Yc6s25k3i+XbYSWQWZPlsSbPU/06tbIhRDtasINm57RLXDNF/O7rt8V5g==}
+    dependencies:
+      dotenv: 16.3.1
+      dotenv-expand: 10.0.0
 
   /dotenv@16.0.3:
     resolution: {integrity: sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==}
@@ -10886,13 +10892,3 @@ packages:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
     engines: {node: '>=12.20'}
     dev: true
-
-  github.com/marcocesarato/dotenv-mono/5b0f6ed57156025046f72f2e83dc3186a5bed877:
-    resolution: {tarball: https://codeload.github.com/marcocesarato/dotenv-mono/tar.gz/5b0f6ed57156025046f72f2e83dc3186a5bed877}
-    name: dotenv-mono
-    version: 1.3.12
-    prepare: true
-    requiresBuild: true
-    dependencies:
-      dotenv: 16.3.1
-      dotenv-expand: 10.0.0


### PR DESCRIPTION
Closes DG-120

## What changed? Why?
Moves off the github fork of dotenv-mono I'd been using for real released version