### PR TITLE
Add agent skills discovery and WebMCP tools

### DIFF
--- a/apps/web/src/app/.well-known/agent-skills/[name]/SKILL.md/route.ts
+++ b/apps/web/src/app/.well-known/agent-skills/[name]/SKILL.md/route.ts
@@ -1,0 +1,26 @@
+import 'server-only';
+
+import { getAgentSkill, isAgentSkillName } from '../../agentSkills';
+
+type RouteContext = {
+  params: Promise<{ name: string }>;
+};
+
+export async function GET(_request: Request, context: RouteContext) {
+  const { name } = await context.params;
+  if (!isAgentSkillName(name)) {
+    return new Response('Not Found\n', { status: 404 });
+  }
+
+  const skill = getAgentSkill(name);
+  if (!skill) {
+    return new Response('Not Found\n', { status: 404 });
+  }
+
+  return new Response(skill.skillMd, {
+    headers: {
+      'Cache-Control': 's-maxage=60, stale-while-revalidate=86400',
+      'Content-Type': 'text/markdown; charset=utf-8',
+    },
+  });
+}

--- a/apps/web/src/app/.well-known/agent-skills/__tests__/agentSkills.test.ts
+++ b/apps/web/src/app/.well-known/agent-skills/__tests__/agentSkills.test.ts
@@ -1,0 +1,43 @@
+/**
+ * @jest-environment node
+ */
+
+import {
+  AGENT_SKILLS_SCHEMA,
+  agentSkills,
+  getAgentSkill,
+  getAgentSkillsIndex,
+  isAgentSkillName,
+  sha256Digest,
+  skillArtifactUrl,
+} from '../agentSkills';
+
+describe('agentSkills', () => {
+  it('builds a v0.2.0 discovery index with matching digests', () => {
+    const index = getAgentSkillsIndex();
+
+    expect(index.$schema).toBe(AGENT_SKILLS_SCHEMA);
+    expect(index.skills).toHaveLength(agentSkills.length);
+
+    for (const entry of index.skills) {
+      expect(entry.type).toBe('skill-md');
+      expect(entry.url).toBe(skillArtifactUrl(entry.name));
+      expect(entry.name).toMatch(/^[a-z0-9]+(?:-[a-z0-9]+)*$/);
+      expect(isAgentSkillName(entry.name)).toBe(true);
+
+      const skill = getAgentSkill(entry.name);
+      expect(skill).toBeDefined();
+      if (!skill) {
+        return;
+      }
+      expect(entry.digest).toBe(sha256Digest(skill.skillMd));
+      expect(skill.skillMd.startsWith('---\n')).toBe(true);
+      expect(skill.skillMd).toContain(`name: ${entry.name}`);
+    }
+  });
+
+  it('rejects unknown skill names', () => {
+    expect(isAgentSkillName('not-a-skill')).toBe(false);
+    expect(getAgentSkill('not-a-skill')).toBeUndefined();
+  });
+});

--- a/apps/web/src/app/.well-known/agent-skills/__tests__/indexRoute.test.ts
+++ b/apps/web/src/app/.well-known/agent-skills/__tests__/indexRoute.test.ts
@@ -1,0 +1,18 @@
+/**
+ * @jest-environment node
+ */
+
+import { GET } from '../index.json/route';
+
+describe('GET /.well-known/agent-skills/index.json', () => {
+  it('returns the discovery index as JSON', async () => {
+    const response = await GET();
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toContain('application/json');
+
+    const body = await response.json();
+    expect(body.$schema).toBe('https://schemas.agentskills.io/discovery/0.2.0/schema.json');
+    expect(Array.isArray(body.skills)).toBe(true);
+    expect(body.skills.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/app/.well-known/agent-skills/__tests__/skillMdRoute.test.ts
+++ b/apps/web/src/app/.well-known/agent-skills/__tests__/skillMdRoute.test.ts
@@ -1,0 +1,27 @@
+/**
+ * @jest-environment node
+ */
+
+import { GET } from '../[name]/SKILL.md/route';
+
+describe('GET /.well-known/agent-skills/[name]/SKILL.md', () => {
+  it('serves a known skill as markdown', async () => {
+    const response = await GET(new Request('http://localhost'), {
+      params: Promise.resolve({ name: 'browse-llms-txt' }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toContain('text/markdown');
+    const body = await response.text();
+    expect(body).toContain('name: browse-llms-txt');
+    expect(body).toContain('/llms.txt');
+  });
+
+  it('returns 404 for an unknown skill', async () => {
+    const response = await GET(new Request('http://localhost'), {
+      params: Promise.resolve({ name: 'missing-skill' }),
+    });
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/apps/web/src/app/.well-known/agent-skills/agentSkills.ts
+++ b/apps/web/src/app/.well-known/agent-skills/agentSkills.ts
@@ -1,0 +1,55 @@
+import { createHash } from 'node:crypto';
+
+import { browseLlmsTxtSkill } from './skills/browseLlmsTxt';
+import { markdownNegotiationSkill } from './skills/markdownNegotiation';
+import { musicAndAlbumsSkill } from './skills/musicAndAlbums';
+
+export const AGENT_SKILLS_SCHEMA =
+  'https://schemas.agentskills.io/discovery/0.2.0/schema.json' as const;
+
+export const agentSkillsPrefix = '/.well-known/agent-skills' as const;
+
+export type AgentSkillDefinition = {
+  description: string;
+  name: string;
+  skillMd: string;
+};
+
+/** Skills published for agents consuming this site. */
+export const agentSkills = [
+  browseLlmsTxtSkill,
+  markdownNegotiationSkill,
+  musicAndAlbumsSkill,
+] as const satisfies ReadonlyArray<AgentSkillDefinition>;
+
+export type AgentSkillName = (typeof agentSkills)[number]['name'];
+
+export function isAgentSkillName(name: string): name is AgentSkillName {
+  return agentSkills.some((skill) => skill.name === name);
+}
+
+export function getAgentSkill(name: string): AgentSkillDefinition | undefined {
+  return agentSkills.find((skill) => skill.name === name);
+}
+
+export function sha256Digest(content: string): `sha256:${string}` {
+  return `sha256:${createHash('sha256').update(content, 'utf8').digest('hex')}`;
+}
+
+export function skillArtifactUrl(name: string): string {
+  return `${agentSkillsPrefix}/${name}/SKILL.md`;
+}
+
+/** Discovery index per Agent Skills Discovery RFC v0.2.0. */
+export function getAgentSkillsIndex() {
+  return {
+    $schema: AGENT_SKILLS_SCHEMA,
+    skills: agentSkills.map((skill) => ({
+      description: skill.description,
+      digest: sha256Digest(skill.skillMd),
+      name: skill.name,
+      type: 'skill-md' as const,
+      url: skillArtifactUrl(skill.name),
+    })),
+  };
+}

--- a/apps/web/src/app/.well-known/agent-skills/index.json/route.ts
+++ b/apps/web/src/app/.well-known/agent-skills/index.json/route.ts
@@ -1,0 +1,11 @@
+import 'server-only';
+
+import { getAgentSkillsIndex } from '../agentSkills';
+
+export function GET() {
+  return Response.json(getAgentSkillsIndex(), {
+    headers: {
+      'Cache-Control': 's-maxage=60, stale-while-revalidate=86400',
+    },
+  });
+}

--- a/apps/web/src/app/.well-known/agent-skills/skills/browseLlmsTxt.ts
+++ b/apps/web/src/app/.well-known/agent-skills/skills/browseLlmsTxt.ts
@@ -1,0 +1,27 @@
+/** Skill body for consuming this site via `/llms.txt` and `.md` twins. */
+export const browseLlmsTxtSkill = {
+  description:
+    'Discover public pages on dylangattey.com via /llms.txt and prefer .md links for clean Markdown.',
+  name: 'browse-llms-txt',
+  skillMd: `---
+name: browse-llms-txt
+description: Discover public pages on dylangattey.com via /llms.txt and prefer .md links for clean Markdown.
+---
+
+# Browse dylangattey.com via llms.txt
+
+Dylan Gattey's personal site publishes a curated agent index at \`/llms.txt\`.
+
+## Steps
+
+1. \`GET https://dylangattey.com/llms.txt\`
+2. Read the H1, summary, and \`## Pages\` list
+3. Follow the \`.md\` links (for example \`/index.md\`, \`/music.md\`) for token-efficient content
+4. Optionally fetch \`/llms-full.txt\` for every public page in one file
+
+## Do not
+
+- Crawl \`/api/*\`, \`/dev-console\`, or \`/llm-markdown\` (internal rewrite target)
+- Prefer HTML when a \`.md\` twin is linked from \`llms.txt\`
+`,
+} as const;

--- a/apps/web/src/app/.well-known/agent-skills/skills/markdownNegotiation.ts
+++ b/apps/web/src/app/.well-known/agent-skills/skills/markdownNegotiation.ts
@@ -1,0 +1,33 @@
+/** Skill body for Accept negotiation and `.md` URL twins. */
+export const markdownNegotiationSkill = {
+  description:
+    'Fetch Markdown from dylangattey.com with Accept: text/markdown or by requesting the .md twin URL.',
+  name: 'markdown-negotiation',
+  skillMd: `---
+name: markdown-negotiation
+description: Fetch Markdown from dylangattey.com with Accept: text/markdown or by requesting the .md twin URL.
+---
+
+# Markdown content negotiation
+
+Public HTML pages on this site also expose Markdown.
+
+## Options
+
+1. **\`.md\` twin URL** (preferred when linked from \`llms.txt\`):
+   - \`/\` → \`/index.md\`
+   - \`/music\` → \`/music.md\`
+   - \`/music/albums\` → \`/music/albums.md\`
+
+2. **Accept header** on the HTML path:
+   \`\`\`http
+   GET /music HTTP/1.1
+   Accept: text/markdown
+   \`\`\`
+   Expect \`Content-Type: text/markdown\` and a \`Link\` alternate header.
+
+## Errors
+
+- Unsupported \`Accept\` types (for example \`application/pdf\`) return **406** with available types listed.
+`,
+} as const;

--- a/apps/web/src/app/.well-known/agent-skills/skills/musicAndAlbums.ts
+++ b/apps/web/src/app/.well-known/agent-skills/skills/musicAndAlbums.ts
@@ -1,0 +1,31 @@
+/** Skill body for music listening history and favorite albums. */
+export const musicAndAlbumsSkill = {
+  description:
+    'Read Dylan Gattey listening history and favorite albums via Markdown pages and llms.txt links.',
+  name: 'music-and-albums',
+  skillMd: `---
+name: music-and-albums
+description: Read Dylan Gattey listening history and favorite albums via Markdown pages and llms.txt links.
+---
+
+# Music and albums
+
+Public music surfaces (no API keys required for agents):
+
+| Page | HTML | Markdown |
+| --- | --- | --- |
+| Recent Spotify plays | \`/music\` | \`/music.md\` |
+| Favorite albums | \`/music/albums\` | \`/music/albums.md\` |
+
+## Recommended flow
+
+1. Start from \`/llms.txt\` for absolute \`.md\` links
+2. Fetch \`/music.md\` for recent listening history
+3. Fetch \`/music/albums.md\` for the all-time favorites grid as Markdown
+
+## Notes
+
+- These pages are public content only. Do not call private \`/api/*\` Spotify or Strava routes.
+- HTML pages support \`Accept: text/markdown\` as an alternative to the \`.md\` twin.
+`,
+} as const;

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -17,6 +17,7 @@ import { Footer } from './layouts/Footer';
 import { Header } from './layouts/Header';
 import { PageScrollProvider } from './layouts/PageScrollContext';
 import { RefreshOnFocusProvider } from './layouts/RefreshOnFocusProvider';
+import { WebMcpTools } from './layouts/WebMcpTools';
 import { baseMetadata, viewport } from './metadata';
 
 export const metadata: Metadata = baseMetadata;
@@ -41,6 +42,7 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
             <GlobalStyleProvider>
               {/* Refresh RSC data on focus or navigation */}
               <RefreshOnFocusProvider />
+              <WebMcpTools />
               {/* Scroll provider wraps header + content for docked header thumbnail */}
               <PageScrollProvider>
                 <Header />

--- a/apps/web/src/app/layouts/WebMcpTools.tsx
+++ b/apps/web/src/app/layouts/WebMcpTools.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import {
+  favoriteAlbumsRoute,
+  homeRoute,
+  markdownPages,
+  musicRoute,
+} from '@dg/shared-core/routes/app';
+import { useEffect } from 'react';
+
+type JsonSchema = {
+  type: 'object';
+  properties?: Record<string, unknown>;
+  required?: Array<string>;
+  additionalProperties?: boolean;
+};
+
+type ModelContextTool = {
+  name: string;
+  description: string;
+  inputSchema: JsonSchema;
+  execute: (args: Record<string, unknown>) => Promise<unknown> | unknown;
+};
+
+type ModelContextRegisterToolOptions = {
+  signal?: AbortSignal;
+};
+
+type ModelContext = {
+  registerTool: (
+    tool: ModelContextTool,
+    options?: ModelContextRegisterToolOptions,
+  ) => void | Promise<void>;
+};
+
+type NavigatorWithModelContext = Navigator & {
+  modelContext?: ModelContext;
+};
+
+type DocumentWithModelContext = Document & {
+  modelContext?: ModelContext;
+};
+
+const navigablePaths = [homeRoute, musicRoute, favoriteAlbumsRoute] as const;
+
+type NavigablePath = (typeof navigablePaths)[number];
+
+function isNavigablePath(value: unknown): value is NavigablePath {
+  return typeof value === 'string' && (navigablePaths as ReadonlyArray<string>).includes(value);
+}
+
+async function summarizeLlmsTxt(): Promise<{ summary: string; preview: string }> {
+  const response = await fetch('/llms.txt');
+  if (!response.ok) {
+    throw new Error(`Failed to fetch /llms.txt (${response.status})`);
+  }
+  const text = await response.text();
+  const lines = text.split('\n').filter((line) => line.trim().length > 0);
+  const title = lines.find((line) => line.startsWith('# '))?.slice(2) ?? 'Dylan Gattey';
+  const blurb = lines.find((line) => line.startsWith('> '))?.slice(2) ?? '';
+  const pageCount = lines.filter((line) => line.startsWith('- [')).length;
+  return {
+    preview: text.slice(0, 500),
+    summary: `${title}: ${blurb} ${pageCount} linked resources in /llms.txt.`.trim(),
+  };
+}
+
+/** Prefer navigator (isitagentready), fall back to document (WebMCP IDL). */
+function getModelContext(): ModelContext | undefined {
+  if (typeof navigator !== 'undefined') {
+    const fromNavigator = (navigator as NavigatorWithModelContext).modelContext;
+    if (fromNavigator?.registerTool) {
+      return fromNavigator;
+    }
+  }
+  if (typeof document !== 'undefined') {
+    const fromDocument = (document as DocumentWithModelContext).modelContext;
+    if (fromDocument?.registerTool) {
+      return fromDocument;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Registers a few public site tools with WebMCP when the browser supports it.
+ * Renders nothing. Passes AbortSignal so tools unregister on unmount.
+ */
+export function WebMcpTools() {
+  useEffect(() => {
+    const modelContext = getModelContext();
+    if (!modelContext?.registerTool) {
+      return;
+    }
+
+    const abortController = new AbortController();
+    const options = { signal: abortController.signal };
+
+    const tools: Array<ModelContextTool> = [
+      {
+        description: 'List public Markdown-capable pages on this site (from the page registry).',
+        execute: () =>
+          markdownPages.map((page) => ({
+            path: page.path,
+            summary: page.summary,
+            title: page.title,
+          })),
+        inputSchema: {
+          additionalProperties: false,
+          properties: {},
+          type: 'object',
+        },
+        name: 'list_public_pages',
+      },
+      {
+        description: 'Navigate the browser to the home, music, or favorite albums page.',
+        execute: (args) => {
+          const path = args.path;
+          if (!isNavigablePath(path)) {
+            throw new Error(
+              `Invalid path. Use one of: ${navigablePaths.map((entry) => JSON.stringify(entry)).join(', ')}`,
+            );
+          }
+          window.location.href = path;
+          return { navigatedTo: path };
+        },
+        inputSchema: {
+          additionalProperties: false,
+          properties: {
+            path: {
+              description: 'Public page path to open',
+              enum: [...navigablePaths],
+              type: 'string',
+            },
+          },
+          required: ['path'],
+          type: 'object',
+        },
+        name: 'navigate_to_page',
+      },
+      {
+        description: 'Fetch /llms.txt and return a short summary plus a text preview.',
+        execute: () => summarizeLlmsTxt(),
+        inputSchema: {
+          additionalProperties: false,
+          properties: {},
+          type: 'object',
+        },
+        name: 'summarize_llms_txt',
+      },
+    ];
+
+    for (const tool of tools) {
+      void modelContext.registerTool(tool, options);
+    }
+
+    return () => {
+      abortController.abort();
+    };
+  }, []);
+
+  return null;
+}

--- a/apps/web/src/app/layouts/__tests__/WebMcpTools.test.tsx
+++ b/apps/web/src/app/layouts/__tests__/WebMcpTools.test.tsx
@@ -1,0 +1,78 @@
+import { favoriteAlbumsRoute, homeRoute, musicRoute } from '@dg/shared-core/routes/app';
+import { render } from '@testing-library/react';
+import { WebMcpTools } from '../WebMcpTools';
+
+type RegisteredTool = {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  execute: (args: Record<string, unknown>) => Promise<unknown> | unknown;
+};
+
+describe('WebMcpTools', () => {
+  const originalNavigator = global.navigator;
+
+  afterEach(() => {
+    Object.defineProperty(global, 'navigator', {
+      configurable: true,
+      value: originalNavigator,
+    });
+    jest.restoreAllMocks();
+  });
+
+  it('registers tools when navigator.modelContext is available', async () => {
+    const registered: Array<{ tool: RegisteredTool; options?: { signal?: AbortSignal } }> = [];
+    Object.defineProperty(global, 'navigator', {
+      configurable: true,
+      value: {
+        modelContext: {
+          registerTool: (tool: RegisteredTool, options?: { signal?: AbortSignal }) => {
+            registered.push({ options, tool });
+          },
+        },
+      },
+    });
+
+    const { unmount } = render(<WebMcpTools />);
+
+    expect(registered.map((entry) => entry.tool.name)).toEqual([
+      'list_public_pages',
+      'navigate_to_page',
+      'summarize_llms_txt',
+    ]);
+    expect(registered.every((entry) => entry.options?.signal instanceof AbortSignal)).toBe(true);
+
+    const listPages = registered.find((entry) => entry.tool.name === 'list_public_pages');
+    const navigate = registered.find((entry) => entry.tool.name === 'navigate_to_page');
+    expect(listPages).toBeDefined();
+    expect(navigate).toBeDefined();
+
+    const pages = await listPages?.tool.execute({});
+    expect(pages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: homeRoute }),
+        expect.objectContaining({ path: musicRoute }),
+        expect.objectContaining({ path: favoriteAlbumsRoute }),
+      ]),
+    );
+
+    expect(() => navigate?.tool.execute({ path: '/dev-console' })).toThrow(/Invalid path/);
+
+    const signal = listPages?.options?.signal;
+    expect(signal?.aborted).toBe(false);
+    unmount();
+    expect(signal?.aborted).toBe(true);
+  });
+
+  it('no-ops when WebMCP is unavailable', () => {
+    Object.defineProperty(global, 'navigator', {
+      configurable: true,
+      value: {},
+    });
+
+    expect(() => {
+      const { unmount } = render(<WebMcpTools />);
+      unmount();
+    }).not.toThrow();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -27,5 +27,5 @@
     "clean": "rm -f .env .env.tmp",
     "preinstall": "npx only-allow pnpm"
   },
-  "version": "2.62.1"
+  "version": "2.62.2"
 }

--- a/package.json
+++ b/package.json
@@ -27,5 +27,5 @@
     "clean": "rm -f .env .env.tmp",
     "preinstall": "npx only-allow pnpm"
   },
-  "version": "2.62.0"
+  "version": "2.62.1"
 }


### PR DESCRIPTION
Closes 

# What changed?

- Publish Agent Skills Discovery RFC v0.2.0 index at `/.well-known/agent-skills/index.json` with three site-consumption skills (`browse-llms-txt`, `markdown-negotiation`, `music-and-albums`), each served as `SKILL.md` with matching `sha256:` digests.
- Register site-wide WebMCP tools (`list_public_pages`, `navigate_to_page`, `summarize_llms_txt`) via `navigator.modelContext.registerTool`, with AbortSignal cleanup. No fake OAuth/AS/MCP server surfaces.

# Release info

- [ ] Major
- [ ] Minor
- [x] Patch

## Verification

- `turbo check`, `check:types`, and `test` green for `@dg/web`
- Local routes on `:3002`: index JSON 200, each `SKILL.md` 200, digests match bodies
- WebMCP tool strings present in the client bundle
- isitagentready scan needs a deployed preview/production URL (localhost rejected)


Made with [Cursor](https://cursor.com)