### PR TITLE
Fix homepage stream dying on Vercel by dropping after() from cached Spotify fetch

### DIFF
--- a/apps/web/src/services/__tests__/spotify.test.ts
+++ b/apps/web/src/services/__tests__/spotify.test.ts
@@ -1,0 +1,42 @@
+import type { Track } from '@dg/content-models/spotify/Track';
+
+jest.mock('next/cache', () => ({
+  cacheLife: jest.fn(),
+  cacheTag: jest.fn(),
+}));
+
+// Simulates environments without `waitUntil` (Vercel PPR resume, ISR
+// revalidation, dynamic RSC renders): any `after()` call throws Next error
+// E91 there. `getLatestSong` runs inside 'use cache', so calling `after()`
+// from it fatally breaks the homepage stream (truncated HTML shell, 0-byte
+// /index.rsc, "Connection closed" in the browser).
+jest.mock('next/server', () => ({
+  ...jest.requireActual('next/server'),
+  after: jest.fn(() => {
+    throw new Error(
+      '`after()` will not work correctly, because `waitUntil` is not available in the current environment.',
+    );
+  }),
+}));
+
+jest.mock('@dg/services/spotify/fetchRecentlyPlayed', () => ({
+  fetchRecentlyPlayed: jest.fn(),
+}));
+
+import { fetchRecentlyPlayed } from '@dg/services/spotify/fetchRecentlyPlayed';
+import { MissingTokenError } from '@dg/shared-core/errors/MissingTokenError';
+import { getLatestSong } from '../spotify';
+
+const track = { id: 'track-1', name: 'Test Song' } as Track;
+
+describe('getLatestSong', () => {
+  it('resolves the latest track even where after() is unavailable', async () => {
+    jest.mocked(fetchRecentlyPlayed).mockResolvedValue(track);
+    await expect(getLatestSong()).resolves.toBe(track);
+  });
+
+  it('returns null when tokens are missing', async () => {
+    jest.mocked(fetchRecentlyPlayed).mockRejectedValue(new MissingTokenError('spotify'));
+    await expect(getLatestSong()).resolves.toBeNull();
+  });
+});

--- a/apps/web/src/services/spotify.ts
+++ b/apps/web/src/services/spotify.ts
@@ -1,9 +1,7 @@
 import 'server-only';
 
 import { fetchRecentlyPlayed } from '@dg/services/spotify/fetchRecentlyPlayed';
-import { syncSpotifyHistoryWithLogging } from '@dg/services/spotify/syncSpotifyHistory';
 import { cacheLife, cacheTag } from 'next/cache';
-import { after } from 'next/server';
 import { withMissingTokenFallback } from './withMissingTokenFallback';
 
 const LATEST_SONG_TAG = 'latest-song';
@@ -13,19 +11,18 @@ const LATEST_SONG_TAG = 'latest-song';
  * - currently playing track if available
  * - otherwise the most recently played track
  * - null if tokens are missing
+ *
+ * Do not schedule `after()` work here: this 'use cache' scope re-executes
+ * during ISR revalidation, PPR resume, and dynamic RSC renders, where
+ * `waitUntil` can be unavailable. `after()` then throws (Next error E91)
+ * and fatally kills the whole stream — the homepage ships a truncated
+ * shell and `/index.rsc` responds with an empty body, so the client dies
+ * with "Connection closed". History syncing runs via the
+ * /api/spotify/sync cron instead.
  */
 export const getLatestSong = async () => {
   'use cache';
   cacheLife('seconds');
   cacheTag(LATEST_SONG_TAG);
-  const track = await withMissingTokenFallback(fetchRecentlyPlayed());
-
-  after(async () => {
-    await syncSpotifyHistoryWithLogging({
-      context: 'backfill',
-      failureLogLevel: 'warn',
-    });
-  });
-
-  return track;
+  return await withMissingTokenFallback(fetchRecentlyPlayed());
 };

--- a/package.json
+++ b/package.json
@@ -27,5 +27,5 @@
     "clean": "rm -f .env .env.tmp",
     "preinstall": "npx only-allow pnpm"
   },
-  "version": "2.61.6"
+  "version": "2.61.7"
 }


### PR DESCRIPTION
Fixes the production homepage dying with `Uncaught (in promise) Error: Connection closed.` and the Spotify card being stuck on its skeleton forever.

## Root cause

`getLatestSong` (`apps/web/src/services/spotify.ts`) called `after(syncSpotifyHistoryWithLogging)` **inside its `'use cache'` scope** (added in #535). That cached scope re-executes during ISR revalidation, PPR resume chains, and dynamic RSC renders. In the Vercel runtime those execution contexts don't provide `waitUntil`, so `after()` throws Next error **E91** (`` `after()` will not work correctly, because `waitUntil` is not available in the current environment ``). `after()` is documented for Server Components, Server Functions, Route Handlers, and Proxy — not `'use cache'` functions.

On the deployed site that one throw cascaded into everything we saw:

- **Dynamic RSC renders died fatally** → `/index.rsc` and `/music.rsc` returned 200 with a **0-byte body**, which the CDN cached (`x-vercel-cache: STALE/HIT`).
- **The PPR resume chain died** → the CDN served the prerendered static shell with no streamed tail: the document ends mid-stream after the `B:0`/`B:1`/`B:2` Suspense holes with no `</body></html>`.
- **Every background revalidation failed** → the poisoned cache entries were served STALE forever (ages kept growing, dating back to the deploy).
- The Next Flight client saw the inlined stream end without completing and threw `Connection closed.`; the Spotify holes (`B:0` header, `B:1` homepage card) never resolved.

Direct production confirmation: requesting `/` with a bot user-agent (which is in `experimentalBypassFor` and forces a full dynamic render) returns **HTTP 500** with `x-matched-path: /500`. Runtime env is fine (`/api/spotify/sync` returns a proper 401 JSON, and that route imports the same `@dg/db` module graph), so the fatal error is in the render path itself.

## Reproduction

Reproduced locally by replicating Vercel's exact lambda launcher (`NextServer` with `minimalMode: true`, no request-context `waitUntil`, per `@vercel/next`'s `server-launcher.js`) against a production build:

| Request | Before fix | After fix |
| --- | --- | --- |
| `POST /` + `next-resume: 1` + postponed state (resume chain) | 200 but Spotify boundaries error with `$RX("B:0","4155596709@E91")` | 200, holes filled, no `$RX` |
| `GET /index.rsc` (dynamic RSC) | **500, 0 bytes** | **200, ~65 KB** |
| `GET /` with bot UA (full render) | Flight error chunks `E{"digest":"4155596709@E91"}` (500 on prod) | 200, complete document |

The `4155596709@E91` digest ties the observed failures directly to the `after()` call.

## Fix

Remove the `after()` call from the cached function. History syncing is unaffected: the `/api/spotify/sync` cron (`.github/workflows/spotify-sync.yml`, every 30 minutes) runs the identical `syncSpotifyHistoryWithLogging` and revalidates tags. The `after()` backfill was a redundant opportunistic path — and because it lived inside `'use cache'`, it only ever ran on cache misses anyway.

Adds a regression test that executes `getLatestSong` with `after()` stubbed to throw E91 (matching `waitUntil`-less environments); it fails against the old code and passes now.

## Verification

- `turbo check --filter=@dg/web` ✅
- `turbo check:types --filter=@dg/web` ✅
- `turbo test --filter=@dg/web` ✅ (19 suites, 79 tests, including the new regression test; confirmed the new test fails against the previous implementation)
- `next build` ✅ — `/` still builds as ◐ Partial Prerender
- Vercel-launcher simulation (minimal mode): resume chain, `/index.rsc`, and bot-UA full render all succeed with complete, non-empty output (table above)
- Plain `next start`: `/` returns a complete document ending in `</html>` with the Spotify card resumed; RSC response is ~74 KB; `/music` complete

## Deploy note

The current CDN entries are poisoned (truncated shell + 0-byte RSC, served STALE). Deploying this PR replaces the cache namespace with the new deployment, and revalidations succeed again afterwards, so no manual purge should be needed — but if anything lingers, purge the data cache for `/` and `/music` once.

## Version

- [ ] Major
- [ ] Minor
- [x] Patch
