### PR TITLE
DG-219: Use more modern CSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,5 @@
     "clean": "rm -f .env .env.tmp",
     "preinstall": "npx only-allow pnpm"
   },
-  "version": "2.61.1"
+  "version": "2.61.2"
 }

--- a/packages/ui/dependent/RichText.tsx
+++ b/packages/ui/dependent/RichText.tsx
@@ -35,12 +35,11 @@ type DataWithId = {
 };
 
 /**
- * Offsets for fixed header so anchor links look right
+ * Clears the sticky header when jumping to heading anchors.
  */
 const HEADING_SX: SxObject = {
   marginBottom: 3,
-  marginTop: -12,
-  paddingTop: 12,
+  scrollMarginTop: 120,
 };
 
 const paragraphSx: SxObject = {

--- a/packages/ui/dependent/RichText.tsx
+++ b/packages/ui/dependent/RichText.tsx
@@ -39,7 +39,8 @@ type DataWithId = {
  */
 const HEADING_SX: SxObject = {
   marginBottom: 3,
-  scrollMarginTop: 120,
+  // Sticky header is ~123px; keep a small gap below it for anchor jumps.
+  scrollMarginTop: 136,
 };
 
 const paragraphSx: SxObject = {

--- a/packages/ui/theme/index.ts
+++ b/packages/ui/theme/index.ts
@@ -181,40 +181,66 @@ export function getTheme(): Theme {
         },
       },
       MuiCssBaseline: {
-        styleOverrides: (theme) => ({
-          ...getSystemPreferenceStyles(theme),
-          ':root': {
-            // Ensure while swapping themes, we have no animations
-            ':root[data-animations-enabled="false"] *': {
-              transition: 'none',
+        styleOverrides: (theme) => {
+          const systemSelector = `html[${themePreferenceAttribute}="system"]:not([${themeSelectorAttribute}])`;
+          return {
+            ...getSystemPreferenceStyles(theme),
+            ':root': {
+              fontVariant: 'tabular-nums',
+              wordBreak: 'break-word',
+              [theme.breakpoints.up('sm')]: {
+                fontSize: 16,
+              },
+              [theme.breakpoints.up('md')]: {
+                fontSize: 17,
+              },
+              [theme.breakpoints.up('lg')]: {
+                fontSize: 18,
+              },
+              [theme.breakpoints.up('xl')]: {
+                fontSize: 19,
+              },
             },
-            fontVariant: 'tabular-nums',
-            wordBreak: 'break-word',
-            [theme.breakpoints.up('sm')]: {
-              fontSize: 16,
+            body: {
+              overscrollBehaviorX: 'none',
             },
-            [theme.breakpoints.up('md')]: {
-              fontSize: 17,
+            html: {
+              colorScheme: 'light',
+              scrollbarGutter: 'stable',
+              textWrap: 'pretty',
             },
-            [theme.breakpoints.up('lg')]: {
-              fontSize: 18,
+            [`html[${themeSelectorAttribute}="light"]`]: {
+              colorScheme: 'light',
             },
-            [theme.breakpoints.up('xl')]: {
-              fontSize: 19,
+            [`html[${themeSelectorAttribute}="dark"]`]: {
+              colorScheme: 'dark',
             },
-          },
-          body: {
-            overscrollBehaviorX: 'none',
-          },
-          html: {
-            scrollbarGutter: 'stable',
-            textWrap: 'pretty',
-          },
-          'html, body': {
-            overflowX: 'clip',
-            width: '100%',
-          },
-        }),
+            [`@media (prefers-color-scheme: dark)`]: {
+              [systemSelector]: {
+                colorScheme: 'dark',
+              },
+            },
+            [`@media (prefers-color-scheme: light)`]: {
+              [systemSelector]: {
+                colorScheme: 'light',
+              },
+            },
+            '@media (prefers-reduced-motion: reduce)': {
+              '*, *::before, *::after': {
+                animationDuration: '0.01ms !important',
+                animationIterationCount: '1 !important',
+                transitionDuration: '0.01ms !important',
+              },
+            },
+            'h1, h2, h3, h4': {
+              textWrap: 'balance',
+            },
+            'html, body': {
+              overflowX: 'clip',
+              width: '100%',
+            },
+          };
+        },
       },
       MuiLink: {
         defaultProps: {
@@ -338,6 +364,7 @@ export function getTheme(): Theme {
   });
 
   return responsiveFontSizes(themeWithColorMode, {
-    variants: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'caption', 'overline', 'body1', 'body2', 'code'],
+    // h1–h3 use clamp() in typography.ts; keep breakpoint scaling for the rest
+    variants: ['h4', 'h5', 'h6', 'caption', 'overline', 'body1', 'body2', 'code'],
   });
 }

--- a/packages/ui/theme/index.ts
+++ b/packages/ui/theme/index.ts
@@ -215,12 +215,12 @@ export function getTheme(): Theme {
             [`html[${themeSelectorAttribute}="dark"]`]: {
               colorScheme: 'dark',
             },
-            [`@media (prefers-color-scheme: dark)`]: {
+            '@media (prefers-color-scheme: dark)': {
               [systemSelector]: {
                 colorScheme: 'dark',
               },
             },
-            [`@media (prefers-color-scheme: light)`]: {
+            '@media (prefers-color-scheme: light)': {
               [systemSelector]: {
                 colorScheme: 'light',
               },

--- a/packages/ui/theme/typography.ts
+++ b/packages/ui/theme/typography.ts
@@ -47,17 +47,17 @@ export function getTypography(theme: Theme): TypographyVariantsOptions {
     ].join(','),
     fontSize: 20,
     h1: {
-      fontSize: 34,
+      fontSize: 'clamp(1.75rem, 1.2rem + 2.5vw, 2.125rem)',
       fontStretch: 'expanded',
       fontVariant: 'all-small-caps',
       fontWeight: 700,
     },
     h2: {
-      fontSize: 29.75,
+      fontSize: 'clamp(1.5rem, 1.1rem + 2vw, 1.859375rem)',
       fontWeight: 700,
     },
     h3: {
-      fontSize: 24.75,
+      fontSize: 'clamp(1.35rem, 1.05rem + 1.5vw, 1.546875rem)',
       fontWeight: 700,
     },
     h4: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes [DG-219](https://linear.app/dgattey/issue/DG-219/use-more-modern-css)

# What changed?

- Sync browser `color-scheme` with light/dark/system theme so native chrome follows the page
- Honor `prefers-reduced-motion` globally; remove unused `data-animations-enabled` rule
- Apply `text-wrap: balance` to h1–h4 while keeping body `pretty`
- Use `clamp()` fluid sizes for h1–h3 (exclude them from `responsiveFontSizes`)
- Replace RichText heading anchor offset hack with `scroll-margin-top: 136`

# Verification

Runtime checks on `localhost:3000` (all passed):

| Check | Result |
| --- | --- |
| `color-scheme` light/dark | light → `"light"`, dark → `"dark"` |
| `prefers-reduced-motion` | media query present; durations → `0.01ms` when reduce is emulated |
| `text-wrap: balance` | `/music` h1 computed `"balance"` |
| `clamp()` headings | h1 `clamp(1.75rem, 1.2rem + 2.5vw, 2.125rem)`; scales ~28.5→40px |
| RichText `scroll-margin` | `136px`; `#hey-friends` clears sticky header (~18px gap) |

Static: `turbo check` / `check:types` / `test` for `@dg/ui` and `@dg/web` green.

![Homepage light](https://cursor.com/artifacts/c/art-e8c70c5d-6da1-4f91-a656-835bc5b4cc08)
![Music page heading](https://cursor.com/artifacts/c/art-8b6c733e-3576-4edb-acd4-160e04941c2b)
![Homepage dark theme](https://cursor.com/artifacts/c/art-d64eaf4d-2245-43a5-8bba-4b2970145a02)
![Anchor clears sticky header](https://cursor.com/artifacts/c/art-9d591d04-c1f9-4b48-8f7a-c1debfeba04e)

# Release info

- [ ] Major
- [ ] Minor
- [x] Patch

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c0b539fc-1d47-4f27-9edd-04c7415f8b0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0b539fc-1d47-4f27-9edd-04c7415f8b0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

