### PR TITLE
Add favorite albums page with sortable album grid

### DIFF
--- a/apps/web/src/app/llm-markdown/pageMarkdown.ts
+++ b/apps/web/src/app/llm-markdown/pageMarkdown.ts
@@ -1,12 +1,14 @@
 import 'server-only';
 
 import {
+  favoriteAlbumsRoute,
   homeRoute,
   isMarkdownPagePath,
   type MarkdownPagePath,
   musicRoute,
 } from '@dg/shared-core/routes/app';
 import { getHomepageMarkdown } from '../home/homepageMarkdown';
+import { getFavoriteAlbumsMarkdown } from '../music/albums/favoriteAlbumsMarkdown';
 import { getMusicMarkdown } from '../music/musicMarkdown';
 
 /**
@@ -16,6 +18,7 @@ import { getMusicMarkdown } from '../music/musicMarkdown';
 export const pageMarkdownGenerators: {
   [Path in MarkdownPagePath]: () => Promise<string>;
 } = {
+  [favoriteAlbumsRoute]: getFavoriteAlbumsMarkdown,
   [homeRoute]: getHomepageMarkdown,
   [musicRoute]: getMusicMarkdown,
 };

--- a/apps/web/src/app/music/albums/FavoriteAlbumsGrid.tsx
+++ b/apps/web/src/app/music/albums/FavoriteAlbumsGrid.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import type { PlaylistAlbum } from '@dg/content-models/spotify/PlaylistAlbums';
+import { EASING_DEFAULT, TIMING_SLOW } from '@dg/ui/helpers/timing';
+import type { SxObject } from '@dg/ui/theme';
+import { Box, Stack, ToggleButton, ToggleButtonGroup } from '@mui/material';
+import { useLayoutEffect, useRef, useState } from 'react';
+import { AlbumThumbnail } from '../../spotify/AlbumThumbnail';
+
+const SORT_OPTIONS = [
+  { key: 'added', label: 'Recently added' },
+  { key: 'album', label: 'Album' },
+  { key: 'artist', label: 'Artist' },
+  { key: 'released', label: 'Release date' },
+] as const;
+
+type AlbumSortKey = (typeof SORT_OPTIONS)[number]['key'];
+
+const comparators: Record<AlbumSortKey, (a: PlaylistAlbum, b: PlaylistAlbum) => number> = {
+  added: (a, b) => b.addedAt.localeCompare(a.addedAt),
+  album: (a, b) => a.name.localeCompare(b.name),
+  artist: (a, b) => a.primaryArtist.localeCompare(b.primaryArtist) || a.name.localeCompare(b.name),
+  released: (a, b) => b.releaseDate.localeCompare(a.releaseDate),
+};
+
+const gridSx: SxObject = {
+  display: 'grid',
+  gap: 2,
+  gridTemplateColumns: {
+    lg: 'repeat(6, 1fr)',
+    md: 'repeat(4, 1fr)',
+    sm: 'repeat(3, 1fr)',
+    xs: 'repeat(2, 1fr)',
+  },
+};
+
+const sortControlSx: SxObject = {
+  flexWrap: 'wrap',
+};
+
+type Props = {
+  albums: Array<PlaylistAlbum>;
+};
+
+/**
+ * Sortable grid of favorite album covers. Reordering runs a FLIP animation:
+ * item positions are captured before the sort is applied, then each moved
+ * item plays from its old position to its new one.
+ */
+export function FavoriteAlbumsGrid({ albums }: Props) {
+  const [sortKey, setSortKey] = useState<AlbumSortKey>('added');
+  const itemRefs = useRef(new Map<string, HTMLElement>());
+  const previousRects = useRef<Map<string, DOMRect> | null>(null);
+
+  const handleSortChange = (_event: React.MouseEvent, next: AlbumSortKey | null) => {
+    if (!next || next === sortKey) {
+      return;
+    }
+    previousRects.current = new Map(
+      [...itemRefs.current].map(([id, element]) => [id, element.getBoundingClientRect()]),
+    );
+    setSortKey(next);
+  };
+
+  // No dependency array: runs after every render but only animates when a
+  // sort change just captured the previous item positions.
+  useLayoutEffect(() => {
+    const previous = previousRects.current;
+    previousRects.current = null;
+    if (!previous || window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) {
+      return;
+    }
+    for (const [id, element] of itemRefs.current) {
+      const before = previous.get(id);
+      if (!before || typeof element.animate !== 'function') {
+        continue;
+      }
+      const after = element.getBoundingClientRect();
+      const deltaX = before.left - after.left;
+      const deltaY = before.top - after.top;
+      if (deltaX === 0 && deltaY === 0) {
+        continue;
+      }
+      element.animate(
+        [{ transform: `translate(${deltaX}px, ${deltaY}px)` }, { transform: 'translate(0, 0)' }],
+        { duration: TIMING_SLOW, easing: EASING_DEFAULT },
+      );
+    }
+  });
+
+  const sortedAlbums = [...albums].sort(comparators[sortKey]);
+
+  return (
+    <Stack spacing={2}>
+      <ToggleButtonGroup
+        aria-label="Sort albums"
+        exclusive={true}
+        onChange={handleSortChange}
+        size="small"
+        sx={sortControlSx}
+        value={sortKey}
+      >
+        {SORT_OPTIONS.map((option) => (
+          <ToggleButton key={option.key} value={option.key}>
+            {option.label}
+          </ToggleButton>
+        ))}
+      </ToggleButtonGroup>
+      <Box sx={gridSx}>
+        {sortedAlbums.map((album) => (
+          <Box
+            key={album.id}
+            ref={(element: HTMLElement | null) => {
+              if (element) {
+                itemRefs.current.set(album.id, element);
+              } else {
+                itemRefs.current.delete(album.id);
+              }
+            }}
+          >
+            <AlbumThumbnail
+              albumName={album.name}
+              imageUrl={album.imageUrl}
+              linkUrl={album.url}
+              tooltip={`${album.name} – ${album.artistNames}`}
+            />
+          </Box>
+        ))}
+      </Box>
+    </Stack>
+  );
+}

--- a/apps/web/src/app/music/albums/FavoriteAlbumsGrid.tsx
+++ b/apps/web/src/app/music/albums/FavoriteAlbumsGrid.tsx
@@ -1,9 +1,11 @@
 'use client';
 
 import type { PlaylistAlbum } from '@dg/content-models/spotify/PlaylistAlbums';
+import { GlassSwitcher } from '@dg/ui/core/GlassSwitcher';
 import { EASING_DEFAULT, TIMING_SLOW } from '@dg/ui/helpers/timing';
 import type { SxObject } from '@dg/ui/theme';
-import { Box, Stack, ToggleButton, ToggleButtonGroup } from '@mui/material';
+import { Box, Stack } from '@mui/material';
+import { ArrowDownUp } from 'lucide-react';
 import { useLayoutEffect, useRef, useState } from 'react';
 import { AlbumThumbnail } from '../../spotify/AlbumThumbnail';
 
@@ -34,10 +36,6 @@ const gridSx: SxObject = {
   },
 };
 
-const sortControlSx: SxObject = {
-  flexWrap: 'wrap',
-};
-
 type Props = {
   albums: Array<PlaylistAlbum>;
 };
@@ -52,8 +50,8 @@ export function FavoriteAlbumsGrid({ albums }: Props) {
   const itemRefs = useRef(new Map<string, HTMLElement>());
   const previousRects = useRef<Map<string, DOMRect> | null>(null);
 
-  const handleSortChange = (_event: React.MouseEvent, next: AlbumSortKey | null) => {
-    if (!next || next === sortKey) {
+  const handleSortChange = (next: AlbumSortKey) => {
+    if (next === sortKey) {
       return;
     }
     previousRects.current = new Map(
@@ -92,20 +90,13 @@ export function FavoriteAlbumsGrid({ albums }: Props) {
 
   return (
     <Stack spacing={2}>
-      <ToggleButtonGroup
+      <GlassSwitcher
         aria-label="Sort albums"
-        exclusive={true}
-        onChange={handleSortChange}
-        size="small"
-        sx={sortControlSx}
+        mobileIcon={<ArrowDownUp size={18} />}
+        onChange={(next) => handleSortChange(next as AlbumSortKey)}
+        options={SORT_OPTIONS.map((option) => ({ label: option.label, value: option.key }))}
         value={sortKey}
-      >
-        {SORT_OPTIONS.map((option) => (
-          <ToggleButton key={option.key} value={option.key}>
-            {option.label}
-          </ToggleButton>
-        ))}
-      </ToggleButtonGroup>
+      />
       <Box sx={gridSx}>
         {sortedAlbums.map((album) => (
           <Box

--- a/apps/web/src/app/music/albums/__tests__/FavoriteAlbumsGrid.test.tsx
+++ b/apps/web/src/app/music/albums/__tests__/FavoriteAlbumsGrid.test.tsx
@@ -1,0 +1,89 @@
+import type { PlaylistAlbum } from '@dg/content-models/spotify/PlaylistAlbums';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FavoriteAlbumsGrid } from '../FavoriteAlbumsGrid';
+
+const albums: Array<PlaylistAlbum> = [
+  {
+    addedAt: '2026-03-01T00:00:00Z',
+    artistNames: 'Alpha',
+    id: 'album-zebra',
+    imageUrl: 'https://i.scdn.co/image/zebra',
+    name: 'Zebra',
+    primaryArtist: 'Alpha',
+    releaseDate: '2001-05-01',
+    url: 'https://open.spotify.com/album/zebra',
+  },
+  {
+    addedAt: '2026-02-01T00:00:00Z',
+    artistNames: 'Zulu',
+    id: 'album-mango',
+    imageUrl: 'https://i.scdn.co/image/mango',
+    name: 'Mango',
+    primaryArtist: 'Zulu',
+    releaseDate: '2010',
+    url: 'https://open.spotify.com/album/mango',
+  },
+  {
+    addedAt: '2026-01-01T00:00:00Z',
+    artistNames: 'Mike, Guest',
+    id: 'album-apple',
+    imageUrl: 'https://i.scdn.co/image/apple',
+    name: 'Apple',
+    primaryArtist: 'Mike',
+    releaseDate: '2020-11-20',
+    url: 'https://open.spotify.com/album/apple',
+  },
+];
+
+const renderedAlbumNames = () =>
+  screen.getAllByRole('img').map((image) => image.getAttribute('alt'));
+
+describe('FavoriteAlbumsGrid', () => {
+  it('defaults to newest added first and links each album on Spotify', () => {
+    render(<FavoriteAlbumsGrid albums={albums} />);
+
+    expect(renderedAlbumNames()).toEqual(['Zebra', 'Mango', 'Apple']);
+
+    const link = screen.getByRole('link', { name: 'Zebra' });
+    expect(link).toHaveAttribute('href', 'https://open.spotify.com/album/zebra');
+    expect(link).toHaveAttribute('target', '_blank');
+  });
+
+  it('sorts by album name', async () => {
+    const user = userEvent.setup();
+    render(<FavoriteAlbumsGrid albums={albums} />);
+
+    await user.click(screen.getByRole('button', { name: 'Album' }));
+
+    expect(renderedAlbumNames()).toEqual(['Apple', 'Mango', 'Zebra']);
+  });
+
+  it('sorts by artist name', async () => {
+    const user = userEvent.setup();
+    render(<FavoriteAlbumsGrid albums={albums} />);
+
+    await user.click(screen.getByRole('button', { name: 'Artist' }));
+
+    expect(renderedAlbumNames()).toEqual(['Zebra', 'Apple', 'Mango']);
+  });
+
+  it('sorts by release date, newest first', async () => {
+    const user = userEvent.setup();
+    render(<FavoriteAlbumsGrid albums={albums} />);
+
+    await user.click(screen.getByRole('button', { name: 'Release date' }));
+
+    expect(renderedAlbumNames()).toEqual(['Apple', 'Mango', 'Zebra']);
+  });
+
+  it('returns to the default order via recently added', async () => {
+    const user = userEvent.setup();
+    render(<FavoriteAlbumsGrid albums={albums} />);
+
+    await user.click(screen.getByRole('button', { name: 'Album' }));
+    await user.click(screen.getByRole('button', { name: 'Recently added' }));
+
+    expect(renderedAlbumNames()).toEqual(['Zebra', 'Mango', 'Apple']);
+  });
+});

--- a/apps/web/src/app/music/albums/__tests__/FavoriteAlbumsGrid.test.tsx
+++ b/apps/web/src/app/music/albums/__tests__/FavoriteAlbumsGrid.test.tsx
@@ -39,6 +39,11 @@ const albums: Array<PlaylistAlbum> = [
 const renderedAlbumNames = () =>
   screen.getAllByRole('img').map((image) => image.getAttribute('alt'));
 
+/** Clicks a sort option in the GlassSwitcher (hidden radio inside a label). */
+const clickSort = async (user: ReturnType<typeof userEvent.setup>, label: string) => {
+  await user.click(screen.getByRole('radio', { hidden: true, name: label }));
+};
+
 describe('FavoriteAlbumsGrid', () => {
   it('defaults to newest added first and links each album on Spotify', () => {
     render(<FavoriteAlbumsGrid albums={albums} />);
@@ -54,7 +59,7 @@ describe('FavoriteAlbumsGrid', () => {
     const user = userEvent.setup();
     render(<FavoriteAlbumsGrid albums={albums} />);
 
-    await user.click(screen.getByRole('button', { name: 'Album' }));
+    await clickSort(user, 'Album');
 
     expect(renderedAlbumNames()).toEqual(['Apple', 'Mango', 'Zebra']);
   });
@@ -63,7 +68,7 @@ describe('FavoriteAlbumsGrid', () => {
     const user = userEvent.setup();
     render(<FavoriteAlbumsGrid albums={albums} />);
 
-    await user.click(screen.getByRole('button', { name: 'Artist' }));
+    await clickSort(user, 'Artist');
 
     expect(renderedAlbumNames()).toEqual(['Zebra', 'Apple', 'Mango']);
   });
@@ -72,7 +77,7 @@ describe('FavoriteAlbumsGrid', () => {
     const user = userEvent.setup();
     render(<FavoriteAlbumsGrid albums={albums} />);
 
-    await user.click(screen.getByRole('button', { name: 'Release date' }));
+    await clickSort(user, 'Release date');
 
     expect(renderedAlbumNames()).toEqual(['Apple', 'Mango', 'Zebra']);
   });
@@ -81,8 +86,8 @@ describe('FavoriteAlbumsGrid', () => {
     const user = userEvent.setup();
     render(<FavoriteAlbumsGrid albums={albums} />);
 
-    await user.click(screen.getByRole('button', { name: 'Album' }));
-    await user.click(screen.getByRole('button', { name: 'Recently added' }));
+    await clickSort(user, 'Album');
+    await clickSort(user, 'Recently added');
 
     expect(renderedAlbumNames()).toEqual(['Zebra', 'Mango', 'Apple']);
   });

--- a/apps/web/src/app/music/albums/favoriteAlbumsMarkdown.ts
+++ b/apps/web/src/app/music/albums/favoriteAlbumsMarkdown.ts
@@ -1,0 +1,38 @@
+import 'server-only';
+
+import { favoriteAlbumsRoute } from '@dg/shared-core/routes/app';
+import { getFavoriteAlbums } from '../../../services/albums';
+import { relatedPageLinksMarkdown } from '../../llm-markdown/relatedPageLinksMarkdown';
+import { SITE_NAME } from '../../metadata';
+
+/**
+ * Markdown representation of favorite albums — kept next to the albums page.
+ */
+export async function getFavoriteAlbumsMarkdown(): Promise<string> {
+  try {
+    const albums = await getFavoriteAlbums();
+    const sections: Array<string> = [
+      '# Favorite albums',
+      `> All-time favorite albums from ${SITE_NAME}`,
+    ];
+
+    if (albums.length === 0) {
+      sections.push('No albums available.');
+    } else {
+      sections.push(
+        '## Albums',
+        albums
+          .map(
+            (album) =>
+              `- [${album.name}](${album.url}) — ${album.artistNames} (released ${album.releaseDate})`,
+          )
+          .join('\n'),
+      );
+    }
+
+    sections.push(relatedPageLinksMarkdown(favoriteAlbumsRoute));
+    return `${sections.join('\n\n')}\n`;
+  } catch {
+    return `# Favorite albums\n\n> Favorite albums are unavailable right now.\n`;
+  }
+}

--- a/apps/web/src/app/music/albums/page.tsx
+++ b/apps/web/src/app/music/albums/page.tsx
@@ -1,0 +1,38 @@
+import 'server-only';
+
+import { isMissingTokenError } from '@dg/shared-core/errors/MissingTokenError';
+import { favoriteAlbumsRoute } from '@dg/shared-core/routes/app';
+import { Stack, Typography } from '@mui/material';
+import type { Metadata } from 'next';
+import { redirect } from 'next/navigation';
+import { getFavoriteAlbums } from '../../../services/albums';
+import { markdownAlternates } from '../../layouts/markdownAlternates';
+import { FavoriteAlbumsGrid } from './FavoriteAlbumsGrid';
+
+export const metadata: Metadata = {
+  alternates: markdownAlternates(favoriteAlbumsRoute),
+  title: 'Favorite albums',
+};
+
+export default async function FavoriteAlbumsPage() {
+  let albums: Awaited<ReturnType<typeof getFavoriteAlbums>>;
+
+  try {
+    albums = await getFavoriteAlbums();
+  } catch (error) {
+    // In development, redirect to the dev page to set up OAuth
+    if (isMissingTokenError(error) && process.env.NODE_ENV === 'development') {
+      redirect('/dev');
+    }
+    throw error;
+  }
+
+  return (
+    <main>
+      <Stack spacing={2}>
+        <Typography variant="h1">Favorite albums</Typography>
+        <FavoriteAlbumsGrid albums={albums} />
+      </Stack>
+    </main>
+  );
+}

--- a/apps/web/src/app/spotify/TrackListing.tsx
+++ b/apps/web/src/app/spotify/TrackListing.tsx
@@ -1,4 +1,5 @@
 import type { Track } from '@dg/content-models/spotify/Track';
+import { favoriteAlbumsRoute } from '@dg/shared-core/routes/app';
 import { Image } from '@dg/ui/dependent/Image';
 import { Link } from '@dg/ui/dependent/Link';
 import { createTransition, EASING_BOUNCE, TIMING_SLOW } from '@dg/ui/helpers/timing';
@@ -49,6 +50,20 @@ const cardHeaderSx: SxObject = {
   justifyContent: 'space-between',
 };
 
+const statusRowSx: SxObject = {
+  alignItems: 'baseline',
+  display: 'flex',
+  gap: 1,
+  justifyContent: 'space-between',
+};
+
+const getAlbumsLinkSx = (color?: string, textShadow?: string): SxObject => ({
+  color: color ?? 'var(--mui-palette-text-secondary)',
+  flexShrink: 0,
+  textShadow,
+  whiteSpace: 'nowrap',
+});
+
 function CardLayout({ track, colors }: { track: Track; colors: Colors | null }) {
   const { primary, secondary, primaryShadow, secondaryShadow } = colors ?? {};
   const trackUrl = track.externalUrls.spotify;
@@ -65,13 +80,23 @@ function CardLayout({ track, colors }: { track: Track; colors: Colors | null }) 
         <AlbumImage isPlaying={Boolean(track.isPlaying)} noteColor={primary} track={track} />
       </Stack>
       <Stack>
-        <PlaybackStatus
-          color={primary}
-          isPlaying={track.isPlaying}
-          listingVariant="card"
-          playedAt={track.playedAt}
-          textShadow={primaryShadow}
-        />
+        <Box sx={statusRowSx}>
+          <PlaybackStatus
+            color={primary}
+            isPlaying={track.isPlaying}
+            listingVariant="card"
+            playedAt={track.playedAt}
+            textShadow={primaryShadow}
+          />
+          <Link
+            href={favoriteAlbumsRoute}
+            sx={getAlbumsLinkSx(secondary, secondaryShadow)}
+            title="Favorite albums"
+            variant="overline"
+          >
+            Favorite albums
+          </Link>
+        </Box>
         <TrackTitle
           color={primary}
           listingVariant="card"

--- a/apps/web/src/app/spotify/TrackListing.tsx
+++ b/apps/web/src/app/spotify/TrackListing.tsx
@@ -1,10 +1,13 @@
 import type { Track } from '@dg/content-models/spotify/Track';
 import { favoriteAlbumsRoute } from '@dg/shared-core/routes/app';
+import { GlassContainer } from '@dg/ui/core/GlassContainer';
 import { Image } from '@dg/ui/dependent/Image';
 import { Link } from '@dg/ui/dependent/Link';
+import { createBouncyTransition } from '@dg/ui/helpers/bouncyTransition';
 import { createTransition, EASING_BOUNCE, TIMING_SLOW } from '@dg/ui/helpers/timing';
 import type { SxObject } from '@dg/ui/theme';
-import { Box, Card, Stack } from '@mui/material';
+import { Box, Card, Stack, Typography } from '@mui/material';
+import { Disc3 } from 'lucide-react';
 import { AlbumArtWithNotes } from './AlbumArtWithNotes';
 import { AlbumImage } from './AlbumImage';
 import { ArtistList } from './ArtistList';
@@ -50,19 +53,43 @@ const cardHeaderSx: SxObject = {
   justifyContent: 'space-between',
 };
 
-const statusRowSx: SxObject = {
-  alignItems: 'baseline',
-  display: 'flex',
-  gap: 1,
-  justifyContent: 'space-between',
+const logoColumnSx: SxObject = {
+  alignItems: 'flex-start',
 };
 
-const getAlbumsLinkSx = (color?: string, textShadow?: string): SxObject => ({
-  color: color ?? 'var(--mui-palette-text-secondary)',
-  flexShrink: 0,
-  textShadow,
+const albumsChipSx: SxObject = {
+  '&:hover': {
+    transform: 'scale(1.05)',
+  },
+  alignItems: 'center',
+  borderRadius: '999px',
+  color: 'var(--mui-palette-text-primary)',
+  display: 'inline-flex',
+  gap: 0.75,
+  paddingBlock: 0.5,
+  paddingInline: 1.25,
+  width: 'fit-content',
+  ...createBouncyTransition('transform'),
+};
+
+const albumsChipTextSx: SxObject = {
+  lineHeight: 1.2,
   whiteSpace: 'nowrap',
-});
+};
+
+/** Small glass chip linking to the favorite albums page. */
+function FavoriteAlbumsChip() {
+  return (
+    <Link href={favoriteAlbumsRoute} title="Favorite albums" underline="none">
+      <GlassContainer sx={albumsChipSx}>
+        <Disc3 size={14} />
+        <Typography component="span" sx={albumsChipTextSx} variant="overline">
+          Favorite albums
+        </Typography>
+      </GlassContainer>
+    </Link>
+  );
+}
 
 function CardLayout({ track, colors }: { track: Track; colors: Colors | null }) {
   const { primary, secondary, primaryShadow, secondaryShadow } = colors ?? {};
@@ -71,32 +98,25 @@ function CardLayout({ track, colors }: { track: Track; colors: Colors | null }) 
   return (
     <Stack sx={cardLayoutSx}>
       <Stack direction="row" sx={cardHeaderSx}>
-        <SpotifyLogo
-          color={primary}
-          textShadow={primaryShadow}
-          trackTitle={track.name}
-          url={trackUrl}
-        />
+        <Stack spacing={1.5} sx={logoColumnSx}>
+          <SpotifyLogo
+            color={primary}
+            textShadow={primaryShadow}
+            trackTitle={track.name}
+            url={trackUrl}
+          />
+          <FavoriteAlbumsChip />
+        </Stack>
         <AlbumImage isPlaying={Boolean(track.isPlaying)} noteColor={primary} track={track} />
       </Stack>
       <Stack>
-        <Box sx={statusRowSx}>
-          <PlaybackStatus
-            color={primary}
-            isPlaying={track.isPlaying}
-            listingVariant="card"
-            playedAt={track.playedAt}
-            textShadow={primaryShadow}
-          />
-          <Link
-            href={favoriteAlbumsRoute}
-            sx={getAlbumsLinkSx(secondary, secondaryShadow)}
-            title="Favorite albums"
-            variant="overline"
-          >
-            Favorite albums
-          </Link>
-        </Box>
+        <PlaybackStatus
+          color={primary}
+          isPlaying={track.isPlaying}
+          listingVariant="card"
+          playedAt={track.playedAt}
+          textShadow={primaryShadow}
+        />
         <TrackTitle
           color={primary}
           listingVariant="card"

--- a/apps/web/src/app/spotify/TrackListing.tsx
+++ b/apps/web/src/app/spotify/TrackListing.tsx
@@ -1,13 +1,9 @@
 import type { Track } from '@dg/content-models/spotify/Track';
-import { favoriteAlbumsRoute } from '@dg/shared-core/routes/app';
-import { GlassContainer } from '@dg/ui/core/GlassContainer';
 import { Image } from '@dg/ui/dependent/Image';
 import { Link } from '@dg/ui/dependent/Link';
-import { createBouncyTransition } from '@dg/ui/helpers/bouncyTransition';
 import { createTransition, EASING_BOUNCE, TIMING_SLOW } from '@dg/ui/helpers/timing';
 import type { SxObject } from '@dg/ui/theme';
-import { Box, Card, Stack, Typography } from '@mui/material';
-import { Disc3 } from 'lucide-react';
+import { Box, Card, Stack } from '@mui/material';
 import { AlbumArtWithNotes } from './AlbumArtWithNotes';
 import { AlbumImage } from './AlbumImage';
 import { ArtistList } from './ArtistList';
@@ -53,55 +49,6 @@ const cardHeaderSx: SxObject = {
   justifyContent: 'space-between',
 };
 
-/**
- * Anchors the chip without contributing width: the card's breakout album art
- * depends on the header row's intrinsic width staying logo + gap + art.
- */
-const logoColumnSx: SxObject = {
-  position: 'relative',
-};
-
-const albumsChipSx: SxObject = {
-  '&:hover': {
-    transform: 'scale(1.05)',
-  },
-  alignItems: 'center',
-  borderRadius: '999px',
-  color: 'var(--mui-palette-text-primary)',
-  display: 'inline-flex',
-  gap: 0.75,
-  // Below the 3rem Spotify logo, out of the header row's layout flow
-  insetBlockStart: 'calc(3rem + 12px)',
-  insetInlineStart: 0,
-  paddingBlock: 0.5,
-  paddingInline: 1.25,
-  position: 'absolute',
-  width: 'fit-content',
-  ...createBouncyTransition('transform'),
-};
-
-const albumsChipTextSx: SxObject = {
-  lineHeight: 1.2,
-  whiteSpace: 'nowrap',
-};
-
-/**
- * Small glass chip linking to the favorite albums page. Label is short so the
- * chip clears the breakout album art on its right.
- */
-function FavoriteAlbumsChip() {
-  return (
-    <Link href={favoriteAlbumsRoute} title="Favorite albums" underline="none">
-      <GlassContainer sx={albumsChipSx}>
-        <Disc3 size={14} />
-        <Typography component="span" sx={albumsChipTextSx} variant="overline">
-          Albums
-        </Typography>
-      </GlassContainer>
-    </Link>
-  );
-}
-
 function CardLayout({ track, colors }: { track: Track; colors: Colors | null }) {
   const { primary, secondary, primaryShadow, secondaryShadow } = colors ?? {};
   const trackUrl = track.externalUrls.spotify;
@@ -109,15 +56,12 @@ function CardLayout({ track, colors }: { track: Track; colors: Colors | null }) 
   return (
     <Stack sx={cardLayoutSx}>
       <Stack direction="row" sx={cardHeaderSx}>
-        <Box sx={logoColumnSx}>
-          <SpotifyLogo
-            color={primary}
-            textShadow={primaryShadow}
-            trackTitle={track.name}
-            url={trackUrl}
-          />
-          <FavoriteAlbumsChip />
-        </Box>
+        <SpotifyLogo
+          color={primary}
+          textShadow={primaryShadow}
+          trackTitle={track.name}
+          url={trackUrl}
+        />
         <AlbumImage isPlaying={Boolean(track.isPlaying)} noteColor={primary} track={track} />
       </Stack>
       <Stack>

--- a/apps/web/src/app/spotify/TrackListing.tsx
+++ b/apps/web/src/app/spotify/TrackListing.tsx
@@ -53,8 +53,12 @@ const cardHeaderSx: SxObject = {
   justifyContent: 'space-between',
 };
 
+/**
+ * Anchors the chip without contributing width: the card's breakout album art
+ * depends on the header row's intrinsic width staying logo + gap + art.
+ */
 const logoColumnSx: SxObject = {
-  alignItems: 'flex-start',
+  position: 'relative',
 };
 
 const albumsChipSx: SxObject = {
@@ -66,8 +70,12 @@ const albumsChipSx: SxObject = {
   color: 'var(--mui-palette-text-primary)',
   display: 'inline-flex',
   gap: 0.75,
+  // Below the 3rem Spotify logo, out of the header row's layout flow
+  insetBlockStart: 'calc(3rem + 12px)',
+  insetInlineStart: 0,
   paddingBlock: 0.5,
   paddingInline: 1.25,
+  position: 'absolute',
   width: 'fit-content',
   ...createBouncyTransition('transform'),
 };
@@ -77,14 +85,17 @@ const albumsChipTextSx: SxObject = {
   whiteSpace: 'nowrap',
 };
 
-/** Small glass chip linking to the favorite albums page. */
+/**
+ * Small glass chip linking to the favorite albums page. Label is short so the
+ * chip clears the breakout album art on its right.
+ */
 function FavoriteAlbumsChip() {
   return (
     <Link href={favoriteAlbumsRoute} title="Favorite albums" underline="none">
       <GlassContainer sx={albumsChipSx}>
         <Disc3 size={14} />
         <Typography component="span" sx={albumsChipTextSx} variant="overline">
-          Favorite albums
+          Albums
         </Typography>
       </GlassContainer>
     </Link>
@@ -98,7 +109,7 @@ function CardLayout({ track, colors }: { track: Track; colors: Colors | null }) 
   return (
     <Stack sx={cardLayoutSx}>
       <Stack direction="row" sx={cardHeaderSx}>
-        <Stack spacing={1.5} sx={logoColumnSx}>
+        <Box sx={logoColumnSx}>
           <SpotifyLogo
             color={primary}
             textShadow={primaryShadow}
@@ -106,7 +117,7 @@ function CardLayout({ track, colors }: { track: Track; colors: Colors | null }) 
             url={trackUrl}
           />
           <FavoriteAlbumsChip />
-        </Stack>
+        </Box>
         <AlbumImage isPlaying={Boolean(track.isPlaying)} noteColor={primary} track={track} />
       </Stack>
       <Stack>

--- a/apps/web/src/services/albums.ts
+++ b/apps/web/src/services/albums.ts
@@ -1,0 +1,23 @@
+import 'server-only';
+
+import { fetchPlaylistAlbums } from '@dg/services/spotify/fetchPlaylistAlbums';
+import { cacheLife, cacheTag } from 'next/cache';
+
+const FAVORITE_ALBUMS_TAG = 'favorite-albums';
+
+/** Playlist holding one or more tracks from each favorite album. */
+const FAVORITE_ALBUMS_PLAYLIST_ID = '1bbwGrz6rSq5APjRfZp63U';
+
+/**
+ * Favorite albums from the curated playlist, deduped and newest-added first.
+ * The playlist changes rarely so hours-long caching is fine. Do not schedule
+ * `after()` work here: this 'use cache' scope re-executes during ISR
+ * revalidation and PPR resume where `waitUntil` can be unavailable, and the
+ * resulting throw kills the whole RSC stream.
+ */
+export async function getFavoriteAlbums() {
+  'use cache';
+  cacheLife('hours');
+  cacheTag(FAVORITE_ALBUMS_TAG);
+  return await fetchPlaylistAlbums(FAVORITE_ALBUMS_PLAYLIST_ID);
+}

--- a/package.json
+++ b/package.json
@@ -27,5 +27,5 @@
     "clean": "rm -f .env .env.tmp",
     "preinstall": "npx only-allow pnpm"
   },
-  "version": "2.61.7"
+  "version": "2.62.0"
 }

--- a/packages/content-models/spotify/PlaylistAlbums.ts
+++ b/packages/content-models/spotify/PlaylistAlbums.ts
@@ -1,0 +1,88 @@
+import * as v from 'valibot';
+import { mapTrackFromApi, trackApiSchema } from './Track';
+
+/**
+ * One page of Spotify's playlist items endpoint. Items stay unknown here so a
+ * single odd entry (local file, episode, removed track) can be skipped at
+ * mapping time instead of failing the whole page.
+ */
+export const playlistItemsPageApiSchema = v.looseObject({
+  items: v.array(v.unknown()),
+  /**
+   * Link to the next page, null on the last page.
+   */
+  next: v.optional(v.nullable(v.string())),
+});
+
+/**
+ * A single playlist entry: when it was added plus the full track payload.
+ * Track is null for entries Spotify can no longer resolve.
+ */
+const playlistItemApiSchema = v.looseObject({
+  /**
+   * Parseable date time string like 2022-01-28T10:06:57.412Z.
+   */
+  added_at: v.string(),
+  track: v.nullable(trackApiSchema),
+});
+
+/**
+ * An album pulled out of a playlist, flattened to exactly what album-grid UI
+ * needs plus the keys the UI sorts by.
+ */
+export type PlaylistAlbum = {
+  /** Spotify album id */
+  id: string;
+  /** Album name */
+  name: string;
+  /** All artist names joined, like "Artist A, Artist B" */
+  artistNames: string;
+  /** First artist name, used for artist sorting */
+  primaryArtist: string;
+  /** Album art URL (preferred size) */
+  imageUrl: string;
+  /** Public open.spotify.com album URL */
+  url: string;
+  /** ISO timestamp the album first entered the playlist */
+  addedAt: string;
+  /** Album release date: YYYY, YYYY-MM, or YYYY-MM-DD */
+  releaseDate: string;
+};
+
+/**
+ * Collapses raw playlist items into unique albums, newest playlist addition
+ * first. Items that fail to parse are skipped. Re-adding another track from
+ * an album keeps the album's earliest add date so it doesn't reshuffle.
+ */
+export const mapPlaylistAlbumsFromApi = (items: Array<unknown>): Array<PlaylistAlbum> => {
+  const albums = new Map<string, PlaylistAlbum>();
+  for (const rawItem of items) {
+    const parsed = v.safeParse(playlistItemApiSchema, rawItem);
+    if (!parsed.success || !parsed.output.track) {
+      continue;
+    }
+    const track = mapTrackFromApi(parsed.output.track);
+    if (!track) {
+      continue;
+    }
+    const addedAt = parsed.output.added_at;
+    const existing = albums.get(track.album.id);
+    if (existing) {
+      if (addedAt < existing.addedAt) {
+        existing.addedAt = addedAt;
+      }
+      continue;
+    }
+    albums.set(track.album.id, {
+      addedAt,
+      artistNames: track.artists.map((artist) => artist.name).join(', '),
+      id: track.album.id,
+      imageUrl: track.albumImage.url,
+      name: track.album.name,
+      primaryArtist: track.artists[0]?.name ?? '',
+      releaseDate: track.album.releaseDate,
+      url: track.album.externalUrls.spotify,
+    });
+  }
+  return [...albums.values()].sort((a, b) => b.addedAt.localeCompare(a.addedAt));
+};

--- a/packages/content-models/spotify/__tests__/PlaylistAlbums.test.ts
+++ b/packages/content-models/spotify/__tests__/PlaylistAlbums.test.ts
@@ -1,0 +1,93 @@
+import { mapPlaylistAlbumsFromApi } from '../PlaylistAlbums';
+
+const buildTrack = (overrides: {
+  albumId: string;
+  albumName?: string;
+  artistNames?: Array<string>;
+  releaseDate?: string;
+}) => {
+  const { albumId, albumName = `Album ${albumId}`, artistNames = ['Artist'] } = overrides;
+  const reference = (id: string, name: string) => ({
+    external_urls: { spotify: `https://open.spotify.com/x/${id}` },
+    href: `https://api.spotify.com/v1/x/${id}`,
+    id,
+    name,
+    uri: `spotify:x:${id}`,
+  });
+  return {
+    ...reference(`track-${albumId}`, `Track ${albumId}`),
+    album: {
+      ...reference(albumId, albumName),
+      external_urls: { spotify: `https://open.spotify.com/album/${albumId}` },
+      images: [
+        { height: 640, url: `https://image.test/${albumId}-640.jpg`, width: 640 },
+        { height: 300, url: `https://image.test/${albumId}-300.jpg`, width: 300 },
+      ],
+      release_date: overrides.releaseDate ?? '2020-01-01',
+    },
+    artists: artistNames.map((name, index) => reference(`artist-${albumId}-${index}`, name)),
+  };
+};
+
+const buildItem = (addedAt: string, track: unknown) => ({ added_at: addedAt, track });
+
+describe('mapPlaylistAlbumsFromApi', () => {
+  it('dedupes tracks into unique albums, newest added first', () => {
+    const albums = mapPlaylistAlbumsFromApi([
+      buildItem('2024-01-01T00:00:00Z', buildTrack({ albumId: 'a' })),
+      buildItem('2025-06-01T00:00:00Z', buildTrack({ albumId: 'b' })),
+      buildItem('2024-03-01T00:00:00Z', buildTrack({ albumId: 'a' })),
+    ]);
+
+    expect(albums.map((album) => album.id)).toEqual(['b', 'a']);
+  });
+
+  it('keeps the earliest add date for a deduped album', () => {
+    const albums = mapPlaylistAlbumsFromApi([
+      buildItem('2024-05-01T00:00:00Z', buildTrack({ albumId: 'a' })),
+      buildItem('2024-01-01T00:00:00Z', buildTrack({ albumId: 'a' })),
+    ]);
+
+    expect(albums).toHaveLength(1);
+    expect(albums[0]?.addedAt).toBe('2024-01-01T00:00:00Z');
+  });
+
+  it('flattens album fields including artists and preferred image', () => {
+    const albums = mapPlaylistAlbumsFromApi([
+      buildItem(
+        '2024-01-01T00:00:00Z',
+        buildTrack({
+          albumId: 'a',
+          albumName: 'In Rainbows',
+          artistNames: ['Radiohead', 'Guest'],
+          releaseDate: '2007-10-10',
+        }),
+      ),
+    ]);
+
+    expect(albums[0]).toEqual({
+      addedAt: '2024-01-01T00:00:00Z',
+      artistNames: 'Radiohead, Guest',
+      id: 'a',
+      imageUrl: 'https://image.test/a-640.jpg',
+      name: 'In Rainbows',
+      primaryArtist: 'Radiohead',
+      releaseDate: '2007-10-10',
+      url: 'https://open.spotify.com/album/a',
+    });
+  });
+
+  it('skips null tracks, unparseable items, and albums without art', () => {
+    const noImages = buildTrack({ albumId: 'no-art' });
+    noImages.album.images = [];
+
+    const albums = mapPlaylistAlbumsFromApi([
+      buildItem('2024-01-01T00:00:00Z', null),
+      { unexpected: 'shape' },
+      buildItem('2024-01-02T00:00:00Z', noImages),
+      buildItem('2024-01-03T00:00:00Z', buildTrack({ albumId: 'ok' })),
+    ]);
+
+    expect(albums.map((album) => album.id)).toEqual(['ok']);
+  });
+});

--- a/packages/services/spotify/__tests__/fetchPlaylistAlbums.test.ts
+++ b/packages/services/spotify/__tests__/fetchPlaylistAlbums.test.ts
@@ -1,0 +1,64 @@
+const mockGet = jest.fn();
+
+jest.mock('../spotifyClient', () => ({
+  getSpotifyClient: () => ({ get: mockGet }),
+}));
+
+import { fetchPlaylistAlbums } from '../fetchPlaylistAlbums';
+
+const buildTrack = (albumId: string) => {
+  const reference = (id: string, name: string) => ({
+    external_urls: { spotify: `https://open.spotify.com/x/${id}` },
+    href: `https://api.spotify.com/v1/x/${id}`,
+    id,
+    name,
+    uri: `spotify:x:${id}`,
+  });
+  return {
+    ...reference(`track-${albumId}`, `Track ${albumId}`),
+    album: {
+      ...reference(albumId, `Album ${albumId}`),
+      images: [{ height: 640, url: `https://image.test/${albumId}.jpg`, width: 640 }],
+      release_date: '2020-01-01',
+    },
+    artists: [reference(`artist-${albumId}`, `Artist ${albumId}`)],
+  };
+};
+
+const buildPage = (albumIds: Array<string>, next: string | null) => ({
+  response: {
+    json: async () => ({
+      items: albumIds.map((albumId, index) => ({
+        added_at: `2024-01-0${index + 1}T00:00:00Z`,
+        track: buildTrack(albumId),
+      })),
+      next,
+    }),
+  },
+  status: 200,
+});
+
+describe('fetchPlaylistAlbums', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+  });
+
+  it('pages through the playlist and dedupes albums across pages', async () => {
+    mockGet
+      .mockResolvedValueOnce(buildPage(['a', 'b'], 'https://api.spotify.com/next'))
+      .mockResolvedValueOnce(buildPage(['a', 'c'], null));
+
+    const albums = await fetchPlaylistAlbums('playlist-id');
+
+    expect(mockGet).toHaveBeenCalledTimes(2);
+    expect(mockGet).toHaveBeenNthCalledWith(1, 'playlists/playlist-id/tracks?limit=50&offset=0');
+    expect(mockGet).toHaveBeenNthCalledWith(2, 'playlists/playlist-id/tracks?limit=50&offset=50');
+    expect(albums.map((album) => album.id).sort()).toEqual(['a', 'b', 'c']);
+  });
+
+  it('throws on a non-200 status instead of returning an empty list', async () => {
+    mockGet.mockResolvedValueOnce({ response: { json: async () => ({}) }, status: 403 });
+
+    await expect(fetchPlaylistAlbums('playlist-id')).rejects.toThrow('status 403');
+  });
+});

--- a/packages/services/spotify/fetchPlaylistAlbums.ts
+++ b/packages/services/spotify/fetchPlaylistAlbums.ts
@@ -1,0 +1,39 @@
+import 'server-only';
+
+import {
+  mapPlaylistAlbumsFromApi,
+  type PlaylistAlbum,
+  playlistItemsPageApiSchema,
+} from '@dg/content-models/spotify/PlaylistAlbums';
+import { parseResponse } from '../clients/parseResponse';
+import { getSpotifyClient } from './spotifyClient';
+
+const PAGE_SIZE = 50;
+
+/** Hard stop so a runaway playlist can't page forever (1000 tracks). */
+const MAX_PAGES = 20;
+
+/**
+ * Fetches every item of a playlist and collapses them into unique albums,
+ * newest playlist addition first. Throws on non-200 so callers never cache
+ * a silently empty list.
+ */
+export async function fetchPlaylistAlbums(playlistId: string): Promise<Array<PlaylistAlbum>> {
+  const items: Array<unknown> = [];
+  for (let page = 0; page < MAX_PAGES; page += 1) {
+    const resource = `playlists/${playlistId}/tracks?limit=${PAGE_SIZE}&offset=${page * PAGE_SIZE}`;
+    const { response, status } = await getSpotifyClient().get(resource);
+    if (status !== 200) {
+      throw new Error(`Spotify playlist ${playlistId} fetch failed with status ${status}`);
+    }
+    const data = parseResponse(playlistItemsPageApiSchema, await response.json(), {
+      kind: 'rest',
+      source: 'spotify.fetchPlaylistAlbums',
+    });
+    items.push(...data.items);
+    if (!data.next) {
+      break;
+    }
+  }
+  return mapPlaylistAlbumsFromApi(items);
+}

--- a/packages/services/spotify/fetchPlaylistAlbums.ts
+++ b/packages/services/spotify/fetchPlaylistAlbums.ts
@@ -5,13 +5,17 @@ import {
   type PlaylistAlbum,
   playlistItemsPageApiSchema,
 } from '@dg/content-models/spotify/PlaylistAlbums';
+import { log } from '@dg/shared-core/logging/log';
 import { parseResponse } from '../clients/parseResponse';
 import { getSpotifyClient } from './spotifyClient';
 
 const PAGE_SIZE = 50;
 
-/** Hard stop so a runaway playlist can't page forever (1000 tracks). */
-const MAX_PAGES = 20;
+/**
+ * Hard stop so a runaway playlist can't page forever (5000 tracks). Whole
+ * albums get added to the playlist, so track count runs ~15x album count.
+ */
+const MAX_PAGES = 100;
 
 /**
  * Fetches every item of a playlist and collapses them into unique albums,
@@ -20,7 +24,8 @@ const MAX_PAGES = 20;
  */
 export async function fetchPlaylistAlbums(playlistId: string): Promise<Array<PlaylistAlbum>> {
   const items: Array<unknown> = [];
-  for (let page = 0; page < MAX_PAGES; page += 1) {
+  let hasMore = true;
+  for (let page = 0; hasMore && page < MAX_PAGES; page += 1) {
     const resource = `playlists/${playlistId}/tracks?limit=${PAGE_SIZE}&offset=${page * PAGE_SIZE}`;
     const { response, status } = await getSpotifyClient().get(resource);
     if (status !== 200) {
@@ -31,9 +36,13 @@ export async function fetchPlaylistAlbums(playlistId: string): Promise<Array<Pla
       source: 'spotify.fetchPlaylistAlbums',
     });
     items.push(...data.items);
-    if (!data.next) {
-      break;
-    }
+    hasMore = Boolean(data.next);
+  }
+  if (hasMore) {
+    log.warn('Playlist truncated at page cap; newest additions may be missing', {
+      maxPages: MAX_PAGES,
+      playlistId,
+    });
   }
   return mapPlaylistAlbumsFromApi(items);
 }

--- a/packages/shared-core/routes/__tests__/app.test.ts
+++ b/packages/shared-core/routes/__tests__/app.test.ts
@@ -12,12 +12,14 @@ describe('markdown page registry', () => {
   it('maps html paths to .md twins by convention', () => {
     expect(htmlPathToMarkdownPath('/')).toBe('/index.md');
     expect(htmlPathToMarkdownPath('/music')).toBe('/music.md');
+    expect(htmlPathToMarkdownPath('/music/albums')).toBe('/music/albums.md');
     expect(tryHtmlPathToMarkdownPath('/dev-console')).toBeNull();
   });
 
   it('maps .md paths back to html', () => {
     expect(markdownPathToHtmlPath('/index.md')).toBe('/');
     expect(markdownPathToHtmlPath('/music.md')).toBe('/music');
+    expect(markdownPathToHtmlPath('/music/albums.md')).toBe('/music/albums');
     expect(markdownPathToHtmlPath('/about.md')).toBeNull();
   });
 

--- a/packages/shared-core/routes/app.ts
+++ b/packages/shared-core/routes/app.ts
@@ -8,6 +8,8 @@ export const homeRoute = '/' as const;
 
 export const musicRoute = '/music' as const;
 
+export const favoriteAlbumsRoute = '/music/albums' as const;
+
 export const devConsoleRoute = '/dev-console' as const;
 
 export const llmsTxtRoute = '/llms.txt' as const;
@@ -40,6 +42,13 @@ export const markdownPages = [
     priority: 0.7,
     summary: 'Recent Spotify plays',
     title: 'Listening history',
+  },
+  {
+    changeFrequency: 'weekly',
+    path: favoriteAlbumsRoute,
+    priority: 0.6,
+    summary: 'All-time favorite albums',
+    title: 'Favorite albums',
   },
 ] as const satisfies ReadonlyArray<MarkdownPageDefinition>;
 

--- a/packages/ui/core/GlassSwitcher.tsx
+++ b/packages/ui/core/GlassSwitcher.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Box, IconButton, Menu, MenuItem, Radio, RadioGroup } from '@mui/material';
+import { Box, IconButton, Menu, MenuItem, Radio, RadioGroup, Typography } from '@mui/material';
 import type { MouseEvent, ReactNode } from 'react';
 import { useId, useState } from 'react';
 import { createBouncyTransition } from '../helpers/bouncyTransition';
@@ -111,6 +111,11 @@ const hiddenRadioSx: SxObject = {
   display: 'none',
 };
 
+const optionLabelSx: SxObject = {
+  lineHeight: 1.2,
+  whiteSpace: 'nowrap',
+};
+
 /** Size to match adjacent header glass container (Logo ~52px + container py 0.75 each side) */
 const MOBILE_CONTAINER_SIZE = 64;
 
@@ -155,7 +160,10 @@ interface SwitcherOptionProps {
   onChange: (value: string) => void;
 }
 
-/** Desktop: Individual clickable option with icon and hidden radio input */
+/**
+ * Desktop: individual clickable option with hidden radio input. Icon options
+ * get a tooltip with the label; text options show the label directly.
+ */
 function SwitcherOption({ option, isSelected, onChange }: SwitcherOptionProps) {
   const element = (
     <Box component="label" sx={optionStyles}>
@@ -165,11 +173,15 @@ function SwitcherOption({ option, isSelected, onChange }: SwitcherOptionProps) {
         sx={hiddenRadioSx}
         value={option.value}
       />
-      {option.icon}
+      {option.icon ?? (
+        <Typography component="span" sx={optionLabelSx} variant="overline">
+          {option.label}
+        </Typography>
+      )}
     </Box>
   );
 
-  if (!option.label) {
+  if (!option.label || !option.icon) {
     return element;
   }
 
@@ -188,6 +200,11 @@ export interface GlassSwitcherProps {
   options: Array<GlassSwitcherOption>;
   sx?: SxElement;
   'aria-label'?: string;
+  /**
+   * Icon for the mobile menu trigger. Required for text-only options, which
+   * have no per-option icon to show; falls back to the selected option's icon.
+   */
+  mobileIcon?: ReactNode;
 }
 
 /**
@@ -201,8 +218,11 @@ export function GlassSwitcher({
   options,
   sx,
   'aria-label': ariaLabel,
+  mobileIcon,
 }: GlassSwitcherProps) {
   const menuId = useId();
+  // Unique radio name so multiple switchers on a page don't share a native group
+  const radioGroupName = useId();
   const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
 
   const selectedIndex = Math.max(
@@ -247,7 +267,7 @@ export function GlassSwitcher({
           onClick={handleMenuOpen}
           sx={mobileButtonSx}
         >
-          {selectedOption?.icon}
+          {mobileIcon ?? selectedOption?.icon}
         </IconButton>
         <Menu
           anchorEl={menuAnchor}
@@ -275,7 +295,7 @@ export function GlassSwitcher({
       <MouseAwareGlassContainer data-role="glass-switcher" sx={desktopSx}>
         <RadioGroup
           aria-label={ariaLabel}
-          name="glass-switcher"
+          name={radioGroupName}
           onChange={(event) => onChange(event.target.value)}
           sx={radioGroupSx}
           value={value}

--- a/packages/ui/core/GlassSwitcher.tsx
+++ b/packages/ui/core/GlassSwitcher.tsx
@@ -174,7 +174,7 @@ function SwitcherOption({ option, isSelected, onChange }: SwitcherOptionProps) {
         value={option.value}
       />
       {option.icon ?? (
-        <Typography component="span" sx={optionLabelSx} variant="overline">
+        <Typography component="span" sx={optionLabelSx} variant="caption">
           {option.label}
         </Typography>
       )}

--- a/packages/ui/core/__tests__/GlassSwitcher.test.tsx
+++ b/packages/ui/core/__tests__/GlassSwitcher.test.tsx
@@ -80,4 +80,29 @@ describe('GlassSwitcher', () => {
 
     expect(screen.getAllByRole('tooltip')).toHaveLength(1);
   });
+
+  it('renders visible labels without tooltips for text-only options', async () => {
+    const user = userEvent.setup();
+    const handleChange = jest.fn();
+    render(
+      <GlassSwitcher
+        aria-label="Sort things"
+        mobileIcon={<span data-testid="mobile-icon" />}
+        onChange={handleChange}
+        options={[
+          { label: 'Recently added', value: 'added' },
+          { label: 'Album', value: 'album' },
+        ]}
+        value="added"
+      />,
+    );
+
+    expect(screen.getByText('Recently added')).toBeInTheDocument();
+    expect(screen.getByText('Album')).toBeInTheDocument();
+    expect(screen.queryAllByRole('tooltip')).toHaveLength(0);
+    expect(screen.getByTestId('mobile-icon')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('radio', { hidden: true, name: 'Album' }));
+    expect(handleChange).toHaveBeenCalledWith('album');
+  });
 });

--- a/packages/ui/dependent/Link.tsx
+++ b/packages/ui/dependent/Link.tsx
@@ -5,7 +5,7 @@ import { faSpotify } from '@fortawesome/free-brands-svg-icons/faSpotify';
 import { faStrava } from '@fortawesome/free-brands-svg-icons/faStrava';
 import type { ButtonProps, LinkProps as MuiLinkProps } from '@mui/material';
 import { Button, Link as MuiLink } from '@mui/material';
-import { Send } from 'lucide-react';
+import { Disc3, Send } from 'lucide-react';
 import NextLink from 'next/link';
 import React from 'react';
 import type { TooltipPlacement } from '../core/Tooltip';
@@ -84,6 +84,7 @@ type LinkProps = BaseLinkProps &
  * Awesome since lucide-react v1 dropped brand icons for trademark reasons.
  */
 const BUILT_IN_ICONS: Record<string, React.ReactNode> = {
+  albums: <Disc3 size="1em" />,
   email: <Send size="1em" />,
   github: <FaIcon icon={faGithub} />,
   instagram: <FaIcon icon={faInstagram} />,


### PR DESCRIPTION
# What changed?

New `/music/albums` page showing every unique album from my favorite-albums Spotify playlist as a grid of album art, each cover linking to that album on Spotify. Sort controls cover recently added (default, newest first), album name, artist name, and release date, and re-sorting animates with a FLIP transition (reduced-motion aware, compositor-driven, no new dependencies).

The sort control reuses the site's `GlassSwitcher` (the header color-scheme control), extended in `@dg/ui` to support sentence-case text-label options and a custom mobile trigger icon, so the pill/thumb design language is shared instead of one-off. The page is linked from the footer via a "Favorite albums" link entry in Contentful (no code change needed for the link; the Spotify card is untouched).

- Playlist fetch pages through `GET /v1/playlists/{id}/tracks` in `@dg/services`; track-to-album dedupe lives in `@dg/content-models` and keeps each album's earliest add date
- Playlist paging cap raised to 100 pages (5000 tracks) with a warning log on truncation, since whole albums get added and the playlist is already ~1650 tracks
- Album list caches for hours via `'use cache'` + `cacheLife('hours')` with no `after()` inside the cache scope
- Page is registered in the markdown page registry, so sitemap, llms.txt, and the `/music/albums.md` twin derive automatically
- Tests: playlist mapping/dedupe, paged fetch, GlassSwitcher text-label options, and user-event coverage of all four sorts

# Release info

- [ ] Major
- [x] Minor
- [ ] Patch

Made with [Cursor](https://cursor.com)