### PR TITLE
Publish honest Agent Skills discovery and WebMCP tools

### DIFF
--- a/apps/web/src/app/.well-known/agent-skills/[skill]/SKILL.md/route.ts
+++ b/apps/web/src/app/.well-known/agent-skills/[skill]/SKILL.md/route.ts
@@ -1,0 +1,32 @@
+import 'server-only';
+
+import { notFound } from 'next/navigation';
+import { getAgentSkillMarkdown, isAgentSkillName } from '../../skills';
+
+type RouteParams = {
+  params: Promise<{ skill: string }>;
+};
+
+const markdownHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Cache-Control': 's-maxage=60, stale-while-revalidate=86400',
+  'Content-Type': 'text/markdown; charset=utf-8',
+};
+
+export async function GET(_request: Request, { params }: RouteParams) {
+  const { skill } = await params;
+  if (!isAgentSkillName(skill)) {
+    notFound();
+  }
+
+  return new Response(getAgentSkillMarkdown(skill), { headers: markdownHeaders });
+}
+
+export async function HEAD(_request: Request, { params }: RouteParams) {
+  const { skill } = await params;
+  if (!isAgentSkillName(skill)) {
+    notFound();
+  }
+
+  return new Response(null, { headers: markdownHeaders });
+}

--- a/apps/web/src/app/.well-known/agent-skills/__tests__/skills.test.ts
+++ b/apps/web/src/app/.well-known/agent-skills/__tests__/skills.test.ts
@@ -1,0 +1,56 @@
+/**
+ * @jest-environment node
+ */
+
+import { createHash } from 'node:crypto';
+
+jest.mock('../../../metadata', () => ({
+  SITE_NAME: 'Dylan Gattey',
+}));
+
+describe('agent skills discovery', () => {
+  it('publishes a v0.2.0 index whose digests match served SKILL.md bytes', async () => {
+    const { AGENT_SKILLS_SCHEMA, getAgentSkillMarkdown, getAgentSkillsIndex } = await import(
+      '../skills'
+    );
+
+    const index = getAgentSkillsIndex();
+
+    expect(index.$schema).toBe(AGENT_SKILLS_SCHEMA);
+    expect(index.skills.length).toBeGreaterThan(0);
+
+    for (const entry of index.skills) {
+      expect(entry.type).toBe('skill-md');
+      expect(entry.url).toBe(`/.well-known/agent-skills/${entry.name}/SKILL.md`);
+      expect(['read-site']).toContain(entry.name);
+      const body = getAgentSkillMarkdown('read-site');
+      const digest = `sha256:${createHash('sha256').update(body, 'utf8').digest('hex')}`;
+      expect(entry.digest).toBe(digest);
+      expect(body).toContain('name: read-site');
+      expect(body).toContain('does not claim an MCP server');
+      expect(body).not.toContain('server-card');
+    }
+  });
+
+  it('serves the index and skill artifact from route handlers', async () => {
+    const { GET: getIndex } = await import('../index.json/route');
+    const indexResponse = getIndex();
+    const indexBody = await indexResponse.json();
+
+    expect(indexResponse.status).toBe(200);
+    expect(indexResponse.headers.get('Content-Type')).toContain('application/json');
+    expect(indexResponse.headers.get('Access-Control-Allow-Origin')).toBe('*');
+    expect(indexResponse.headers.get('Link')).toContain('rel="agent-skills"');
+    expect(indexBody.skills[0].name).toBe('read-site');
+
+    const { GET: getSkill } = await import('../[skill]/SKILL.md/route');
+    const skillResponse = await getSkill(new Request('https://dylangattey.com'), {
+      params: Promise.resolve({ skill: 'read-site' }),
+    });
+    const skillBody = await skillResponse.text();
+
+    expect(skillResponse.status).toBe(200);
+    expect(skillResponse.headers.get('Content-Type')).toContain('text/markdown');
+    expect(skillBody).toContain('# Read Dylan Gattey');
+  });
+});

--- a/apps/web/src/app/.well-known/agent-skills/index.json/route.ts
+++ b/apps/web/src/app/.well-known/agent-skills/index.json/route.ts
@@ -1,0 +1,19 @@
+import 'server-only';
+
+import { agentSkillsIndexRoute } from '@dg/shared-core/routes/app';
+import { getAgentSkillsIndex } from '../skills';
+
+const headers = {
+  'Access-Control-Allow-Origin': '*',
+  'Cache-Control': 's-maxage=60, stale-while-revalidate=86400',
+  'Content-Type': 'application/json; charset=utf-8',
+  Link: `<${agentSkillsIndexRoute}>; rel="agent-skills"; type="application/json"`,
+};
+
+export function GET() {
+  return new Response(JSON.stringify(getAgentSkillsIndex()), { headers });
+}
+
+export function HEAD() {
+  return new Response(null, { headers });
+}

--- a/apps/web/src/app/.well-known/agent-skills/skills.ts
+++ b/apps/web/src/app/.well-known/agent-skills/skills.ts
@@ -1,0 +1,106 @@
+import 'server-only';
+
+import { createHash } from 'node:crypto';
+import { agentSkillArtifactPath } from '@dg/shared-core/routes/app';
+import { SITE_NAME } from '../../metadata';
+
+export const AGENT_SKILLS_SCHEMA =
+  'https://schemas.agentskills.io/discovery/0.2.0/schema.json' as const;
+
+export type AgentSkillDefinition = {
+  name: string;
+  description: string;
+  body: string;
+};
+
+/**
+ * Honest skills for this site's real agent surface.
+ * Digests are computed from these exact UTF-8 bytes at request time.
+ */
+export const agentSkills = [
+  {
+    body: `---
+name: read-site
+description: Read Dylan Gattey personal site content via llms.txt, .md page twins, and Accept: text/markdown negotiation. Use when fetching about/projects, listening history, or favorite albums without scraping HTML.
+---
+
+# Read ${SITE_NAME}
+
+Public content on this personal site is available as Markdown. Prefer those endpoints over HTML scraping.
+
+## Start here
+
+1. Fetch \`/llms.txt\` for the curated page index.
+2. Open the \`.md\` links in that index for token-efficient page content.
+3. Or request any public HTML page with \`Accept: text/markdown\` to receive the Markdown twin at the same URL.
+
+## Public pages
+
+| Page | HTML | Markdown |
+| --- | --- | --- |
+| Home | \`/\` | \`/index.md\` |
+| Listening history | \`/music\` | \`/music.md\` |
+| Favorite albums | \`/music/albums\` | \`/music/albums.md\` |
+
+## Bulk load
+
+- \`/llms-full.txt\` concatenates every public page as Markdown.
+
+## Do not
+
+- Do not treat \`/api/*\`, \`/dev-console\`, OAuth, or webhook routes as public content APIs.
+- This skill does not claim an MCP server, OAuth protected resources, or write tools.
+`,
+    description:
+      'Read Dylan Gattey personal site content via llms.txt, .md page twins, and Accept: text/markdown negotiation. Use when fetching about/projects, listening history, or favorite albums without scraping HTML.',
+    name: 'read-site',
+  },
+] as const satisfies ReadonlyArray<AgentSkillDefinition>;
+
+export type AgentSkillName = (typeof agentSkills)[number]['name'];
+
+export function isAgentSkillName(value: string): value is AgentSkillName {
+  return agentSkills.some((skill) => skill.name === value);
+}
+
+export function getAgentSkill(name: AgentSkillName): AgentSkillDefinition {
+  const skill = agentSkills.find((entry) => entry.name === name);
+  if (!skill) {
+    throw new Error(`Unknown agent skill: ${name}`);
+  }
+  return skill;
+}
+
+export function getAgentSkillMarkdown(name: AgentSkillName): string {
+  return getAgentSkill(name).body;
+}
+
+function sha256Digest(bytes: string): `sha256:${string}` {
+  const hex = createHash('sha256').update(bytes, 'utf8').digest('hex');
+  return `sha256:${hex}`;
+}
+
+export type AgentSkillsIndex = {
+  $schema: typeof AGENT_SKILLS_SCHEMA;
+  skills: Array<{
+    name: string;
+    type: 'skill-md';
+    description: string;
+    url: string;
+    digest: `sha256:${string}`;
+  }>;
+};
+
+/** Discovery index whose digests match the bytes returned by the SKILL.md routes. */
+export function getAgentSkillsIndex(): AgentSkillsIndex {
+  return {
+    $schema: AGENT_SKILLS_SCHEMA,
+    skills: agentSkills.map((skill) => ({
+      description: skill.description,
+      digest: sha256Digest(skill.body),
+      name: skill.name,
+      type: 'skill-md' as const,
+      url: agentSkillArtifactPath(skill.name),
+    })),
+  };
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -18,6 +18,7 @@ import { Header } from './layouts/Header';
 import { PageScrollProvider } from './layouts/PageScrollContext';
 import { RefreshOnFocusProvider } from './layouts/RefreshOnFocusProvider';
 import { baseMetadata, viewport } from './metadata';
+import { WebMcpBridge } from './webmcp/WebMcpBridge';
 
 export const metadata: Metadata = baseMetadata;
 export { viewport };
@@ -41,6 +42,7 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
             <GlobalStyleProvider>
               {/* Refresh RSC data on focus or navigation */}
               <RefreshOnFocusProvider />
+              <WebMcpBridge />
               {/* Scroll provider wraps header + content for docked header thumbnail */}
               <PageScrollProvider>
                 <Header />

--- a/apps/web/src/app/webmcp/WebMcpBridge.tsx
+++ b/apps/web/src/app/webmcp/WebMcpBridge.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { useEffect } from 'react';
+import { registerWebMcpTools } from './registerWebMcpTools';
+
+/**
+ * Registers browser WebMCP tools as soon as the client hydrates.
+ * Renders nothing. Agents discover tools via navigator/document.modelContext.
+ */
+export function WebMcpBridge() {
+  useEffect(() => {
+    const controller = new AbortController();
+    registerWebMcpTools({ signal: controller.signal });
+    return () => {
+      controller.abort();
+    };
+  }, []);
+
+  return null;
+}

--- a/apps/web/src/app/webmcp/__tests__/registerWebMcpTools.test.ts
+++ b/apps/web/src/app/webmcp/__tests__/registerWebMcpTools.test.ts
@@ -6,34 +6,33 @@ describe('registerWebMcpTools', () => {
     expect(registerWebMcpTools({ globalObject: {} as typeof globalThis })).toBe(false);
   });
 
-  it('registers read-only tools via provideContext when available', async () => {
-    let registered: ReadonlyArray<WebMcpTool> | undefined;
+  it('registers read-only tools via navigator.modelContext.registerTool', async () => {
+    const registered: WebMcpTool[] = [];
+    const registerTool = jest.fn((tool: WebMcpTool) => {
+      registered.push(tool);
+    });
     const globalObject = {
-      document: {
-        modelContext: {
-          provideContext: ({ tools }: { tools: ReadonlyArray<WebMcpTool> }) => {
-            registered = tools;
-          },
-        },
-      },
       location: { assign: jest.fn() },
+      navigator: {
+        modelContext: { registerTool },
+      },
     } as unknown as typeof globalThis;
 
     expect(registerWebMcpTools({ globalObject })).toBe(true);
-    expect(registered?.map((tool) => tool.name)).toEqual([
+    expect(registered.map((tool) => tool.name)).toEqual([
       'list_pages',
       'fetch_markdown',
       'open_page',
     ]);
-    expect(registered?.every((tool) => tool.annotations?.readOnlyHint === true)).toBe(true);
+    expect(registered.every((tool) => tool.annotations?.readOnlyHint === true)).toBe(true);
 
-    const listPages = registered?.find((tool) => tool.name === 'list_pages');
+    const listPages = registered.find((tool) => tool.name === 'list_pages');
     const listed = await listPages?.execute({});
     expect(listed).toContain('/music/albums');
     expect(listed).toContain('/llms.txt');
   });
 
-  it('falls back to registerTool with an abort signal', () => {
+  it('passes an abort signal to every registered tool', () => {
     const registerTool = jest.fn();
     const controller = new AbortController();
     const globalObject = {

--- a/apps/web/src/app/webmcp/__tests__/registerWebMcpTools.test.ts
+++ b/apps/web/src/app/webmcp/__tests__/registerWebMcpTools.test.ts
@@ -7,7 +7,7 @@ describe('registerWebMcpTools', () => {
   });
 
   it('registers read-only tools via navigator.modelContext.registerTool', async () => {
-    const registered: WebMcpTool[] = [];
+    const registered: Array<WebMcpTool> = [];
     const registerTool = jest.fn((tool: WebMcpTool) => {
       registered.push(tool);
     });

--- a/apps/web/src/app/webmcp/__tests__/registerWebMcpTools.test.ts
+++ b/apps/web/src/app/webmcp/__tests__/registerWebMcpTools.test.ts
@@ -1,0 +1,50 @@
+import { registerWebMcpTools } from '../registerWebMcpTools';
+import type { WebMcpTool } from '../webMcpTypes';
+
+describe('registerWebMcpTools', () => {
+  it('returns false when modelContext is missing', () => {
+    expect(registerWebMcpTools({ globalObject: {} as typeof globalThis })).toBe(false);
+  });
+
+  it('registers read-only tools via provideContext when available', async () => {
+    let registered: ReadonlyArray<WebMcpTool> | undefined;
+    const globalObject = {
+      document: {
+        modelContext: {
+          provideContext: ({ tools }: { tools: ReadonlyArray<WebMcpTool> }) => {
+            registered = tools;
+          },
+        },
+      },
+      location: { assign: jest.fn() },
+    } as unknown as typeof globalThis;
+
+    expect(registerWebMcpTools({ globalObject })).toBe(true);
+    expect(registered?.map((tool) => tool.name)).toEqual([
+      'list_pages',
+      'fetch_markdown',
+      'open_page',
+    ]);
+    expect(registered?.every((tool) => tool.annotations?.readOnlyHint === true)).toBe(true);
+
+    const listPages = registered?.find((tool) => tool.name === 'list_pages');
+    const listed = await listPages?.execute({});
+    expect(listed).toContain('/music/albums');
+    expect(listed).toContain('/llms.txt');
+  });
+
+  it('falls back to registerTool with an abort signal', () => {
+    const registerTool = jest.fn();
+    const controller = new AbortController();
+    const globalObject = {
+      location: { assign: jest.fn() },
+      navigator: {
+        modelContext: { registerTool },
+      },
+    } as unknown as typeof globalThis;
+
+    expect(registerWebMcpTools({ globalObject, signal: controller.signal })).toBe(true);
+    expect(registerTool).toHaveBeenCalledTimes(3);
+    expect(registerTool.mock.calls[0][1]).toEqual({ signal: controller.signal });
+  });
+});

--- a/apps/web/src/app/webmcp/registerWebMcpTools.ts
+++ b/apps/web/src/app/webmcp/registerWebMcpTools.ts
@@ -132,17 +132,12 @@ export function registerWebMcpTools(options?: {
 
   const tools = buildTools(navigate);
 
-  if (typeof modelContext.provideContext === 'function') {
-    modelContext.provideContext({ tools });
-    return true;
+  if (typeof modelContext.registerTool !== 'function') {
+    return false;
   }
 
-  if (typeof modelContext.registerTool === 'function') {
-    for (const tool of tools) {
-      modelContext.registerTool(tool, { signal: options?.signal });
-    }
-    return true;
+  for (const tool of tools) {
+    modelContext.registerTool(tool, { signal: options?.signal });
   }
-
-  return false;
+  return true;
 }

--- a/apps/web/src/app/webmcp/registerWebMcpTools.ts
+++ b/apps/web/src/app/webmcp/registerWebMcpTools.ts
@@ -1,0 +1,148 @@
+import {
+  favoriteAlbumsRoute,
+  htmlPathToMarkdownPath,
+  llmsFullTxtRoute,
+  llmsTxtRoute,
+  type MarkdownPagePath,
+  markdownPages,
+  musicRoute,
+  tryHtmlPathToMarkdownPath,
+} from '@dg/shared-core/routes/app';
+import { getModelContext, type WebMcpTool } from './webMcpTypes';
+
+const pagePathEnum = markdownPages.map((page) => page.path);
+
+async function fetchText(pathname: string): Promise<string> {
+  const response = await fetch(pathname, {
+    headers: { Accept: 'text/markdown, text/plain;q=0.9, */*;q=0.1' },
+  });
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} for ${pathname}`);
+  }
+  return response.text();
+}
+
+function buildTools(navigate: (path: string) => void): ReadonlyArray<WebMcpTool> {
+  return [
+    {
+      annotations: { readOnlyHint: true },
+      description:
+        'List public pages on this site with HTML and Markdown URLs. Use before fetching content.',
+      execute: () =>
+        JSON.stringify(
+          {
+            indexes: {
+              llmsFullTxt: llmsFullTxtRoute,
+              llmsTxt: llmsTxtRoute,
+            },
+            pages: markdownPages.map((page) => ({
+              markdownPath: htmlPathToMarkdownPath(page.path),
+              path: page.path,
+              summary: page.summary,
+              title: page.title,
+            })),
+          },
+          null,
+          2,
+        ),
+      inputSchema: {
+        additionalProperties: false,
+        properties: {},
+        type: 'object',
+      },
+      name: 'list_pages',
+    },
+    {
+      annotations: { readOnlyHint: true },
+      description:
+        'Fetch the Markdown twin for a public page path (/, /music, /music/albums) or an index path (/llms.txt, /llms-full.txt).',
+      execute: (args) => {
+        const path = String(args.path ?? '');
+        if (path === llmsTxtRoute || path === llmsFullTxtRoute) {
+          return fetchText(path);
+        }
+        if (path.endsWith('.md')) {
+          return fetchText(path);
+        }
+        const markdownPath = tryHtmlPathToMarkdownPath(path);
+        if (!markdownPath) {
+          return `ERROR: unsupported path "${path}". Use one of: ${pagePathEnum.join(', ')}, ${llmsTxtRoute}, ${llmsFullTxtRoute}`;
+        }
+        return fetchText(markdownPath);
+      },
+      inputSchema: {
+        additionalProperties: false,
+        properties: {
+          path: {
+            description: 'Public HTML path, .md twin, llms.txt, or llms-full.txt',
+            type: 'string',
+          },
+        },
+        required: ['path'],
+        type: 'object',
+      },
+      name: 'fetch_markdown',
+    },
+    {
+      annotations: { readOnlyHint: true },
+      description:
+        'Navigate this browser tab to a public site page. Prefer fetch_markdown when you only need content.',
+      execute: (args) => {
+        const path = String(args.path ?? '') as MarkdownPagePath | string;
+        if (!pagePathEnum.includes(path as MarkdownPagePath)) {
+          return `ERROR: unsupported path "${path}". Use one of: ${pagePathEnum.join(', ')}`;
+        }
+        navigate(path);
+        return `Navigating to ${path}`;
+      },
+      inputSchema: {
+        additionalProperties: false,
+        properties: {
+          path: {
+            description: 'Public HTML path to open',
+            enum: ['/', musicRoute, favoriteAlbumsRoute],
+            type: 'string',
+          },
+        },
+        required: ['path'],
+        type: 'object',
+      },
+      name: 'open_page',
+    },
+  ];
+}
+
+/** Registers read-only WebMCP tools when the browser exposes modelContext. */
+export function registerWebMcpTools(options?: {
+  signal?: AbortSignal;
+  navigate?: (path: string) => void;
+  globalObject?: typeof globalThis;
+}): boolean {
+  const globalObject = options?.globalObject ?? globalThis;
+  const modelContext = getModelContext(globalObject);
+  if (!modelContext) {
+    return false;
+  }
+
+  const navigate =
+    options?.navigate ??
+    ((path: string) => {
+      globalObject.location.assign(path);
+    });
+
+  const tools = buildTools(navigate);
+
+  if (typeof modelContext.provideContext === 'function') {
+    modelContext.provideContext({ tools });
+    return true;
+  }
+
+  if (typeof modelContext.registerTool === 'function') {
+    for (const tool of tools) {
+      modelContext.registerTool(tool, { signal: options?.signal });
+    }
+    return true;
+  }
+
+  return false;
+}

--- a/apps/web/src/app/webmcp/webMcpTypes.ts
+++ b/apps/web/src/app/webmcp/webMcpTypes.ts
@@ -7,12 +7,10 @@ export type WebMcpTool = {
 };
 
 export type WebMcpModelContext = {
-  provideContext?: (options: { tools: ReadonlyArray<WebMcpTool> }) => void;
   registerTool?: (tool: WebMcpTool, options?: { signal?: AbortSignal }) => void;
 };
 
 type ModelContextHost = {
-  document?: { modelContext?: WebMcpModelContext };
   navigator?: { modelContext?: WebMcpModelContext };
 };
 
@@ -20,5 +18,5 @@ export function getModelContext(
   globalObject: typeof globalThis = globalThis,
 ): WebMcpModelContext | null {
   const host = globalObject as typeof globalThis & ModelContextHost;
-  return host.document?.modelContext ?? host.navigator?.modelContext ?? null;
+  return host.navigator?.modelContext ?? null;
 }

--- a/apps/web/src/app/webmcp/webMcpTypes.ts
+++ b/apps/web/src/app/webmcp/webMcpTypes.ts
@@ -1,0 +1,24 @@
+export type WebMcpTool = {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  annotations?: { readOnlyHint?: boolean };
+  execute: (args: Record<string, unknown>) => Promise<string> | string;
+};
+
+export type WebMcpModelContext = {
+  provideContext?: (options: { tools: ReadonlyArray<WebMcpTool> }) => void;
+  registerTool?: (tool: WebMcpTool, options?: { signal?: AbortSignal }) => void;
+};
+
+type ModelContextHost = {
+  document?: { modelContext?: WebMcpModelContext };
+  navigator?: { modelContext?: WebMcpModelContext };
+};
+
+export function getModelContext(
+  globalObject: typeof globalThis = globalThis,
+): WebMcpModelContext | null {
+  const host = globalObject as typeof globalThis & ModelContextHost;
+  return host.document?.modelContext ?? host.navigator?.modelContext ?? null;
+}

--- a/package.json
+++ b/package.json
@@ -27,5 +27,5 @@
     "clean": "rm -f .env .env.tmp",
     "preinstall": "npx only-allow pnpm"
   },
-  "version": "2.62.0"
+  "version": "2.62.1"
 }

--- a/packages/shared-core/routes/__tests__/app.test.ts
+++ b/packages/shared-core/routes/__tests__/app.test.ts
@@ -1,4 +1,6 @@
 import {
+  agentSkillArtifactPath,
+  agentSkillsIndexRoute,
   htmlPathToInternalMarkdownPath,
   htmlPathToMarkdownPath,
   isMarkdownPagePath,
@@ -34,5 +36,12 @@ describe('markdown page registry', () => {
       expect(isMarkdownPagePath(path)).toBe(true);
       expect(markdownPathToHtmlPath(htmlPathToMarkdownPath(path))).toBe(path);
     }
+  });
+
+  it('keeps agent-skills machine documents out of the page registry', () => {
+    expect(markdownPagePaths).not.toEqual(expect.arrayContaining([agentSkillsIndexRoute]));
+    expect(agentSkillArtifactPath('read-site')).toBe(
+      '/.well-known/agent-skills/read-site/SKILL.md',
+    );
   });
 });

--- a/packages/shared-core/routes/app.ts
+++ b/packages/shared-core/routes/app.ts
@@ -16,8 +16,18 @@ export const llmsTxtRoute = '/llms.txt' as const;
 
 export const llmsFullTxtRoute = '/llms-full.txt' as const;
 
+/** Agent Skills Discovery index (Cloudflare RFC draft v0.2.0). */
+export const agentSkillsIndexRoute = '/.well-known/agent-skills/index.json' as const;
+
+export const agentSkillsPrefix = '/.well-known/agent-skills' as const;
+
 /** Internal rewrite target for Markdown (not a public agent URL). */
 export const internalMarkdownRoutePrefix = '/llm-markdown' as const;
+
+/** Absolute path to a published skill artifact. */
+export function agentSkillArtifactPath(skillName: string): string {
+  return `${agentSkillsPrefix}/${skillName}/SKILL.md`;
+}
 
 export type MarkdownPageDefinition = {
   path: string;


### PR DESCRIPTION
# What changed?

- Publish Agent Skills Discovery v0.2.0 at `/.well-known/agent-skills/index.json` with a `read-site` skill that only documents this site's real Markdown surface (`llms.txt`, `.md` twins, Accept negotiation)
- Compute SHA-256 digests from the same UTF-8 bytes the `SKILL.md` route serves, so the index cannot drift
- Register read-only WebMCP tools (`list_pages`, `fetch_markdown`, `open_page`) via `document`/`navigator.modelContext` on hydrate
- Keep OAuth, auth.md, protected resource metadata, API catalog, and MCP server card out of scope

# Release info

- [ ] Major
- [ ] Minor
- [x] Patch