### PR TITLE
Sheet content view transitions

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -13,6 +13,7 @@ const nextConfig: NextConfig = {
     },
     turbopackFileSystemCacheForBuild: true,
     turbopackFileSystemCacheForDev: true,
+    viewTransition: true,
   },
   headers() {
     return [

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -12,6 +12,7 @@ import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
+import { ViewTransition } from 'react';
 import { getServerTime } from '../services/getServerTime';
 import { Footer } from './layouts/Footer';
 import { Header } from './layouts/Header';
@@ -49,7 +50,16 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
                 {/* Contained main content with consistent section spacing */}
                 <Section sx={mainSectionSx}>
                   <Container>
-                    <main>{children}</main>
+                    <main>
+                      <ViewTransition
+                        enter="vt-page-enter"
+                        exit="vt-page-exit"
+                        name="page-content"
+                        share="vt-page-share"
+                      >
+                        {children}
+                      </ViewTransition>
+                    </main>
                   </Container>
                 </Section>
               </PageScrollProvider>

--- a/apps/web/src/app/layouts/Header.tsx
+++ b/apps/web/src/app/layouts/Header.tsx
@@ -16,7 +16,8 @@ const stickyContainerSx: SxObject = {
   maxWidth: 'unset',
   position: 'sticky',
   top: 0,
-  zIndex: 10, // Higher z-index to stay above grid content with transforms
+  viewTransitionName: 'site-header',
+  zIndex: 10,
 };
 
 const navSx: SxObject = {

--- a/apps/web/src/app/music/page.tsx
+++ b/apps/web/src/app/music/page.tsx
@@ -1,7 +1,8 @@
 import 'server-only';
 
 import { isMissingTokenError } from '@dg/shared-core/errors/MissingTokenError';
-import { Stack, Typography } from '@mui/material';
+import { Sheet } from '@dg/ui/core/Sheet';
+import { Stack } from '@mui/material';
 import { redirect } from 'next/navigation';
 import { getMusicHistory } from '../../services/music';
 import { MusicInfiniteScroll } from './MusicInfiniteScroll';
@@ -15,7 +16,6 @@ export default async function MusicPage() {
     tracks = result.tracks;
     nextCursor = result.nextCursor;
   } catch (error) {
-    // In development, redirect to the dev page to set up OAuth
     if (isMissingTokenError(error) && process.env.NODE_ENV === 'development') {
       redirect('/dev');
     }
@@ -23,11 +23,10 @@ export default async function MusicPage() {
   }
 
   return (
-    <main>
+    <Sheet title="Listening history">
       <Stack spacing={2}>
-        <Typography variant="h1">Listening history</Typography>
         <MusicInfiniteScroll initialCursor={nextCursor} initialTracks={tracks} />
       </Stack>
-    </main>
+    </Sheet>
   );
 }

--- a/apps/web/src/types/react-view-transition.d.ts
+++ b/apps/web/src/types/react-view-transition.d.ts
@@ -1,0 +1,22 @@
+import 'react';
+
+type ViewTransitionClass =
+  | string
+  | {
+      default?: string;
+      [transitionType: string]: string | undefined;
+    };
+
+declare module 'react' {
+  interface ViewTransitionProps {
+    children: ReactNode;
+    name?: string;
+    default?: ViewTransitionClass;
+    enter?: ViewTransitionClass;
+    exit?: ViewTransitionClass;
+    share?: ViewTransitionClass;
+    update?: ViewTransitionClass;
+  }
+
+  const ViewTransition: ExoticComponent<ViewTransitionProps>;
+}

--- a/biome.json
+++ b/biome.json
@@ -107,6 +107,16 @@
   },
   "overrides": [
     {
+      "includes": ["**/sheet-transitions.css"],
+      "linter": {
+        "rules": {
+          "correctness": {
+            "noUnknownTypeSelector": "off"
+          }
+        }
+      }
+    },
+    {
       "includes": ["packages/shared-core/logging/log.ts"],
       "linter": {
         "rules": {

--- a/package.json
+++ b/package.json
@@ -26,5 +26,5 @@
     "clean": "rm -f .env .env.tmp",
     "preinstall": "npx only-allow pnpm"
   },
-  "version": "2.60.0"
+  "version": "2.61.0"
 }

--- a/packages/maps/package.json
+++ b/packages/maps/package.json
@@ -7,13 +7,13 @@
     "lucide-react": "catalog:",
     "pigeon-maps": "0.22.1",
     "react": "catalog:",
-    "react-dom": "19.2.3"
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "@dg/tsconfig": "workspace:*",
     "@types/node": "catalog:",
     "@types/react": "catalog:",
-    "@types/react-dom": "19.2.3",
+    "@types/react-dom": "catalog:",
     "dotenv-mono": "catalog:",
     "typescript": "catalog:"
   },

--- a/packages/maps/src/WatercolorTile.tsx
+++ b/packages/maps/src/WatercolorTile.tsx
@@ -67,9 +67,7 @@ export function WatercolorTile({ tile, tileLoaded }: TileComponentProps) {
 
   return (
     <Box sx={containerSx}>
-      {/* biome-ignore lint/performance/noImgElement: dynamic tile URLs from pigeon-maps, not optimizable by next/image */}
       <Box alt="" component="img" onLoad={handleImageLoad} src={tile.url} sx={tileImgSx} />
-      {/* biome-ignore lint/performance/noImgElement: dynamic tile URLs from pigeon-maps, not optimizable by next/image */}
       <Box alt="" component="img" onLoad={handleImageLoad} src={labelsUrl} sx={tileImgSx} />
     </Box>
   );

--- a/packages/ui/core/Sheet.tsx
+++ b/packages/ui/core/Sheet.tsx
@@ -1,0 +1,74 @@
+import { Box, IconButton, Stack, Typography } from '@mui/material';
+import { X } from 'lucide-react';
+import NextLink from 'next/link';
+import type { ReactNode } from 'react';
+import { ViewTransition } from 'react';
+import type { SxObject } from '../theme';
+import './sheet-transitions.css';
+
+const sheetContainerSx: SxObject = {
+  background: 'var(--mui-palette-background-default)',
+  borderTopLeftRadius: 32,
+  borderTopRightRadius: 32,
+  boxShadow: '0 -4px 32px rgba(0, 0, 0, 0.08), 0 -1px 8px rgba(0, 0, 0, 0.04)',
+  display: 'flex',
+  flexDirection: 'column',
+  minHeight: '60vh',
+  overflow: 'hidden',
+  pb: 4,
+};
+
+const stickyHeaderSx: SxObject = {
+  alignItems: 'center',
+  backdropFilter: 'blur(12px)',
+  background: 'color-mix(in srgb, var(--mui-palette-background-default) 85%, transparent)',
+  borderBottom: '1px solid var(--mui-palette-divider)',
+  borderTopLeftRadius: 32,
+  borderTopRightRadius: 32,
+  display: 'flex',
+  justifyContent: 'space-between',
+  position: 'sticky',
+  px: 3,
+  py: 2,
+  top: 0,
+  zIndex: 2,
+};
+
+const contentSx: SxObject = {
+  flexGrow: 1,
+  p: 3,
+};
+
+interface SheetProps {
+  title: string;
+  children: ReactNode;
+}
+
+/**
+ * Sheet wrapper for page content. Wrap a page's content in `<Sheet>` to give it
+ * a raised card-like appearance with rounded top corners, a sticky title bar
+ * with close button, and View Transition animations for navigation.
+ *
+ * The Sheet's ViewTransition name ("sheet") overrides the layout's default
+ * "page-content" transition, enabling different animation behaviors:
+ * - Entering a sheet page: slides up from bottom
+ * - Leaving a sheet page: slides down
+ * - Sheet-to-sheet navigation: horizontal slide
+ */
+export function Sheet({ title, children }: SheetProps) {
+  return (
+    <ViewTransition enter="vt-sheet-enter" exit="vt-sheet-exit" name="sheet" share="vt-sheet-share">
+      <Box sx={sheetContainerSx}>
+        <Stack direction="row" sx={stickyHeaderSx}>
+          <Typography component="h1" variant="h1">
+            {title}
+          </Typography>
+          <IconButton aria-label="Close" component={NextLink} href="/" size="small">
+            <X size={20} />
+          </IconButton>
+        </Stack>
+        <Box sx={contentSx}>{children}</Box>
+      </Box>
+    </ViewTransition>
+  );
+}

--- a/packages/ui/core/Sheet.tsx
+++ b/packages/ui/core/Sheet.tsx
@@ -6,6 +6,11 @@ import { ViewTransition } from 'react';
 import type { SxObject } from '../theme';
 import './sheet-transitions.css';
 
+const closeLinkStyle = {
+  color: 'inherit',
+  display: 'inline-flex',
+} as const;
+
 const sheetContainerSx: SxObject = {
   background: 'var(--mui-palette-background-default)',
   borderTopLeftRadius: 32,
@@ -63,9 +68,11 @@ export function Sheet({ title, children }: SheetProps) {
           <Typography component="h1" variant="h1">
             {title}
           </Typography>
-          <IconButton aria-label="Close" component={NextLink} href="/" size="small">
-            <X size={20} />
-          </IconButton>
+          <NextLink aria-label="Close" href="/" style={closeLinkStyle}>
+            <IconButton size="small" tabIndex={-1}>
+              <X size={20} />
+            </IconButton>
+          </NextLink>
         </Stack>
         <Box sx={contentSx}>{children}</Box>
       </Box>

--- a/packages/ui/core/sheet-transitions.css
+++ b/packages/ui/core/sheet-transitions.css
@@ -1,0 +1,126 @@
+/*
+ * View Transition animations for Sheet and page content.
+ *
+ * Transition cases:
+ * 1. no-sheet → sheet: sheet slides up, contents fade in
+ * 2. sheet → sheet: old slides left, new slides from right (reversed on back)
+ * 3. sheet → no-sheet: sheet slides down, contents fade out
+ * 4. no-sheet → no-sheet: old slides left, new slides from right (reversed on back)
+ */
+
+/* --- Sheet enter: slides up from bottom with fade --- */
+.vt-sheet-enter {
+  animation: sheet-slide-up 0.4s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+/* --- Sheet exit: slides down to bottom with fade --- */
+.vt-sheet-exit {
+  animation: sheet-slide-down 0.35s cubic-bezier(0.7, 0, 0.84, 0) both;
+}
+
+/* --- Sheet share (sheet→sheet): cross-slide horizontally --- */
+.vt-sheet-share {
+  animation: sheet-slide-in-right 0.35s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+/* --- Page content enter: slide in from right --- */
+.vt-page-enter {
+  animation: page-slide-in-right 0.35s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+/* --- Page content exit: slide out to left --- */
+.vt-page-exit {
+  animation: page-slide-out-left 0.35s cubic-bezier(0.7, 0, 0.84, 0) both;
+}
+
+/* --- Page content share (no-sheet→no-sheet): slide horizontally --- */
+.vt-page-share {
+  animation: page-slide-in-right 0.35s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+/* --- Keyframes --- */
+
+@keyframes sheet-slide-up {
+  from {
+    opacity: 0;
+    transform: translateY(40%);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes sheet-slide-down {
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(40%);
+  }
+}
+
+@keyframes sheet-slide-in-right {
+  from {
+    opacity: 0;
+    transform: translateX(30%);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes page-slide-in-right {
+  from {
+    opacity: 0;
+    transform: translateX(30%);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes page-slide-out-left {
+  from {
+    opacity: 1;
+    transform: translateX(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateX(-30%);
+  }
+}
+
+/* --- view-transition pseudo-element overrides ---
+ * These target the browser's view transition pseudo-elements
+ * for finer control over the snapshot animations.
+ */
+
+::view-transition-old(sheet) {
+  animation-duration: 0.35s;
+  animation-timing-function: cubic-bezier(0.7, 0, 0.84, 0);
+}
+
+::view-transition-new(sheet) {
+  animation-duration: 0.4s;
+  animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+::view-transition-old(page-content) {
+  animation-duration: 0.35s;
+  animation-timing-function: cubic-bezier(0.7, 0, 0.84, 0);
+}
+
+::view-transition-new(page-content) {
+  animation-duration: 0.35s;
+  animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+/* Keep the header stable during transitions */
+::view-transition-group(site-header) {
+  animation: none;
+}

--- a/packages/ui/types/react-view-transition.d.ts
+++ b/packages/ui/types/react-view-transition.d.ts
@@ -1,0 +1,22 @@
+import 'react';
+
+type ViewTransitionClass =
+  | string
+  | {
+      default?: string;
+      [transitionType: string]: string | undefined;
+    };
+
+declare module 'react' {
+  interface ViewTransitionProps {
+    children: ReactNode;
+    name?: string;
+    default?: ViewTransitionClass;
+    enter?: ViewTransitionClass;
+    exit?: ViewTransitionClass;
+    share?: ViewTransitionClass;
+    update?: ViewTransitionClass;
+  }
+
+  const ViewTransition: ExoticComponent<ViewTransitionProps>;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,8 +40,11 @@ catalogs:
       specifier: 25.0.10
       version: 25.0.10
     '@types/react':
-      specifier: 19.2.9
-      version: 19.2.9
+      specifier: 19.2.14
+      version: 19.2.14
+    '@types/react-dom':
+      specifier: 19.2.3
+      version: 19.2.3
     babel-plugin-react-compiler:
       specifier: 1.0.0
       version: 1.0.0
@@ -67,8 +70,11 @@ catalogs:
       specifier: 16.1.4
       version: 16.1.4
     react:
-      specifier: 19.2.3
-      version: 19.2.3
+      specifier: 19.3.0-canary-2ba30655-20260219
+      version: 19.3.0-canary-2ba30655-20260219
+    react-dom:
+      specifier: 19.3.0-canary-2ba30655-20260219
+      version: 19.3.0-canary-2ba30655-20260219
     server-only:
       specifier: 0.0.1
       version: 0.0.1
@@ -137,40 +143,40 @@ importers:
         version: 11.14.0
       '@emotion/react':
         specifier: 11.14.0
-        version: 11.14.0(@types/react@19.2.9)(react@19.2.3)
+        version: 11.14.0(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219)
       '@emotion/styled':
         specifier: 11.14.1
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.2.3))(@types/react@19.2.9)(react@19.2.3)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219))(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219)
       '@fortawesome/free-brands-svg-icons':
         specifier: 'catalog:'
         version: 7.1.0
       '@mui/material':
         specifier: 'catalog:'
-        version: 7.3.7(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.2.3))(@types/react@19.2.9)(react@19.2.3))(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 7.3.7(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219))(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219))(@types/react@19.2.14)(react-dom@19.3.0-canary-2ba30655-20260219(react@19.3.0-canary-2ba30655-20260219))(react@19.3.0-canary-2ba30655-20260219)
       '@mui/material-nextjs':
         specifier: 7.3.7
-        version: 7.3.7(@emotion/cache@11.14.0)(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.2.3))(@types/react@19.2.9)(next@16.1.4(@babel/core@7.28.6)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+        version: 7.3.7(@emotion/cache@11.14.0)(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219))(@types/react@19.2.14)(next@16.1.4(@babel/core@7.28.6)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.3.0-canary-2ba30655-20260219(react@19.3.0-canary-2ba30655-20260219))(react@19.3.0-canary-2ba30655-20260219))(react@19.3.0-canary-2ba30655-20260219)
       '@vercel/analytics':
         specifier: 1.6.1
-        version: 1.6.1(next@16.1.4(@babel/core@7.28.6)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+        version: 1.6.1(next@16.1.4(@babel/core@7.28.6)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.3.0-canary-2ba30655-20260219(react@19.3.0-canary-2ba30655-20260219))(react@19.3.0-canary-2ba30655-20260219))(react@19.3.0-canary-2ba30655-20260219)
       '@vercel/speed-insights':
         specifier: 1.3.1
-        version: 1.3.1(next@16.1.4(@babel/core@7.28.6)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+        version: 1.3.1(next@16.1.4(@babel/core@7.28.6)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.3.0-canary-2ba30655-20260219(react@19.3.0-canary-2ba30655-20260219))(react@19.3.0-canary-2ba30655-20260219))(react@19.3.0-canary-2ba30655-20260219)
       dotenv-mono:
         specifier: 'catalog:'
         version: 1.5.1
       lucide-react:
         specifier: 'catalog:'
-        version: 0.563.0(react@19.2.3)
+        version: 0.563.0(react@19.3.0-canary-2ba30655-20260219)
       next:
         specifier: 'catalog:'
-        version: 16.1.4(@babel/core@7.28.6)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.4(@babel/core@7.28.6)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.3.0-canary-2ba30655-20260219(react@19.3.0-canary-2ba30655-20260219))(react@19.3.0-canary-2ba30655-20260219)
       react:
         specifier: 'catalog:'
-        version: 19.2.3
+        version: 19.3.0-canary-2ba30655-20260219
       react-intersection-observer:
         specifier: 10.0.2
-        version: 10.0.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 10.0.2(react-dom@19.3.0-canary-2ba30655-20260219(react@19.3.0-canary-2ba30655-20260219))(react@19.3.0-canary-2ba30655-20260219)
       server-only:
         specifier: 'catalog:'
         version: 0.0.1
@@ -192,7 +198,7 @@ importers:
         version: 6.9.1
       '@testing-library/react':
         specifier: 'catalog:'
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.9))(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-2ba30655-20260219(react@19.3.0-canary-2ba30655-20260219))(react@19.3.0-canary-2ba30655-20260219)
       '@testing-library/user-event':
         specifier: 'catalog:'
         version: 14.6.1(@testing-library/dom@10.4.1)
@@ -201,7 +207,7 @@ importers:
         version: 30.0.0
       '@types/react':
         specifier: 'catalog:'
-        version: 19.2.9
+        version: 19.2.14
       babel-plugin-react-compiler:
         specifier: 'catalog:'
         version: 1.0.0
@@ -342,19 +348,19 @@ importers:
         version: link:../ui
       '@mui/material':
         specifier: 'catalog:'
-        version: 7.3.7(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.2.3))(@types/react@19.2.9)(react@19.2.3))(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 7.3.7(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219))(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219))(@types/react@19.2.14)(react-dom@19.3.0-canary-2ba30655-20260219(react@19.3.0-canary-2ba30655-20260219))(react@19.3.0-canary-2ba30655-20260219)
       lucide-react:
         specifier: 'catalog:'
-        version: 0.563.0(react@19.2.3)
+        version: 0.563.0(react@19.3.0-canary-2ba30655-20260219)
       pigeon-maps:
         specifier: 0.22.1
-        version: 0.22.1(react@19.2.3)
+        version: 0.22.1(react@19.3.0-canary-2ba30655-20260219)
       react:
         specifier: 'catalog:'
-        version: 19.2.3
+        version: 19.3.0-canary-2ba30655-20260219
       react-dom:
-        specifier: 19.2.3
-        version: 19.2.3(react@19.2.3)
+        specifier: 'catalog:'
+        version: 19.3.0-canary-2ba30655-20260219(react@19.3.0-canary-2ba30655-20260219)
     devDependencies:
       '@dg/tsconfig':
         specifier: workspace:*
@@ -364,10 +370,10 @@ importers:
         version: 25.0.10
       '@types/react':
         specifier: 'catalog:'
-        version: 19.2.9
+        version: 19.2.14
       '@types/react-dom':
-        specifier: 19.2.3
-        version: 19.2.3(@types/react@19.2.9)
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.14)
       dotenv-mono:
         specifier: 'catalog:'
         version: 1.5.1
@@ -388,7 +394,7 @@ importers:
         version: 0.8.6
       react:
         specifier: 'catalog:'
-        version: 19.2.3
+        version: 19.3.0-canary-2ba30655-20260219
     devDependencies:
       '@dg/tsconfig':
         specifier: workspace:*
@@ -398,7 +404,7 @@ importers:
         version: 25.0.10
       '@types/react':
         specifier: 'catalog:'
-        version: 19.2.9
+        version: 19.2.14
       dotenv-mono:
         specifier: 'catalog:'
         version: 1.5.1
@@ -519,7 +525,7 @@ importers:
     dependencies:
       '@contentful/rich-text-react-renderer':
         specifier: 16.1.6
-        version: 16.1.6(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.6(babel-plugin-macros@3.1.0)(react-dom@19.3.0-canary-2ba30655-20260219(react@19.3.0-canary-2ba30655-20260219))(react@19.3.0-canary-2ba30655-20260219)
       '@contentful/rich-text-types':
         specifier: 'catalog:'
         version: 17.2.5(babel-plugin-macros@3.1.0)
@@ -537,25 +543,25 @@ importers:
         version: 7.1.0
       '@fortawesome/react-fontawesome':
         specifier: 3.1.1
-        version: 3.1.1(@fortawesome/fontawesome-svg-core@7.1.0)(react@19.2.3)
+        version: 3.1.1(@fortawesome/fontawesome-svg-core@7.1.0)(react@19.3.0-canary-2ba30655-20260219)
       '@mui/material':
         specifier: 'catalog:'
-        version: 7.3.7(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.2.3))(@types/react@19.2.9)(react@19.2.3))(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 7.3.7(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219))(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219))(@types/react@19.2.14)(react-dom@19.3.0-canary-2ba30655-20260219(react@19.3.0-canary-2ba30655-20260219))(react@19.3.0-canary-2ba30655-20260219)
       '@mui/system':
         specifier: 'catalog:'
-        version: 7.3.7(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.2.3))(@types/react@19.2.9)(react@19.2.3))(@types/react@19.2.9)(react@19.2.3)
+        version: 7.3.7(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219))(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219))(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219)
       '@mui/utils':
         specifier: 'catalog:'
-        version: 7.3.7(@types/react@19.2.9)(react@19.2.3)
+        version: 7.3.7(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219)
       lucide-react:
         specifier: 'catalog:'
-        version: 0.563.0(react@19.2.3)
+        version: 0.563.0(react@19.3.0-canary-2ba30655-20260219)
       next:
         specifier: 'catalog:'
-        version: 16.1.4(@babel/core@7.28.6)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.4(@babel/core@7.28.6)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.3.0-canary-2ba30655-20260219(react@19.3.0-canary-2ba30655-20260219))(react@19.3.0-canary-2ba30655-20260219)
       react:
         specifier: 'catalog:'
-        version: 19.2.3
+        version: 19.3.0-canary-2ba30655-20260219
       sharp:
         specifier: 'catalog:'
         version: 0.34.5
@@ -571,7 +577,7 @@ importers:
         version: 6.9.1
       '@testing-library/react':
         specifier: 'catalog:'
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.9))(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-2ba30655-20260219(react@19.3.0-canary-2ba30655-20260219))(react@19.3.0-canary-2ba30655-20260219)
       '@testing-library/user-event':
         specifier: 'catalog:'
         version: 14.6.1(@testing-library/dom@10.4.1)
@@ -583,7 +589,7 @@ importers:
         version: 25.0.10
       '@types/react':
         specifier: 'catalog:'
-        version: 19.2.9
+        version: 19.2.14
       dotenv-mono:
         specifier: 'catalog:'
         version: 1.5.1
@@ -2124,8 +2130,8 @@ packages:
     peerDependencies:
       '@types/react': '*'
 
-  '@types/react@19.2.9':
-    resolution: {integrity: sha512-Lpo8kgb/igvMIPeNV2rsYKTgaORYdO1XGVZ4Qz3akwOj0ySGYMPlQWa8BaLn0G63D1aSaAQ5ldR06wCpChQCjA==}
+  '@types/react@19.2.14':
+    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
@@ -3972,10 +3978,10 @@ packages:
     resolution: {integrity: sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==}
     engines: {node: '>= 0.8'}
 
-  react-dom@19.2.3:
-    resolution: {integrity: sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==}
+  react-dom@19.3.0-canary-2ba30655-20260219:
+    resolution: {integrity: sha512-BKNvRq/7rNumithT2pMMPDTWqGGDpn0nQ7BpnRkmOQ8xsFWzn8vplR8xqFUT/wYOHQzv3JgrJiCyyulQZFdyfA==}
     peerDependencies:
-      react: ^19.2.3
+      react: 19.3.0-canary-2ba30655-20260219
 
   react-intersection-observer@10.0.2:
     resolution: {integrity: sha512-lAMzxVWrBko6SLd1jx6l84fVrzJu91hpxHlvD2as2Wec9mDCjdYXwc5xNOFBchpeBir0Y7AGBW+C/AYMa7CSFg==}
@@ -4004,8 +4010,8 @@ packages:
       react: '>=16.6.0'
       react-dom: '>=16.6.0'
 
-  react@19.2.3:
-    resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
+  react@19.3.0-canary-2ba30655-20260219:
+    resolution: {integrity: sha512-IdXwg3Tw+W4ucbuWP+Jn8vVIzDiQUtv6dK3QUpVjYbdxGPqDqgPzbR0UTlVB/txaKOZbQudKkWkNSuJpa4w0KA==}
     engines: {node: '>=0.10.0'}
 
   readdirp@4.1.2:
@@ -4084,8 +4090,8 @@ packages:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
 
-  scheduler@0.27.0:
-    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+  scheduler@0.28.0-canary-2ba30655-20260219:
+    resolution: {integrity: sha512-co/S1aXbLfADGYZg7F7KwC6hxNFOtd2ZBiGgA5wDVUQhNq0ApMuMiMqjP/RjE4hKDlnsatZQfNh4iVz2brwJ+g==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -4937,11 +4943,11 @@ snapshots:
   '@biomejs/cli-win32-x64@2.3.12':
     optional: true
 
-  '@contentful/rich-text-react-renderer@16.1.6(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@contentful/rich-text-react-renderer@16.1.6(babel-plugin-macros@3.1.0)(react-dom@19.3.0-canary-2ba30655-20260219(react@19.3.0-canary-2ba30655-20260219))(react@19.3.0-canary-2ba30655-20260219)':
     dependencies:
       '@contentful/rich-text-types': 17.2.5(babel-plugin-macros@3.1.0)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      react: 19.3.0-canary-2ba30655-20260219
+      react-dom: 19.3.0-canary-2ba30655-20260219(react@19.3.0-canary-2ba30655-20260219)
     transitivePeerDependencies:
       - '@lingui/babel-plugin-lingui-macro'
       - babel-plugin-macros
@@ -5038,19 +5044,19 @@ snapshots:
 
   '@emotion/memoize@0.9.0': {}
 
-  '@emotion/react@11.14.0(@types/react@19.2.9)(react@19.2.3)':
+  '@emotion/react@11.14.0(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@emotion/babel-plugin': 11.13.5
       '@emotion/cache': 11.14.0
       '@emotion/serialize': 1.3.3
-      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.2.3)
+      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.3.0-canary-2ba30655-20260219)
       '@emotion/utils': 1.4.2
       '@emotion/weak-memoize': 0.4.0
       hoist-non-react-statics: 3.3.2
-      react: 19.2.3
+      react: 19.3.0-canary-2ba30655-20260219
     optionalDependencies:
-      '@types/react': 19.2.9
+      '@types/react': 19.2.14
     transitivePeerDependencies:
       - supports-color
 
@@ -5064,26 +5070,26 @@ snapshots:
 
   '@emotion/sheet@1.4.0': {}
 
-  '@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.2.3))(@types/react@19.2.9)(react@19.2.3)':
+  '@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219))(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@emotion/babel-plugin': 11.13.5
       '@emotion/is-prop-valid': 1.4.0
-      '@emotion/react': 11.14.0(@types/react@19.2.9)(react@19.2.3)
+      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219)
       '@emotion/serialize': 1.3.3
-      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.2.3)
+      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.3.0-canary-2ba30655-20260219)
       '@emotion/utils': 1.4.2
-      react: 19.2.3
+      react: 19.3.0-canary-2ba30655-20260219
     optionalDependencies:
-      '@types/react': 19.2.9
+      '@types/react': 19.2.14
     transitivePeerDependencies:
       - supports-color
 
   '@emotion/unitless@0.10.0': {}
 
-  '@emotion/use-insertion-effect-with-fallbacks@1.2.0(react@19.2.3)':
+  '@emotion/use-insertion-effect-with-fallbacks@1.2.0(react@19.3.0-canary-2ba30655-20260219)':
     dependencies:
-      react: 19.2.3
+      react: 19.3.0-canary-2ba30655-20260219
 
   '@emotion/utils@1.4.2': {}
 
@@ -5257,10 +5263,10 @@ snapshots:
     dependencies:
       '@fortawesome/fontawesome-common-types': 7.1.0
 
-  '@fortawesome/react-fontawesome@3.1.1(@fortawesome/fontawesome-svg-core@7.1.0)(react@19.2.3)':
+  '@fortawesome/react-fontawesome@3.1.1(@fortawesome/fontawesome-svg-core@7.1.0)(react@19.3.0-canary-2ba30655-20260219)':
     dependencies:
       '@fortawesome/fontawesome-svg-core': 7.1.0
-      react: 19.2.3
+      react: 19.3.0-canary-2ba30655-20260219
 
   '@graphql-typed-document-node/core@3.2.0(graphql@16.12.0)':
     dependencies:
@@ -5642,47 +5648,47 @@ snapshots:
 
   '@mui/core-downloads-tracker@7.3.7': {}
 
-  '@mui/material-nextjs@7.3.7(@emotion/cache@11.14.0)(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.2.3))(@types/react@19.2.9)(next@16.1.4(@babel/core@7.28.6)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
+  '@mui/material-nextjs@7.3.7(@emotion/cache@11.14.0)(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219))(@types/react@19.2.14)(next@16.1.4(@babel/core@7.28.6)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.3.0-canary-2ba30655-20260219(react@19.3.0-canary-2ba30655-20260219))(react@19.3.0-canary-2ba30655-20260219))(react@19.3.0-canary-2ba30655-20260219)':
     dependencies:
       '@babel/runtime': 7.28.6
-      '@emotion/react': 11.14.0(@types/react@19.2.9)(react@19.2.3)
-      next: 16.1.4(@babel/core@7.28.6)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      react: 19.2.3
+      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219)
+      next: 16.1.4(@babel/core@7.28.6)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.3.0-canary-2ba30655-20260219(react@19.3.0-canary-2ba30655-20260219))(react@19.3.0-canary-2ba30655-20260219)
+      react: 19.3.0-canary-2ba30655-20260219
     optionalDependencies:
       '@emotion/cache': 11.14.0
-      '@types/react': 19.2.9
+      '@types/react': 19.2.14
 
-  '@mui/material@7.3.7(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.2.3))(@types/react@19.2.9)(react@19.2.3))(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@mui/material@7.3.7(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219))(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219))(@types/react@19.2.14)(react-dom@19.3.0-canary-2ba30655-20260219(react@19.3.0-canary-2ba30655-20260219))(react@19.3.0-canary-2ba30655-20260219)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@mui/core-downloads-tracker': 7.3.7
-      '@mui/system': 7.3.7(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.2.3))(@types/react@19.2.9)(react@19.2.3))(@types/react@19.2.9)(react@19.2.3)
-      '@mui/types': 7.4.10(@types/react@19.2.9)
-      '@mui/utils': 7.3.7(@types/react@19.2.9)(react@19.2.3)
+      '@mui/system': 7.3.7(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219))(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219))(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219)
+      '@mui/types': 7.4.10(@types/react@19.2.14)
+      '@mui/utils': 7.3.7(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219)
       '@popperjs/core': 2.11.8
-      '@types/react-transition-group': 4.4.12(@types/react@19.2.9)
+      '@types/react-transition-group': 4.4.12(@types/react@19.2.14)
       clsx: 2.1.1
       csstype: 3.2.3
       prop-types: 15.8.1
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      react: 19.3.0-canary-2ba30655-20260219
+      react-dom: 19.3.0-canary-2ba30655-20260219(react@19.3.0-canary-2ba30655-20260219)
       react-is: 19.2.3
-      react-transition-group: 4.4.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react-transition-group: 4.4.5(react-dom@19.3.0-canary-2ba30655-20260219(react@19.3.0-canary-2ba30655-20260219))(react@19.3.0-canary-2ba30655-20260219)
     optionalDependencies:
-      '@emotion/react': 11.14.0(@types/react@19.2.9)(react@19.2.3)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.2.3))(@types/react@19.2.9)(react@19.2.3)
-      '@types/react': 19.2.9
+      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219))(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219)
+      '@types/react': 19.2.14
 
-  '@mui/private-theming@7.3.7(@types/react@19.2.9)(react@19.2.3)':
+  '@mui/private-theming@7.3.7(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219)':
     dependencies:
       '@babel/runtime': 7.28.6
-      '@mui/utils': 7.3.7(@types/react@19.2.9)(react@19.2.3)
+      '@mui/utils': 7.3.7(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219)
       prop-types: 15.8.1
-      react: 19.2.3
+      react: 19.3.0-canary-2ba30655-20260219
     optionalDependencies:
-      '@types/react': 19.2.9
+      '@types/react': 19.2.14
 
-  '@mui/styled-engine@7.3.7(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.2.3))(@types/react@19.2.9)(react@19.2.3))(react@19.2.3)':
+  '@mui/styled-engine@7.3.7(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219))(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219))(react@19.3.0-canary-2ba30655-20260219)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@emotion/cache': 11.14.0
@@ -5690,44 +5696,44 @@ snapshots:
       '@emotion/sheet': 1.4.0
       csstype: 3.2.3
       prop-types: 15.8.1
-      react: 19.2.3
+      react: 19.3.0-canary-2ba30655-20260219
     optionalDependencies:
-      '@emotion/react': 11.14.0(@types/react@19.2.9)(react@19.2.3)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.2.3))(@types/react@19.2.9)(react@19.2.3)
+      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219))(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219)
 
-  '@mui/system@7.3.7(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.2.3))(@types/react@19.2.9)(react@19.2.3))(@types/react@19.2.9)(react@19.2.3)':
+  '@mui/system@7.3.7(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219))(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219))(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219)':
     dependencies:
       '@babel/runtime': 7.28.6
-      '@mui/private-theming': 7.3.7(@types/react@19.2.9)(react@19.2.3)
-      '@mui/styled-engine': 7.3.7(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.2.3))(@types/react@19.2.9)(react@19.2.3))(react@19.2.3)
-      '@mui/types': 7.4.10(@types/react@19.2.9)
-      '@mui/utils': 7.3.7(@types/react@19.2.9)(react@19.2.3)
+      '@mui/private-theming': 7.3.7(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219)
+      '@mui/styled-engine': 7.3.7(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219))(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219))(react@19.3.0-canary-2ba30655-20260219)
+      '@mui/types': 7.4.10(@types/react@19.2.14)
+      '@mui/utils': 7.3.7(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219)
       clsx: 2.1.1
       csstype: 3.2.3
       prop-types: 15.8.1
-      react: 19.2.3
+      react: 19.3.0-canary-2ba30655-20260219
     optionalDependencies:
-      '@emotion/react': 11.14.0(@types/react@19.2.9)(react@19.2.3)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.2.3))(@types/react@19.2.9)(react@19.2.3)
-      '@types/react': 19.2.9
+      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219))(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219)
+      '@types/react': 19.2.14
 
-  '@mui/types@7.4.10(@types/react@19.2.9)':
+  '@mui/types@7.4.10(@types/react@19.2.14)':
     dependencies:
       '@babel/runtime': 7.28.6
     optionalDependencies:
-      '@types/react': 19.2.9
+      '@types/react': 19.2.14
 
-  '@mui/utils@7.3.7(@types/react@19.2.9)(react@19.2.3)':
+  '@mui/utils@7.3.7(@types/react@19.2.14)(react@19.3.0-canary-2ba30655-20260219)':
     dependencies:
       '@babel/runtime': 7.28.6
-      '@mui/types': 7.4.10(@types/react@19.2.9)
+      '@mui/types': 7.4.10(@types/react@19.2.14)
       '@types/prop-types': 15.7.15
       clsx: 2.1.1
       prop-types: 15.8.1
-      react: 19.2.3
+      react: 19.3.0-canary-2ba30655-20260219
       react-is: 19.2.3
     optionalDependencies:
-      '@types/react': 19.2.9
+      '@types/react': 19.2.14
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
@@ -5943,15 +5949,15 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.9))(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-2ba30655-20260219(react@19.3.0-canary-2ba30655-20260219))(react@19.3.0-canary-2ba30655-20260219)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@testing-library/dom': 10.4.1
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      react: 19.3.0-canary-2ba30655-20260219
+      react-dom: 19.3.0-canary-2ba30655-20260219(react@19.3.0-canary-2ba30655-20260219)
     optionalDependencies:
-      '@types/react': 19.2.9
-      '@types/react-dom': 19.2.3(@types/react@19.2.9)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
     dependencies:
@@ -6051,15 +6057,15 @@ snapshots:
 
   '@types/prop-types@15.7.15': {}
 
-  '@types/react-dom@19.2.3(@types/react@19.2.9)':
+  '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
-      '@types/react': 19.2.9
+      '@types/react': 19.2.14
 
-  '@types/react-transition-group@4.4.12(@types/react@19.2.9)':
+  '@types/react-transition-group@4.4.12(@types/react@19.2.14)':
     dependencies:
-      '@types/react': 19.2.9
+      '@types/react': 19.2.14
 
-  '@types/react@19.2.9':
+  '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
 
@@ -6136,10 +6142,10 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vercel/analytics@1.6.1(next@16.1.4(@babel/core@7.28.6)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
+  '@vercel/analytics@1.6.1(next@16.1.4(@babel/core@7.28.6)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.3.0-canary-2ba30655-20260219(react@19.3.0-canary-2ba30655-20260219))(react@19.3.0-canary-2ba30655-20260219))(react@19.3.0-canary-2ba30655-20260219)':
     optionalDependencies:
-      next: 16.1.4(@babel/core@7.28.6)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      react: 19.2.3
+      next: 16.1.4(@babel/core@7.28.6)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.3.0-canary-2ba30655-20260219(react@19.3.0-canary-2ba30655-20260219))(react@19.3.0-canary-2ba30655-20260219)
+      react: 19.3.0-canary-2ba30655-20260219
 
   '@vercel/backends@0.0.23(typescript@5.9.3)':
     dependencies:
@@ -6410,10 +6416,10 @@ snapshots:
       '@iarna/toml': 2.2.5
       execa: 5.1.1
 
-  '@vercel/speed-insights@1.3.1(next@16.1.4(@babel/core@7.28.6)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
+  '@vercel/speed-insights@1.3.1(next@16.1.4(@babel/core@7.28.6)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.3.0-canary-2ba30655-20260219(react@19.3.0-canary-2ba30655-20260219))(react@19.3.0-canary-2ba30655-20260219))(react@19.3.0-canary-2ba30655-20260219)':
     optionalDependencies:
-      next: 16.1.4(@babel/core@7.28.6)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      react: 19.2.3
+      next: 16.1.4(@babel/core@7.28.6)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.3.0-canary-2ba30655-20260219(react@19.3.0-canary-2ba30655-20260219))(react@19.3.0-canary-2ba30655-20260219)
+      react: 19.3.0-canary-2ba30655-20260219
 
   '@vercel/static-build@2.8.27':
     dependencies:
@@ -7730,9 +7736,9 @@ snapshots:
     dependencies:
       yallist: 4.0.0
 
-  lucide-react@0.563.0(react@19.2.3):
+  lucide-react@0.563.0(react@19.3.0-canary-2ba30655-20260219):
     dependencies:
-      react: 19.2.3
+      react: 19.3.0-canary-2ba30655-20260219
 
   lz-string@1.5.0: {}
 
@@ -7836,16 +7842,16 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@16.1.4(@babel/core@7.28.6)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.1.4(@babel/core@7.28.6)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.3.0-canary-2ba30655-20260219(react@19.3.0-canary-2ba30655-20260219))(react@19.3.0-canary-2ba30655-20260219):
     dependencies:
       '@next/env': 16.1.4
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.9.18
       caniuse-lite: 1.0.30001766
       postcss: 8.4.31
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-      styled-jsx: 5.1.6(@babel/core@7.28.6)(babel-plugin-macros@3.1.0)(react@19.2.3)
+      react: 19.3.0-canary-2ba30655-20260219
+      react-dom: 19.3.0-canary-2ba30655-20260219(react@19.3.0-canary-2ba30655-20260219)
+      styled-jsx: 5.1.6(@babel/core@7.28.6)(babel-plugin-macros@3.1.0)(react@19.3.0-canary-2ba30655-20260219)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.1.4
       '@next/swc-darwin-x64': 16.1.4
@@ -8050,9 +8056,9 @@ snapshots:
 
   picomatch@4.0.3: {}
 
-  pigeon-maps@0.22.1(react@19.2.3):
+  pigeon-maps@0.22.1(react@19.3.0-canary-2ba30655-20260219):
     dependencies:
-      react: 19.2.3
+      react: 19.3.0-canary-2ba30655-20260219
 
   pirates@4.0.7: {}
 
@@ -8122,16 +8128,16 @@ snapshots:
       iconv-lite: 0.4.24
       unpipe: 1.0.0
 
-  react-dom@19.2.3(react@19.2.3):
+  react-dom@19.3.0-canary-2ba30655-20260219(react@19.3.0-canary-2ba30655-20260219):
     dependencies:
-      react: 19.2.3
-      scheduler: 0.27.0
+      react: 19.3.0-canary-2ba30655-20260219
+      scheduler: 0.28.0-canary-2ba30655-20260219
 
-  react-intersection-observer@10.0.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  react-intersection-observer@10.0.2(react-dom@19.3.0-canary-2ba30655-20260219(react@19.3.0-canary-2ba30655-20260219))(react@19.3.0-canary-2ba30655-20260219):
     dependencies:
-      react: 19.2.3
+      react: 19.3.0-canary-2ba30655-20260219
     optionalDependencies:
-      react-dom: 19.2.3(react@19.2.3)
+      react-dom: 19.3.0-canary-2ba30655-20260219(react@19.3.0-canary-2ba30655-20260219)
 
   react-is@16.13.1: {}
 
@@ -8141,16 +8147,16 @@ snapshots:
 
   react-is@19.2.3: {}
 
-  react-transition-group@4.4.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  react-transition-group@4.4.5(react-dom@19.3.0-canary-2ba30655-20260219(react@19.3.0-canary-2ba30655-20260219))(react@19.3.0-canary-2ba30655-20260219):
     dependencies:
       '@babel/runtime': 7.28.6
       dom-helpers: 5.2.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      react: 19.3.0-canary-2ba30655-20260219
+      react-dom: 19.3.0-canary-2ba30655-20260219(react@19.3.0-canary-2ba30655-20260219)
 
-  react@19.2.3: {}
+  react@19.3.0-canary-2ba30655-20260219: {}
 
   readdirp@4.1.2: {}
 
@@ -8237,7 +8243,7 @@ snapshots:
     dependencies:
       xmlchars: 2.2.0
 
-  scheduler@0.27.0: {}
+  scheduler@0.28.0-canary-2ba30655-20260219: {}
 
   semver@6.3.1: {}
 
@@ -8424,10 +8430,10 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  styled-jsx@5.1.6(@babel/core@7.28.6)(babel-plugin-macros@3.1.0)(react@19.2.3):
+  styled-jsx@5.1.6(@babel/core@7.28.6)(babel-plugin-macros@3.1.0)(react@19.3.0-canary-2ba30655-20260219):
     dependencies:
       client-only: 0.0.1
-      react: 19.2.3
+      react: 19.3.0-canary-2ba30655-20260219
     optionalDependencies:
       '@babel/core': 7.28.6
       babel-plugin-macros: 3.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,7 +17,8 @@ catalog:
   '@testing-library/user-event': 14.6.1
   '@types/jest': 30.0.0
   '@types/node': 25.0.10
-  '@types/react': 19.2.9
+  '@types/react': 19.2.14
+  '@types/react-dom': 19.2.3
   babel-plugin-react-compiler: 1.0.0
   dotenv-mono: 1.5.1
   graphql: 16.12.0
@@ -26,7 +27,8 @@ catalog:
   jest-environment-jsdom: 30.2.0
   lucide-react: 0.563.0
   next: 16.1.4
-  react: 19.2.3
+  react: 19.3.0-canary-2ba30655-20260219
+  react-dom: 19.3.0-canary-2ba30655-20260219
   server-only: 0.0.1
   sharp: 0.34.5
   tsx: 4.21.0


### PR DESCRIPTION
Closes DG-216

# What changed?

- Implemented a "sheet" paradigm for page navigation using the View Transitions API.
- Introduced a `Sheet` server component to wrap page content, providing a modal-like UI with animated transitions (slide up/down, horizontal content slide).
- Configured Next.js and React canary for View Transitions API support, including necessary TypeScript declarations.
- Applied `view-transition-name` to the header for persistent visibility during transitions.
- Integrated the `Sheet` component on the `/music` page as an example.

# Release info

- [ ] Major
- [x] Minor
- [ ] Patch

---
Linear Issue: [DG-216](https://linear.app/dgattey/issue/DG-216/create-sheet-paradigm-for-showing-new-page-content)

<p><a href="https://cursor.com/agents?id=bc-f569c8da-4806-4143-9e7c-0525d46ef81e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f569c8da-4806-4143-9e7c-0525d46ef81e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

