### PR TITLE
Publish RFC 9727 API catalog

### DIFF
--- a/apps/web/src/app/.well-known/api-catalog/__tests__/route.test.ts
+++ b/apps/web/src/app/.well-known/api-catalog/__tests__/route.test.ts
@@ -1,0 +1,57 @@
+/**
+ * @jest-environment node
+ */
+
+jest.mock('../../../metadata', () => ({
+  metadataBase: new URL('https://dylangattey.com'),
+}));
+
+describe('API catalog route', () => {
+  it('returns a profiled RFC 9727 Linkset for the public content API', async () => {
+    const { GET } = await import('../route');
+    const response = GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe(
+      'application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727"',
+    );
+    expect(response.headers.get('Link')).toContain('rel="api-catalog"');
+    expect(body).toEqual({
+      linkset: [
+        {
+          anchor: 'https://dylangattey.com/',
+          'service-desc': [
+            {
+              href: 'https://dylangattey.com/.well-known/openapi.json',
+              type: 'application/vnd.oai.openapi+json;version=3.1.0',
+            },
+          ],
+          'service-doc': [
+            {
+              href: 'https://dylangattey.com/llms.txt',
+              type: 'text/markdown',
+            },
+          ],
+          status: [
+            {
+              href: 'https://dylangattey.com/.well-known/api-status',
+              type: 'application/json',
+            },
+          ],
+        },
+      ],
+    });
+    expect(JSON.stringify(body)).not.toContain('/api/');
+  });
+
+  it('returns catalog headers and no body for HEAD', async () => {
+    const { HEAD } = await import('../route');
+    const response = HEAD();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toContain('application/linkset+json');
+    expect(response.headers.get('Link')).toContain('rel="api-catalog"');
+    expect(await response.text()).toBe('');
+  });
+});

--- a/apps/web/src/app/.well-known/api-catalog/getApiCatalog.ts
+++ b/apps/web/src/app/.well-known/api-catalog/getApiCatalog.ts
@@ -1,0 +1,54 @@
+import 'server-only';
+
+import {
+  apiOpenApiRoute,
+  apiStatusRoute,
+  llmsTxtRoute,
+} from '@dg/shared-core/routes/app';
+import { metadataBase } from '../../metadata';
+
+type ApiCatalogLink = {
+  href: string;
+  type: string;
+};
+
+type ApiCatalogEntry = {
+  anchor: string;
+  'service-desc': [ApiCatalogLink];
+  'service-doc': [ApiCatalogLink];
+  status: [ApiCatalogLink];
+};
+
+type ApiCatalog = {
+  linkset: [ApiCatalogEntry];
+};
+
+const absoluteUrl = (pathname: string) => new URL(pathname, metadataBase).toString();
+
+export function getApiCatalog(): ApiCatalog {
+  return {
+    linkset: [
+      {
+        anchor: absoluteUrl('/'),
+        'service-desc': [
+          {
+            href: absoluteUrl(apiOpenApiRoute),
+            type: 'application/vnd.oai.openapi+json;version=3.1.0',
+          },
+        ],
+        'service-doc': [
+          {
+            href: absoluteUrl(llmsTxtRoute),
+            type: 'text/markdown',
+          },
+        ],
+        status: [
+          {
+            href: absoluteUrl(apiStatusRoute),
+            type: 'application/json',
+          },
+        ],
+      },
+    ],
+  };
+}

--- a/apps/web/src/app/.well-known/api-catalog/getApiCatalog.ts
+++ b/apps/web/src/app/.well-known/api-catalog/getApiCatalog.ts
@@ -1,10 +1,6 @@
 import 'server-only';
 
-import {
-  apiOpenApiRoute,
-  apiStatusRoute,
-  llmsTxtRoute,
-} from '@dg/shared-core/routes/app';
+import { apiOpenApiRoute, apiStatusRoute, llmsTxtRoute } from '@dg/shared-core/routes/app';
 import { metadataBase } from '../../metadata';
 
 type ApiCatalogLink = {

--- a/apps/web/src/app/.well-known/api-catalog/route.ts
+++ b/apps/web/src/app/.well-known/api-catalog/route.ts
@@ -1,0 +1,19 @@
+import 'server-only';
+
+import { apiCatalogRoute } from '@dg/shared-core/routes/app';
+import { getApiCatalog } from './getApiCatalog';
+
+const headers = {
+  'Cache-Control': 's-maxage=60, stale-while-revalidate=86400',
+  'Content-Type':
+    'application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727"',
+  Link: `<${apiCatalogRoute}>; rel="api-catalog"; type="application/linkset+json"`,
+};
+
+export function GET() {
+  return new Response(JSON.stringify(getApiCatalog()), { headers });
+}
+
+export function HEAD() {
+  return new Response(null, { headers });
+}

--- a/apps/web/src/app/.well-known/api-catalog/route.ts
+++ b/apps/web/src/app/.well-known/api-catalog/route.ts
@@ -5,8 +5,7 @@ import { getApiCatalog } from './getApiCatalog';
 
 const headers = {
   'Cache-Control': 's-maxage=60, stale-while-revalidate=86400',
-  'Content-Type':
-    'application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727"',
+  'Content-Type': 'application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727"',
   Link: `<${apiCatalogRoute}>; rel="api-catalog"; type="application/linkset+json"`,
 };
 

--- a/apps/web/src/app/.well-known/api-status/__tests__/route.test.ts
+++ b/apps/web/src/app/.well-known/api-status/__tests__/route.test.ts
@@ -1,0 +1,14 @@
+/**
+ * @jest-environment node
+ */
+
+describe('API status route', () => {
+  it('reports the public discovery surface as available', async () => {
+    const { GET } = await import('../route');
+    const response = GET();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe('application/json');
+    await expect(response.json()).resolves.toEqual({ status: 'ok' });
+  });
+});

--- a/apps/web/src/app/.well-known/api-status/route.ts
+++ b/apps/web/src/app/.well-known/api-status/route.ts
@@ -1,0 +1,10 @@
+import 'server-only';
+
+export function GET() {
+  return new Response(JSON.stringify({ status: 'ok' }), {
+    headers: {
+      'Cache-Control': 'no-store',
+      'Content-Type': 'application/json',
+    },
+  });
+}

--- a/apps/web/src/app/.well-known/openapi.json/__tests__/route.test.ts
+++ b/apps/web/src/app/.well-known/openapi.json/__tests__/route.test.ts
@@ -1,0 +1,38 @@
+/**
+ * @jest-environment node
+ */
+
+jest.mock('../../../metadata', () => ({
+  metadataBase: new URL('https://dylangattey.com'),
+  SITE_NAME: 'Dylan Gattey',
+}));
+
+describe('content discovery OpenAPI route', () => {
+  it('describes the public discovery endpoints without private integrations', async () => {
+    const { GET } = await import('../route');
+    const response = GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe(
+      'application/vnd.oai.openapi+json;version=3.1.0',
+    );
+    expect(body.openapi).toBe('3.1.0');
+    expect(body.servers).toEqual([{ url: 'https://dylangattey.com' }]);
+    expect(Object.keys(body.paths)).toEqual(
+      expect.arrayContaining([
+        '/',
+        '/index.md',
+        '/llms-full.txt',
+        '/llms.txt',
+        '/music',
+        '/music.md',
+        '/music/albums',
+        '/music/albums.md',
+        '/robots.txt',
+        '/sitemap.xml',
+      ]),
+    );
+    expect(JSON.stringify(body)).not.toContain('/api/');
+  });
+});

--- a/apps/web/src/app/.well-known/openapi.json/getContentDiscoveryOpenApi.ts
+++ b/apps/web/src/app/.well-known/openapi.json/getContentDiscoveryOpenApi.ts
@@ -51,10 +51,7 @@ export function getContentDiscoveryOpenApi() {
   const pagePaths = Object.fromEntries(
     markdownPages.flatMap((page) => [
       [page.path, negotiatedGet(`${page.title} page`)],
-      [
-        htmlPathToMarkdownPath(page.path),
-        textGet(`${page.title} Markdown`, ['text/markdown']),
-      ],
+      [htmlPathToMarkdownPath(page.path), textGet(`${page.title} Markdown`, ['text/markdown'])],
     ]),
   );
 

--- a/apps/web/src/app/.well-known/openapi.json/getContentDiscoveryOpenApi.ts
+++ b/apps/web/src/app/.well-known/openapi.json/getContentDiscoveryOpenApi.ts
@@ -1,0 +1,82 @@
+import 'server-only';
+
+import {
+  htmlPathToMarkdownPath,
+  llmsFullTxtRoute,
+  llmsTxtRoute,
+  markdownPages,
+} from '@dg/shared-core/routes/app';
+import { metadataBase, SITE_NAME } from '../../metadata';
+
+const textResponse = (mediaTypes: ReadonlyArray<string>) => ({
+  content: Object.fromEntries(
+    mediaTypes.map((mediaType) => [mediaType, { schema: { type: 'string' } }]),
+  ),
+  description: 'Successful response',
+});
+
+const textGet = (summary: string, mediaTypes: ReadonlyArray<string>) => ({
+  get: {
+    responses: {
+      '200': textResponse(mediaTypes),
+    },
+    summary,
+  },
+});
+
+const negotiatedGet = (summary: string) => ({
+  get: {
+    parameters: [
+      {
+        description: 'Request text/markdown for the Markdown representation.',
+        in: 'header',
+        name: 'Accept',
+        required: false,
+        schema: {
+          type: 'string',
+        },
+      },
+    ],
+    responses: {
+      '200': textResponse(['text/html', 'text/markdown']),
+      '406': {
+        description: 'The requested representation is not available',
+      },
+    },
+    summary,
+  },
+});
+
+export function getContentDiscoveryOpenApi() {
+  const pagePaths = Object.fromEntries(
+    markdownPages.flatMap((page) => [
+      [page.path, negotiatedGet(`${page.title} page`)],
+      [
+        htmlPathToMarkdownPath(page.path),
+        textGet(`${page.title} Markdown`, ['text/markdown']),
+      ],
+    ]),
+  );
+
+  return {
+    info: {
+      description:
+        'Public, read-only endpoints for discovering and retrieving content from this personal site.',
+      title: `${SITE_NAME} content discovery API`,
+      version: '1.0.0',
+    },
+    openapi: '3.1.0',
+    paths: {
+      ...pagePaths,
+      [llmsTxtRoute]: textGet('Curated LLM content index', ['text/markdown']),
+      [llmsFullTxtRoute]: textGet('Combined site Markdown', ['text/markdown']),
+      '/robots.txt': textGet('Crawler policy', ['text/plain']),
+      '/sitemap.xml': textGet('Public page sitemap', ['application/xml']),
+    },
+    servers: [
+      {
+        url: new URL('/', metadataBase).origin,
+      },
+    ],
+  };
+}

--- a/apps/web/src/app/.well-known/openapi.json/route.ts
+++ b/apps/web/src/app/.well-known/openapi.json/route.ts
@@ -1,0 +1,12 @@
+import 'server-only';
+
+import { getContentDiscoveryOpenApi } from './getContentDiscoveryOpenApi';
+
+export function GET() {
+  return new Response(JSON.stringify(getContentDiscoveryOpenApi()), {
+    headers: {
+      'Cache-Control': 's-maxage=60, stale-while-revalidate=86400',
+      'Content-Type': 'application/vnd.oai.openapi+json;version=3.1.0',
+    },
+  });
+}

--- a/package.json
+++ b/package.json
@@ -27,5 +27,5 @@
     "clean": "rm -f .env .env.tmp",
     "preinstall": "npx only-allow pnpm"
   },
-  "version": "2.62.2"
+  "version": "2.62.3"
 }

--- a/package.json
+++ b/package.json
@@ -27,5 +27,5 @@
     "clean": "rm -f .env .env.tmp",
     "preinstall": "npx only-allow pnpm"
   },
-  "version": "2.62.1"
+  "version": "2.62.2"
 }

--- a/package.json
+++ b/package.json
@@ -27,5 +27,5 @@
     "clean": "rm -f .env .env.tmp",
     "preinstall": "npx only-allow pnpm"
   },
-  "version": "2.62.0"
+  "version": "2.62.1"
 }

--- a/packages/shared-core/routes/__tests__/app.test.ts
+++ b/packages/shared-core/routes/__tests__/app.test.ts
@@ -1,4 +1,7 @@
 import {
+  apiCatalogRoute,
+  apiOpenApiRoute,
+  apiStatusRoute,
   htmlPathToInternalMarkdownPath,
   htmlPathToMarkdownPath,
   isMarkdownPagePath,
@@ -34,5 +37,11 @@ describe('markdown page registry', () => {
       expect(isMarkdownPagePath(path)).toBe(true);
       expect(markdownPathToHtmlPath(htmlPathToMarkdownPath(path))).toBe(path);
     }
+  });
+
+  it('keeps well-known machine documents out of the page registry', () => {
+    expect(markdownPagePaths).not.toEqual(
+      expect.arrayContaining([apiCatalogRoute, apiOpenApiRoute, apiStatusRoute]),
+    );
   });
 });

--- a/packages/shared-core/routes/app.ts
+++ b/packages/shared-core/routes/app.ts
@@ -16,6 +16,12 @@ export const llmsTxtRoute = '/llms.txt' as const;
 
 export const llmsFullTxtRoute = '/llms-full.txt' as const;
 
+export const apiCatalogRoute = '/.well-known/api-catalog' as const;
+
+export const apiOpenApiRoute = '/.well-known/openapi.json' as const;
+
+export const apiStatusRoute = '/.well-known/api-status' as const;
+
 /** Internal rewrite target for Markdown (not a public agent URL). */
 export const internalMarkdownRoutePrefix = '/llm-markdown' as const;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# What changed?

- Publish an RFC 9727 Linkset at `/.well-known/api-catalog` for the site's public content-discovery API
- Add an OpenAPI 3.1 description at `/.well-known/openapi.json` and a minimal availability endpoint at `/.well-known/api-status`
- Keep private OAuth, webhook, and Spotify sync endpoints out of the catalog and keep machine documents out of the human Markdown registry
- Cover catalog GET/HEAD behavior, OpenAPI contents, and status responses with route tests

# Verification

- CI: check, typecheck, tests, bump version, and Vercel deployment pass on `ba3c85f`
- Branch is up to date with `main` (includes #560 agent skills / WebMCP)
- No review threads; bot comments only (Vercel + release version)
- Local route tests: 3 suites and 4 tests pass (from original implementation)
- Live local GET and HEAD return 200 with `application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727"`; OpenAPI and status targets return 200
- The Vercel preview is protected by SSO, so isitagentready follows its redirect to `vercel.com`; scan production after merge

# Release info

- [ ] Major
- [ ] Minor
- [x] Patch

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-89dfb6c3-c8cb-48ab-bb71-1cfd2411c533?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-89dfb6c3-c8cb-48ab-bb71-1cfd2411c533&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

