### PR TITLE
[Releases] prevent problems with lots of branches by releasing only on main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Dry run release onto main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: pnpm turbo release -- --dry-run --branches="${{ github.ref_name }}"
+        run: pnpm turbo release -- --dry-run --branches="main, ${{ github.ref_name }}"
 
   release:
     timeout-minutes: 5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Dry run release onto main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: pnpm turbo release -- --dry-run --branches="main"
+        run: pnpm turbo release -- --dry-run --branches="${{ github.ref_name }}"
 
   release:
     timeout-minutes: 5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           node-version-file: .node-version
           cache: 'pnpm'
       - run: pnpm install
-      - name: Print new version
+      - name: Dry run release onto main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm turbo release -- --dry-run --branches="main"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Print new version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: pnpm turbo release -- --dry-run --branches="*"
+        run: pnpm turbo release -- --dry-run --branches="main"
 
   release:
     timeout-minutes: 5


### PR DESCRIPTION
Closes DG-140

## What changed? Why?
Semantic release needs branches to be between 1 & 3 branches and before it was configured to be _every_ branch. I think I can get away with just main here?