### PR TITLE
[Dependabot] set up automated PRs for pnpm dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+      
+    # Assign to Dylan explicitly
+    assignees:
+      - "dgattey"
+    reviewers:
+      - "dgattey"
+
+    # Commits start with a specific prefix and include the updated dependencies
+    commit-message:
+      prefix: "[Dependencies] "
+      include: "scope"
+
+    # Group things together if possible
+    groups:
+      all:
+        patterns:
+        - "*"
+
+    # Ensure we bump to actual latest automatically
+    versioning-strategy: increase


### PR DESCRIPTION
Closes DG-139

## What changed? Why?

Adds an explicit setup for Dependabot for updating npm packages weekly