### PR TITLE
Fix Spotify homepage card stuck on loading skeleton

### DIFF
--- a/apps/web/src/__tests__/proxy.test.ts
+++ b/apps/web/src/__tests__/proxy.test.ts
@@ -28,6 +28,19 @@ const createRequest = ({
 };
 
 describe('proxy', () => {
+  describe('markdown negotiation on public pages', () => {
+    it('does not 406 Flight resumes that lack the stripped rsc header', () => {
+      const response = proxy(
+        new NextRequest('https://example.com/', {
+          headers: { accept: 'text/x-component' },
+        }),
+      );
+
+      expect(response.status).not.toBe(406);
+      expect(response.headers.get('x-middleware-next')).toBe('1');
+    });
+  });
+
   describe('without credentials configured', () => {
     beforeEach(() => {
       mockEnv({
@@ -95,6 +108,7 @@ describe('proxy', () => {
 
     it.each<{ desc: string; headers: Record<string, string> }>([
       { desc: 'RSC requests', headers: { rsc: '1' } },
+      { desc: 'Flight Accept without rsc header', headers: { accept: 'text/x-component' } },
       { desc: 'prefetch requests', headers: { 'next-router-prefetch': '1' } },
       { desc: 'purpose prefetch requests', headers: { purpose: 'prefetch' } },
     ])('returns 401 without WWW-Authenticate for $desc', ({ headers }) => {

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -5,6 +5,7 @@ import {
 import { devConsoleRoute, homeRoute } from '@dg/shared-core/routes/app';
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
+import { isNextFlightRequest } from './services/isNextFlightRequest';
 import { negotiateMarkdown } from './services/markdown/contentNegotiation';
 
 /**
@@ -50,12 +51,8 @@ function protectDevConsole(request: NextRequest): NextResponse | null {
   //   falls back to a hard navigation which triggers the real auth dialog
   // Using redirect() here instead would confuse the client router — it
   // follows the 307, gets home page RSC data, and creates duplicate prompts.
-  const isPrefetchOrRsc =
-    request.headers.get('next-router-prefetch') === '1' ||
-    request.headers.get('purpose') === 'prefetch' ||
-    request.headers.get('rsc') === '1';
-
-  if (isPrefetchOrRsc) {
+  // Detect via Accept: text/x-component too — Proxy strips Flight headers.
+  if (isNextFlightRequest(request)) {
     return new NextResponse(null, { status: 401 });
   }
 

--- a/apps/web/src/services/__tests__/isNextFlightRequest.test.ts
+++ b/apps/web/src/services/__tests__/isNextFlightRequest.test.ts
@@ -1,0 +1,22 @@
+import { NextRequest } from 'next/server';
+import { isNextFlightRequest } from '../isNextFlightRequest';
+
+const createRequest = (headers: Record<string, string> = {}) =>
+  new NextRequest('https://example.com/', { headers });
+
+describe('isNextFlightRequest', () => {
+  it('detects Accept: text/x-component without Flight headers', () => {
+    expect(isNextFlightRequest(createRequest({ accept: 'text/x-component' }))).toBe(true);
+  });
+
+  it('detects rsc / prefetch headers when present', () => {
+    expect(isNextFlightRequest(createRequest({ rsc: '1' }))).toBe(true);
+    expect(isNextFlightRequest(createRequest({ 'next-router-prefetch': '1' }))).toBe(true);
+    expect(isNextFlightRequest(createRequest({ purpose: 'prefetch' }))).toBe(true);
+  });
+
+  it('returns false for normal document Accept', () => {
+    expect(isNextFlightRequest(createRequest({ accept: 'text/html' }))).toBe(false);
+    expect(isNextFlightRequest(createRequest({ accept: 'application/pdf' }))).toBe(false);
+  });
+});

--- a/apps/web/src/services/isNextFlightRequest.ts
+++ b/apps/web/src/services/isNextFlightRequest.ts
@@ -1,0 +1,21 @@
+import type { NextRequest } from 'next/server';
+
+/**
+ * Detects App Router Flight/RSC or prefetch requests.
+ *
+ * Next.js strips internal Flight headers (`rsc`, `next-router-state-tree`,
+ * `next-router-prefetch`) from the `request` instance inside Proxy, so those
+ * headers alone are unreliable. RSC fetches still advertise
+ * `Accept: text/x-component`, which Proxy can see.
+ *
+ * @see https://nextjs.org/docs/app/api-reference/file-conventions/proxy#rsc-requests-and-rewrites
+ */
+export function isNextFlightRequest(request: NextRequest): boolean {
+  const accept = request.headers.get('accept') ?? '';
+  return (
+    accept.includes('text/x-component') ||
+    request.headers.get('rsc') === '1' ||
+    request.headers.get('next-router-prefetch') === '1' ||
+    request.headers.get('purpose') === 'prefetch'
+  );
+}

--- a/apps/web/src/services/markdown/__tests__/contentNegotiation.test.ts
+++ b/apps/web/src/services/markdown/__tests__/contentNegotiation.test.ts
@@ -38,8 +38,26 @@ describe('negotiateMarkdown', () => {
     expect(response?.headers.get('Vary')).toContain('Accept');
   });
 
-  it('skips negotiation for RSC requests', () => {
+  it('skips negotiation for RSC requests with the rsc header', () => {
     const response = negotiateMarkdown(createRequest('/', { accept: 'application/pdf', rsc: '1' }));
+
+    expect(response).toBeNull();
+  });
+
+  it('skips negotiation for Flight Accept without rsc header (Proxy strips it)', () => {
+    // Mirrors production Proxy: Next removes `rsc` from request.headers, but
+    // RSC resumes still send Accept: text/x-component.
+    const response = negotiateMarkdown(createRequest('/', { accept: 'text/x-component' }));
+
+    expect(response).toBeNull();
+  });
+
+  it('skips negotiation for Flight Accept that also lists html', () => {
+    const response = negotiateMarkdown(
+      createRequest('/', {
+        accept: 'text/x-component, text/html;q=0.9',
+      }),
+    );
 
     expect(response).toBeNull();
   });

--- a/apps/web/src/services/markdown/contentNegotiation.ts
+++ b/apps/web/src/services/markdown/contentNegotiation.ts
@@ -8,6 +8,7 @@ import {
 } from '@dg/shared-core/routes/app';
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
+import { isNextFlightRequest } from '../isNextFlightRequest';
 
 const PRODUCES = ['text/html', 'text/markdown'] as const;
 
@@ -31,12 +32,6 @@ const rewriteToMarkdown = (request: NextRequest, htmlPath: MarkdownPagePath): Ne
   return rewritten;
 };
 
-const isNextInternalRequest = (request: NextRequest): boolean =>
-  request.headers.get('rsc') === '1' ||
-  request.headers.get('next-router-prefetch') === '1' ||
-  request.headers.get('purpose') === 'prefetch' ||
-  request.method !== 'GET';
-
 /**
  * Negotiates Markdown vs HTML for registered pages and rewrites `.md` twins
  * to `/llm-markdown`.
@@ -49,7 +44,8 @@ export function negotiateMarkdown(request: NextRequest): NextResponse | null {
     return rewriteToMarkdown(request, htmlFromMarkdown);
   }
 
-  if (!isMarkdownPagePath(pathname) || isNextInternalRequest(request)) {
+  // Skip Flight/RSC + non-GET: negotiation must not 406 text/x-component resumes.
+  if (!isMarkdownPagePath(pathname) || isNextFlightRequest(request) || request.method !== 'GET') {
     return null;
   }
 

--- a/package.json
+++ b/package.json
@@ -27,5 +27,5 @@
     "clean": "rm -f .env .env.tmp",
     "preinstall": "npx only-allow pnpm"
   },
-  "version": "2.61.4"
+  "version": "2.61.5"
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes

# What changed?

- Homepage Spotify card (and other Cache Components Suspense holes) stayed on the loading skeleton after [#547](https://github.com/dgattey/dg/pull/547) shipped Markdown Accept negotiation.
- **Root cause (code, not Spotify auth):** Next.js Proxy strips Flight headers (`rsc`, etc.) from the request instance. Negotiation only checked those headers, then returned **406** for `Accept: text/x-component`, which is what RSC resumes use. The static PPR shell kept showing `SpotifyCardLoading` forever.
- Detect Flight/RSC via `Accept: text/x-component` (shared `isNextFlightRequest`) in markdown negotiation and dev-console auth handling.
- Tests cover Flight Accept without the stripped `rsc` header.

### Live evidence (production, pre-fix)

[evidence note](https://cursor.com/artifacts/c/art-3163a6ab-871b-47d2-889d-4234327d169b)

- HTML: `MuiSkeleton` present, no `open.spotify.com/track`, response ends on postponed `<!--$?-->` hole (no `</html>`).
- `curl -H 'Accept: text/x-component' https://dylangattey.com/` → **406** `Not Acceptable / Available: text/html, text/markdown`.

### Not the cause

- Spotify OAuth token / API path itself was not exercised; Suspense never resumed so `getLatestSong` never got a chance to render.
- Did not touch GatteySites / side-projects work.

### Verification

- `turbo check --filter=@dg/web`
- `turbo check:types --filter=@dg/web`
- Focused Jest: `contentNegotiation|isNextFlightRequest|proxy.test` (22 passed; noop globalSetup because `DATABASE_URL_TEST` unavailable in this cloud env)

# Release info

- [ ] Major
- [ ] Minor
- [x] Patch

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4188f3b3-6fd3-4fce-abaa-a54911dbbb2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4188f3b3-6fd3-4fce-abaa-a54911dbbb2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

