### PR TITLE
Fix production 500 on / by tracing libvips into the deployment bundle

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -26,6 +26,18 @@ const nextConfig: NextConfig = {
       },
     ],
   },
+  /**
+   * `@vercel/nft` only emits libvips alongside sharp's native addon when it sees
+   * `sharp/lib/index.js`, an entry point sharp 0.35 replaced with `dist/index.cjs`. Without
+   * this the deployed bundle ships the addon but not the `libvips-cpp.so` it dlopens, and
+   * every route that renders the Spotify card dies with `ERR_DLOPEN_FAILED`.
+   * `scripts/verifyTracedNativeLibraries.ts` fails the build if this stops covering it.
+   */
+  outputFileTracingIncludes: {
+    '/**': [
+      '../../node_modules/.pnpm/@img+sharp-libvips-*/node_modules/@img/sharp-libvips-*/lib/**/*',
+    ],
+  },
   reactCompiler: true,
   reactStrictMode: true,
   // Disables the Sequelize warning about the `sequelize` package not being found

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -42,7 +42,7 @@
   "name": "@dg/web",
   "private": true,
   "scripts": {
-    "build": "next build --turbopack",
+    "build": "next build --turbopack && tsx scripts/verifyTracedNativeLibraries.ts",
     "build:analyze": "next experimental-analyze",
     "build:serve": "next start",
     "check": "biome check --write .",

--- a/apps/web/scripts/verifyTracedNativeLibraries.ts
+++ b/apps/web/scripts/verifyTracedNativeLibraries.ts
@@ -1,0 +1,121 @@
+/**
+ * Fails the build when a native `.node` addon is traced into a route's deployment bundle
+ * without the shared libraries it dlopens.
+ *
+ * Next.js hands `@vercel/nft` the job of listing every file a route needs at runtime, and
+ * Vercel builds each serverless function from those lists. nft finds `.node` addons through
+ * ordinary `require` analysis, but it cannot see the ELF `DT_NEEDED` entries inside them, so
+ * it leans on per-package special cases to pick up the matching shared object. When one of
+ * those special cases stops matching, the deploy still succeeds and every request to the
+ * affected route throws `ERR_DLOPEN_FAILED` instead.
+ */
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { log } from '@dg/shared-core/logging/log';
+
+const APP_TRACE_DIR = path.join(process.cwd(), '.next', 'server', 'app');
+
+/** Matches an soname the way it appears verbatim in an addon's ELF string table. */
+const SONAME_PATTERN = /lib[\w+-]*\.so(?:\.[0-9.]+)?/g;
+
+type TraceFile = {
+  /** Paths a route needs at runtime, relative to the directory holding the `.nft.json` */
+  files: Array<string>;
+};
+
+type PackageJson = {
+  optionalDependencies?: Record<string, string>;
+};
+
+async function findFiles(dir: string, matches: (name: string) => boolean) {
+  const entries = await readdir(dir, { recursive: true, withFileTypes: true }).catch(() => []);
+  return entries
+    .filter((entry) => entry.isFile() && matches(entry.name))
+    .map((entry) => path.join(entry.parentPath, entry.name));
+}
+
+/** Walks up from a file to the directory holding the `package.json` that owns it. */
+async function findPackageRoot(filePath: string) {
+  let dir = path.dirname(filePath);
+  while (dir !== path.dirname(dir)) {
+    const manifest = await readFile(path.join(dir, 'package.json'), 'utf8').catch(() => null);
+    if (manifest !== null) {
+      return { dir, manifest: JSON.parse(manifest) as PackageJson };
+    }
+    dir = path.dirname(dir);
+  }
+  return null;
+}
+
+/**
+ * Shared libraries an addon's own package tree ships. Prebuilt-binary packages put them in
+ * sibling optional dependencies picked by platform, which under any node_modules layout sit
+ * next to the addon's package inside the same `node_modules` directory. Anything an addon
+ * needs that isn't found this way comes from the OS and shouldn't be bundled.
+ */
+async function findVendoredLibraries(addonPath: string) {
+  const owner = await findPackageRoot(addonPath);
+  if (!owner) {
+    return new Set<string>();
+  }
+  const siblings = Object.keys(owner.manifest.optionalDependencies ?? {}).map((name) =>
+    path.resolve(owner.dir, '..', '..', name),
+  );
+  const libraries = await Promise.all(
+    siblings.map((sibling) => findFiles(sibling, (name) => name.includes('.so'))),
+  );
+  return new Set(libraries.flat().map((library) => path.basename(library)));
+}
+
+async function findMissingLibraries(tracePath: string) {
+  const { files } = JSON.parse(await readFile(tracePath, 'utf8')) as TraceFile;
+  const traceDir = path.dirname(tracePath);
+  const traced = new Set(files.map((file) => path.basename(file)));
+
+  const missing: Array<string> = [];
+  for (const file of files.filter((candidate) => candidate.endsWith('.node'))) {
+    const addonPath = path.resolve(traceDir, file);
+    const addon = await readFile(addonPath).catch(() => null);
+    if (!addon) {
+      continue;
+    }
+    const vendored = await findVendoredLibraries(addonPath);
+    for (const soname of new Set(addon.toString('latin1').match(SONAME_PATTERN) ?? [])) {
+      if (vendored.has(soname) && !traced.has(soname)) {
+        missing.push(`${soname} (needed by ${path.basename(file)})`);
+      }
+    }
+  }
+  return missing;
+}
+
+async function verifyTracedNativeLibraries() {
+  const tracePaths = await findFiles(APP_TRACE_DIR, (name) => name.endsWith('.nft.json'));
+  const failures = new Map<string, Array<string>>();
+
+  for (const tracePath of tracePaths) {
+    const missing = await findMissingLibraries(tracePath);
+    if (missing.length > 0) {
+      failures.set(path.relative(process.cwd(), tracePath), missing);
+    }
+  }
+
+  if (failures.size > 0) {
+    for (const [route, missing] of failures) {
+      log.error(`${route} is missing ${missing.join(', ')}`);
+    }
+    throw new Error(
+      `${failures.size} route bundle(s) trace a native addon without the shared libraries it ` +
+        'loads. Add the owning package to `outputFileTracingIncludes` in next.config.ts.',
+    );
+  }
+
+  log.info(
+    `Traced native addons resolve their shared libraries across ${tracePaths.length} routes`,
+  );
+}
+
+verifyTracedNativeLibraries().catch((error: unknown) => {
+  log.error(String(error));
+  process.exitCode = 1;
+});

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -5,5 +5,5 @@
     "types": ["jest", "node"]
   },
   "extends": "@dg/tsconfig/nextjs.json",
-  "include": ["src", "next.config.ts", "next-env.d.ts"]
+  "include": ["src", "scripts", "next.config.ts", "next-env.d.ts"]
 }

--- a/package.json
+++ b/package.json
@@ -27,5 +27,5 @@
     "clean": "rm -f .env .env.tmp",
     "preinstall": "npx only-allow pnpm"
   },
-  "version": "2.62.0"
+  "version": "2.62.1"
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# What changed?

Every request to `/` in production has been throwing since the sharp catalog bump in #543.

```
Error: Failed to load external module sharp-8085db5486fb5afb: Error: Could not load the "sharp" module using the linux-x64 runtime
ERR_DLOPEN_FAILED: libvips-cpp.so.8.18.3: cannot open shared object file: No such file or directory
```

The live site confirms it. `https://dylangattey.com/` currently serves the prerendered shell with a 200, but the streamed Spotify card never arrives. Its HTML contains zero occurrences of `Now playing` and zero of the `radial-gradient(circle at top right` string that `buildRadialGradient` emits.

This only affects the built server. `next dev` resolves sharp through the normal module graph rather than externalizing it, and on macOS the darwin binaries load fine, so the bug is invisible in development.

## Root cause

`@vercel/nft`, the tracer Next.js uses to decide which files ship in each serverless function, has a hardcoded special case that pulls libvips in alongside sharp's native addon. It is keyed on the file path `sharp/lib/index.js` ([special-cases.ts](https://github.com/vercel/nft/blob/main/src/utils/special-cases.ts)):

```js
sharp: async ({ id, emitAssetDirectory, job }) => {
  if (id.endsWith('sharp/lib/index.js')) {
```

sharp 0.34.5 had `"main": "lib/index.js"`. sharp 0.35.3 restructured to `"main": "./dist/index.cjs"` and dropped `lib/*.js` from its published `files`, so that branch never fires. nft still traced `@img/sharp-linux-x64/lib/sharp-linux-x64-0.35.3.node` through ordinary `require` analysis, but it cannot read the addon's ELF `DT_NEEDED` entries, so `libvips-cpp.so.8.18.3` was left out of every route bundle. The addon shipped without the library it dlopens.

`packages/services/images/getImageGradient.ts` imports sharp at the top level, and `/` reaches it statically through `layout.tsx` → `Header` → `getLatestSong` → `fetchRecentlyPlayed` → `getImageGradient`. The import is evaluated when the chunk loads, so the existing try/catch inside `getImageGradientInformationFromUrl` never got a chance to degrade gracefully. The whole render died.

## Regression

a5a9f5f (#543, 2026-07-21) moved the catalog from `sharp: 0.34.5` to `sharp: 0.35.3`. Before it the lockfile resolved a single sharp; after it there are two, because `next@16.2.10` and `@vercel/og@0.11.1` both keep an optional `sharp: 0.34.5`. The homepage import chain itself has existed since ad11214 (#531, 2026-02-10), back when tracing still worked.

The 01:20:57Z failure log lands 3 minutes 21 seconds after fe23e50 (#555) merged at 01:17:36Z, so that deploy is what put the broken bundle live rather than what broke it. #555 changes no dependencies. Worth noting that `/` was independently broken for unrelated reasons for much of the window between #543 and now (#553's Flight 406, #554's `after()` inside `'use cache'`), so the missing libvips was plausibly latent in every deploy since 2026-07-21 and only became the visible failure once the stream was otherwise healthy.

## The fix

`outputFileTracingIncludes` in `apps/web/next.config.ts` puts the libvips packages back next to the addon. The glob has no version in it, so a future sharp bump keeps working.

`apps/web/scripts/verifyTracedNativeLibraries.ts` runs after `next build` and fails the build if any app route traces a `.node` addon without the shared libraries it needs. It reads the sonames out of each traced addon and only demands the ones the addon's own package tree vendors, so OS libraries like `libc.so.6` are correctly ignored. It is red on `main` and green here.

## Verification against the real Vercel builder

`vercel build` runs offline with a manual project link, so the strongest evidence here comes from Vercel's own `@vercel/next` builder producing the actual Build Output API artifact, not from an emulation. The manifest of files Vercel ships into the `/` function is `functions/index.func/.vc-config.json` → `filePathMap`.

On this branch with the fix:

```
Traced native addons resolve their shared libraries across 14 routes
"status": "ok", "message": "Build completed successfully."

index.func entries: 918
  node_modules/.pnpm/@img+sharp-libvips-linux-x64@1.3.2/node_modules/@img/sharp-libvips-linux-x64/lib/libvips-cpp.so.8.18.3
  node_modules/.pnpm/@img+sharp-linux-x64@0.35.3/node_modules/@img/sharp-linux-x64/lib/sharp-linux-x64-0.35.3.node
```

With the fix reverted and the guard temporarily disabled, the same builder ships the addon with no shared library at all, which is the broken production artifact:

```
index.func entries: 913
libvips .so entries: []
.node entries: ['@img+sharp-linux-x64@0.35.3/.../sharp-linux-x64-0.35.3.node']
```

With the fix reverted and the guard active, Vercel's build refuses to produce output, so this cannot silently ship again:

```
.next/server/app/page.js.nft.json is missing libvips-cpp.so.8.18.3 (needed by sharp-linux-x64-0.35.3.node)
...4 more routes...
Error: 5 route bundle(s) trace a native addon without the shared libraries it loads.
"status": "error", "reason": "build_failed", "message": "Command \"pnpm run build\" exited with 1"
```

That last run also confirms Vercel invokes `@dg/web`'s `build` script, so the guard really does gate deploys.

## Runtime verification on linux-x64

Built with `NOW_BUILDER=1` so Next applies Vercel's tracing rules, then served from the pruned artifact rather than the full `node_modules`, on Ubuntu 24.04. Contentful, Spotify and Strava were stubbed by a local fetch mock and the database by a local Postgres, so the sharp code path actually executes.

Before, the exact production failure including the same module hash:

```
GET /   HTTP 200 (prerendered shell, stream aborted)
GET /   HTTP 500

⨯ Error: failed to pipe response
  [cause]: Error: Failed to load external module sharp-8085db5486fb5afb: Error: Could not load the "sharp" module using the linux-x64 runtime
  ERR_DLOPEN_FAILED: libvips-cpp.so.8.18.3: cannot open shared object file: No such file or directory
```

![Homepage before the fix, blank white page from the HTTP 500](https://cursor.com/artifacts/c/art-657c9b1c-5e07-4818-a507-c9895a9cb6e3)

After:

```
GET /                  HTTP 200  bytes=376147
GET /                  HTTP 200  bytes=376520
GET /                  HTTP 200  bytes=376520
GET /                  HTTP 200  bytes=376520
GET /opengraph-image   HTTP 200  type=image/png  bytes=33048
GET /twitter-image     HTTP 200  type=image/png  bytes=33048
GET /music             HTTP 200
GET /music/albums      HTTP 200
GET /llms.txt          HTTP 200
GET /sitemap.xml       HTTP 200
GET /robots.txt        HTTP 200
```

sharp really ran, not just loaded. The served HTML contains six `radial-gradient(circle at top right, hsla(...))` strings that only `buildRadialGradient` produces, the "Now playing" card renders with the gradient sharp derived from the album art, and the server log has zero `ERR_DLOPEN_FAILED` lines.

![Homepage after the fix, Now playing card rendering with its sharp-derived gradient](https://cursor.com/artifacts/c/art-e8f31819-d44c-45bf-90f6-a92f7402b504)

Repo checks, with a local Postgres for the DB-backed suites:

- `turbo check` and `turbo check:types`: 22/22 tasks pass
- `turbo test`: 5/5 tasks, 142/142 in `@dg/services`, 84/84 in `@dg/web`
- `turbo build`: 24/24 tasks, with the new guard running as part of `@dg/web:build`

## Notes for review

- The Vercel preview for this branch built successfully but sits behind deployment protection, so requesting its `/` from CI returns a 302 to `vercel.com/sso-api`. No `VERCEL_TOKEN` or `VERCEL_AUTOMATION_BYPASS_SECRET` is available to me. The local `vercel build` A/B above is the closest substitute, since it exercises the same builder and the same function manifest.
- The glob also matches `@img/sharp-libvips-linux-x64@1.2.4`, the copy that `next` and `@vercel/og` pin, adding roughly 9 MB per function. Neither actually needs it in these bundles: Vercel supplies its own sharp for image optimization, and the OG routes run on the edge runtime, where `@vercel/og` uses resvg wasm and where tracing includes are skipped entirely. Pinning a version in the glob would drop that 9 MB but would silently under-include on the next sharp bump, which is the failure mode that caused this outage.
- `packages/ui` declares `sharp` in its dependencies but never imports it. Removing it is unrelated cleanup and stayed out of this hotfix.

# Release info

- [ ] Major
- [ ] Minor
- [x] Patch
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bfa00869-1772-4050-8311-0e6c071e0dc7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bfa00869-1772-4050-8311-0e6c071e0dc7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

