### PR TITLE
Simplify gattey sites card implementation

### DIFF
--- a/apps/web/src/app/home/GatteySitesCard.tsx
+++ b/apps/web/src/app/home/GatteySitesCard.tsx
@@ -3,12 +3,12 @@ import { Link } from '@dg/ui/dependent/Link';
 import { truncated } from '@dg/ui/helpers/truncated';
 import type { SxObject } from '@dg/ui/theme';
 import { Box, Stack, Typography } from '@mui/material';
-import type { ReactNode } from 'react';
+import type { ComponentType } from 'react';
 import { PhotosSiteMark, WmmSiteMark } from './gatteySiteMarks';
 
 type GatteySite = {
   description: string;
-  mark: ReactNode;
+  Mark: ComponentType;
   title: string;
   url: string;
 };
@@ -16,13 +16,13 @@ type GatteySite = {
 const SITES: Array<GatteySite> = [
   {
     description: 'Family gallery uploads and frame sync',
-    mark: <PhotosSiteMark />,
+    Mark: PhotosSiteMark,
     title: 'Gattey Photos',
     url: 'https://photos.gattey.com',
   },
   {
     description: 'What you own, where it sits',
-    mark: <WmmSiteMark />,
+    Mark: WmmSiteMark,
     title: 'WMM',
     url: 'https://wmm.gattey.com',
   },
@@ -74,20 +74,16 @@ export function GatteySitesCard() {
           Also on gattey.com
         </Typography>
         <Stack sx={siteListSx}>
-          {SITES.map(({ description, mark, title, url }) => (
+          {SITES.map(({ description, Mark, title, url }) => (
             <Stack key={url} sx={siteRowSx}>
-              <Box sx={markSx}>{mark}</Box>
+              <Box sx={markSx}>
+                <Mark />
+              </Box>
               <Stack>
-                <Link href={url} isExternal={true} sx={siteTitleSx} title={title} variant="h5">
+                <Link href={url} isExternal sx={siteTitleSx} title={title} variant="h5">
                   {title}
                 </Link>
-                <Link
-                  href={url}
-                  isExternal={true}
-                  sx={siteDescriptionSx}
-                  title={title}
-                  variant="body2"
-                >
+                <Link href={url} isExternal sx={siteDescriptionSx} title={title} variant="body2">
                   {description}
                 </Link>
               </Stack>

--- a/apps/web/src/app/home/__tests__/GatteySitesCard.test.tsx
+++ b/apps/web/src/app/home/__tests__/GatteySitesCard.test.tsx
@@ -6,13 +6,24 @@ describe('GatteySitesCard', () => {
     render(<GatteySitesCard />);
 
     expect(screen.getByRole('heading', { name: 'Also on gattey.com' })).toBeInTheDocument();
+    expect(screen.getByText('Family gallery uploads and frame sync')).toBeInTheDocument();
+    expect(screen.getByText('What you own, where it sits')).toBeInTheDocument();
 
+    // Link title becomes aria-label, so title + description share the site name.
     const photosLinks = screen.getAllByRole('link', { name: 'Gattey Photos' });
-    expect(photosLinks[0]).toHaveAttribute('href', 'https://photos.gattey.com');
-    expect(photosLinks[0]).toHaveAttribute('target', '_blank');
+    expect(photosLinks).toHaveLength(2);
+    for (const link of photosLinks) {
+      expect(link).toHaveAttribute('href', 'https://photos.gattey.com');
+      expect(link).toHaveAttribute('target', '_blank');
+      expect(link).toHaveAttribute('rel', 'noreferrer');
+    }
 
     const wmmLinks = screen.getAllByRole('link', { name: 'WMM' });
-    expect(wmmLinks[0]).toHaveAttribute('href', 'https://wmm.gattey.com');
-    expect(wmmLinks[0]).toHaveAttribute('target', '_blank');
+    expect(wmmLinks).toHaveLength(2);
+    for (const link of wmmLinks) {
+      expect(link).toHaveAttribute('href', 'https://wmm.gattey.com');
+      expect(link).toHaveAttribute('target', '_blank');
+      expect(link).toHaveAttribute('rel', 'noreferrer');
+    }
   });
 });

--- a/apps/web/src/app/home/gatteySiteMarks.tsx
+++ b/apps/web/src/app/home/gatteySiteMarks.tsx
@@ -1,7 +1,6 @@
-import type { SxObject } from '@dg/ui/theme';
-import { Box } from '@mui/material';
+import type { CSSProperties } from 'react';
 
-const markSx: SxObject = {
+const markStyle: CSSProperties = {
   display: 'block',
   height: '100%',
   width: '100%',
@@ -12,13 +11,7 @@ const markSx: SxObject = {
  */
 export function PhotosSiteMark() {
   return (
-    <Box
-      aria-hidden="true"
-      component="svg"
-      sx={markSx}
-      viewBox="0 0 32 32"
-      xmlns="http://www.w3.org/2000/svg"
-    >
+    <svg aria-hidden="true" style={markStyle} viewBox="0 0 32 32">
       <rect fill="#f0a06a" height="22" rx="5" width="26" x="3" y="7" />
       <path
         d="M11 7 L13.2 4.2 A2 2 0 0 1 14.8 3.5 H17.2 A2 2 0 0 1 18.8 4.2 L21 7 Z"
@@ -29,7 +22,7 @@ export function PhotosSiteMark() {
       <circle cx="16" cy="18" fill="#0f172a" r="2.25" />
       <circle cx="14.4" cy="16.4" fill="#ffffff" fillOpacity="0.85" r="1.1" />
       <circle cx="24.5" cy="11.5" fill="#fde68a" r="1.6" />
-    </Box>
+    </svg>
   );
 }
 
@@ -38,13 +31,7 @@ export function PhotosSiteMark() {
  */
 export function WmmSiteMark() {
   return (
-    <Box
-      aria-hidden="true"
-      component="svg"
-      sx={markSx}
-      viewBox="0 0 32 32"
-      xmlns="http://www.w3.org/2000/svg"
-    >
+    <svg aria-hidden="true" style={markStyle} viewBox="0 0 32 32">
       <rect
         fill="#968954"
         height="24"
@@ -89,6 +76,6 @@ export function WmmSiteMark() {
         x="22"
         y="14"
       />
-    </Box>
+    </svg>
   );
 }

--- a/package.json
+++ b/package.json
@@ -27,5 +27,5 @@
     "clean": "rm -f .env .env.tmp",
     "preinstall": "npx only-allow pnpm"
   },
-  "version": "2.61.0"
+  "version": "2.61.1"
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Behavior-preserving cleanup on top of the gattey.com sites homepage card for parent PR #544
- Swap MUI `Box component="svg"` marks for native `<svg>` elements
- Store mark components in site data instead of prebuilt React nodes
- Tighten the unit test around dual title/description links and `rel="noreferrer"`

## Thermos (parent #544)
- No confirmed correctness/security blockers
- Dual title+description links with shared `title`/`aria-label` match existing StravaCard patterns (`ActivityName` / `ActivityDescription`)
- External links already use `Link` `isExternal` (`target="_blank"`, `rel="noreferrer"`)

## Validation
- [x] `turbo check --filter=@dg/web`
- [x] `turbo check:types --filter=@dg/web`
- [x] `GatteySitesCard` unit test (local; DB globalSetup stubbed because `DATABASE_URL_TEST` is unavailable here)
- [x] Vercel preview deploy green for this branch
- Note: full CI matrix (`check`/`check:types`/`test`) only runs for PRs into `main`, so parent #544 remains the CI source of truth until this lands on `feature/gattey-sites-card`

## Diff
- 3 files, +31 / −37, 2 commits

Base: `feature/gattey-sites-card` → parent https://github.com/dgattey/dg/pull/544

**Did not merge** this PR or #544.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2cc69d00-45ef-4c77-8042-ac22d1f82eff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2cc69d00-45ef-4c77-8042-ac22d1f82eff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

