### PR TITLE
fix: release script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Release new repo version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: pnpm turbo release --branches="main"
+        run: pnpm turbo release -- --branches="main"
 
   redeploy:
     timeout-minutes: 5


### PR DESCRIPTION
Followup to #440 

## What changed? Why?
Fixes release script a bit, it didn't have the escaping `--`