### PR TITLE
Fix production build failing on /music/albums when Spotify token is missing

### DIFF
--- a/apps/web/src/app/music/albums/favoriteAlbumsMarkdown.ts
+++ b/apps/web/src/app/music/albums/favoriteAlbumsMarkdown.ts
@@ -16,7 +16,7 @@ export async function getFavoriteAlbumsMarkdown(): Promise<string> {
       `> All-time favorite albums from ${SITE_NAME}`,
     ];
 
-    if (albums.length === 0) {
+    if (!albums || albums.length === 0) {
       sections.push('No albums available.');
     } else {
       sections.push(

--- a/apps/web/src/app/music/albums/page.tsx
+++ b/apps/web/src/app/music/albums/page.tsx
@@ -1,10 +1,8 @@
 import 'server-only';
 
-import { isMissingTokenError } from '@dg/shared-core/errors/MissingTokenError';
 import { favoriteAlbumsRoute } from '@dg/shared-core/routes/app';
 import { Stack, Typography } from '@mui/material';
 import type { Metadata } from 'next';
-import { redirect } from 'next/navigation';
 import { getFavoriteAlbums } from '../../../services/albums';
 import { markdownAlternates } from '../../layouts/markdownAlternates';
 import { FavoriteAlbumsGrid } from './FavoriteAlbumsGrid';
@@ -15,23 +13,17 @@ export const metadata: Metadata = {
 };
 
 export default async function FavoriteAlbumsPage() {
-  let albums: Awaited<ReturnType<typeof getFavoriteAlbums>>;
-
-  try {
-    albums = await getFavoriteAlbums();
-  } catch (error) {
-    // In development, redirect to the dev page to set up OAuth
-    if (isMissingTokenError(error) && process.env.NODE_ENV === 'development') {
-      redirect('/dev');
-    }
-    throw error;
-  }
+  const albums = await getFavoriteAlbums();
 
   return (
     <main>
       <Stack spacing={2}>
         <Typography variant="h1">Favorite albums</Typography>
-        <FavoriteAlbumsGrid albums={albums} />
+        {albums?.length ? (
+          <FavoriteAlbumsGrid albums={albums} />
+        ) : (
+          <Typography color="text.secondary">No albums right now. Check back soon.</Typography>
+        )}
       </Stack>
     </main>
   );

--- a/apps/web/src/services/albums.ts
+++ b/apps/web/src/services/albums.ts
@@ -2,6 +2,7 @@ import 'server-only';
 
 import { fetchPlaylistAlbums } from '@dg/services/spotify/fetchPlaylistAlbums';
 import { cacheLife, cacheTag } from 'next/cache';
+import { withMissingTokenFallback } from './withMissingTokenFallback';
 
 const FAVORITE_ALBUMS_TAG = 'favorite-albums';
 
@@ -9,7 +10,9 @@ const FAVORITE_ALBUMS_TAG = 'favorite-albums';
 const FAVORITE_ALBUMS_PLAYLIST_ID = '1bbwGrz6rSq5APjRfZp63U';
 
 /**
- * Favorite albums from the curated playlist, deduped and newest-added first.
+ * Favorite albums from the curated playlist, deduped and newest-added first,
+ * or null when the Spotify token is missing (e.g. preview builds whose
+ * database has no token row) so prerendering degrades instead of failing.
  * The playlist changes rarely so hours-long caching is fine. Do not schedule
  * `after()` work here: this 'use cache' scope re-executes during ISR
  * revalidation and PPR resume where `waitUntil` can be unavailable, and the
@@ -19,5 +22,5 @@ export async function getFavoriteAlbums() {
   'use cache';
   cacheLife('hours');
   cacheTag(FAVORITE_ALBUMS_TAG);
-  return await fetchPlaylistAlbums(FAVORITE_ALBUMS_PLAYLIST_ID);
+  return await withMissingTokenFallback(fetchPlaylistAlbums(FAVORITE_ALBUMS_PLAYLIST_ID));
 }

--- a/package.json
+++ b/package.json
@@ -27,5 +27,5 @@
     "clean": "rm -f .env .env.tmp",
     "preinstall": "npx only-allow pnpm"
   },
-  "version": "2.62.0"
+  "version": "2.62.1"
 }


### PR DESCRIPTION
# What changed?

Production and preview deploy builds were failing to prerender `/music/albums`: the build environment's database has no `spotify` token row, so `fetchPlaylistAlbums` threw `MissingTokenError` inside `getFavoriteAlbums`'s `'use cache'` scope and killed the export (this took down the production deployment of #555's merge commit). Every other Spotify surface already degrades through `withMissingTokenFallback`; the albums path was the one that didn't.

- `getFavoriteAlbums` now wraps the playlist fetch in `withMissingTokenFallback`, matching `getLatestSong`, and returns `null` when the token is missing
- The page renders an intentional empty state ("No albums right now. Check back soon.") instead of the now-unreachable try/catch + dev redirect, which is deleted
- The `/music/albums.md` markdown twin handles the `null` case explicitly
- No `after()` added inside the cache scope; the existing constraint comment stands

Verified by reproducing the exact CI condition locally: a production `turbo build` against a database with an empty `Token` table failed with the same `MissingTokenError` before the fix and passes after (21/21 tasks, `/music/albums` prerenders with the empty state baked). With a token present, the built production server renders the full 102-album grid and all four sorts reorder correctly (verified via CDP against `next start`).

# Release info

- [ ] Major
- [ ] Minor
- [x] Patch

Made with [Cursor](https://cursor.com)