### PR TITLE
Add honest agent discovery and WebMCP tools

### DIFF
--- a/apps/web/public/.well-known/agent-skills/explore-music/SKILL.md
+++ b/apps/web/public/.well-known/agent-skills/explore-music/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: explore-music
+description: Explore public listening history and favorite albums via /music and /music/albums HTML and Markdown URLs.
+---
+
+# Explore music
+
+Two public music surfaces, with different jobs.
+
+## Recent listening
+
+Recent Spotify plays.
+
+- HTML: `/music`
+- Markdown: `/music.md`
+
+## Favorite albums
+
+All-time favorite albums, separate from recent listening.
+
+- HTML: `/music/albums`
+- Markdown: `/music/albums.md`
+
+Prefer the `.md` URLs, or the HTML URLs with `Accept: text/markdown`, for clean content.

--- a/apps/web/public/.well-known/agent-skills/index.json
+++ b/apps/web/public/.well-known/agent-skills/index.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
+  "skills": [
+    {
+      "description": "Read this site as Markdown via /llms.txt, /llms-full.txt, .md twins, and Accept negotiation.",
+      "digest": "sha256:6c5a3fcd79d881e15dd08fb221452d5eacef452f46c741ee00198a2d6a01cccf",
+      "name": "read-site-markdown",
+      "type": "skill-md",
+      "url": "/.well-known/agent-skills/read-site-markdown/SKILL.md"
+    },
+    {
+      "description": "Explore public listening history and favorite albums via /music and /music/albums HTML and Markdown URLs.",
+      "digest": "sha256:fb1c7c4d846fea37c1737b0524b2ef19ef69160813625a9ad22f05a62af3c1ab",
+      "name": "explore-music",
+      "type": "skill-md",
+      "url": "/.well-known/agent-skills/explore-music/SKILL.md"
+    }
+  ]
+}

--- a/apps/web/public/.well-known/agent-skills/read-site-markdown/SKILL.md
+++ b/apps/web/public/.well-known/agent-skills/read-site-markdown/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: read-site-markdown
+description: Read this site as Markdown via /llms.txt, /llms-full.txt, .md twins, and Accept negotiation.
+---
+
+# Read site Markdown
+
+Prefer Markdown over HTML chrome for public pages.
+
+## Discovery indexes
+
+- `/llms.txt` is a curated index of public pages with absolute `.md` links.
+- `/llms-full.txt` contains all public page Markdown in one file.
+
+## Per-page Markdown
+
+Each public HTML page has a `.md` twin:
+
+- `/` → `/index.md`
+- `/music` → `/music.md`
+- `/music/albums` → `/music/albums.md`
+
+You can also request the HTML URL with `Accept: text/markdown`. When that type is explicitly preferred, the response body is Markdown.
+
+## Scope
+
+Use only these public Markdown surfaces. Do not invent private endpoints.

--- a/apps/web/src/app/__tests__/agentSkillsDiscovery.test.ts
+++ b/apps/web/src/app/__tests__/agentSkillsDiscovery.test.ts
@@ -1,0 +1,188 @@
+/**
+ * @jest-environment node
+ */
+
+import { createHash } from 'node:crypto';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join, relative, resolve, sep } from 'node:path';
+
+const DISCOVERY_SCHEMA = 'https://schemas.agentskills.io/discovery/0.2.0/schema.json';
+const SKILL_NAME_PATTERN = /^[a-z0-9](?:[a-z0-9]|-(?=[a-z0-9])){0,63}$/;
+const DIGEST_PATTERN = /^sha256:[a-f0-9]{64}$/;
+
+const publicDir = resolve(__dirname, '../../../public');
+const skillsDir = resolve(publicDir, '.well-known/agent-skills');
+const indexPath = join(skillsDir, 'index.json');
+
+type SkillIndexEntry = {
+  name: string;
+  type: string;
+  description: string;
+  url: string;
+  digest: string;
+};
+
+type SkillIndex = {
+  $schema: string;
+  skills: Array<SkillIndexEntry>;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function parseSkillIndex(raw: string): SkillIndex {
+  const parsed: unknown = JSON.parse(raw);
+  if (!isRecord(parsed)) {
+    throw new Error('index.json must be an object');
+  }
+  if (parsed.$schema !== DISCOVERY_SCHEMA) {
+    throw new Error(`Unexpected $schema: ${String(parsed.$schema)}`);
+  }
+  if (!Array.isArray(parsed.skills)) {
+    throw new Error('index.json skills must be an array');
+  }
+
+  const skills: Array<SkillIndexEntry> = parsed.skills.map((entry, index) => {
+    if (!isRecord(entry)) {
+      throw new Error(`skills[${index}] must be an object`);
+    }
+
+    const name = entry.name;
+    const type = entry.type;
+    const description = entry.description;
+    const url = entry.url;
+    const digest = entry.digest;
+
+    if (typeof name !== 'string' || name.length === 0) {
+      throw new Error(`skills[${index}].name must be a non-empty string`);
+    }
+    if (typeof type !== 'string' || type.length === 0) {
+      throw new Error(`skills[${index}].type must be a non-empty string`);
+    }
+    if (typeof description !== 'string' || description.length === 0) {
+      throw new Error(`skills[${index}].description must be a non-empty string`);
+    }
+    if (typeof url !== 'string' || url.length === 0) {
+      throw new Error(`skills[${index}].url must be a non-empty string`);
+    }
+    if (typeof digest !== 'string' || digest.length === 0) {
+      throw new Error(`skills[${index}].digest must be a non-empty string`);
+    }
+
+    return { description, digest, name, type, url };
+  });
+
+  return { $schema: DISCOVERY_SCHEMA, skills };
+}
+
+/** Parses the two required frontmatter fields without adding a YAML dependency. */
+function parseRequiredFrontmatter(raw: string): { name: string; description: string } {
+  if (!raw.startsWith('---\n')) {
+    throw new Error('SKILL.md must start with YAML frontmatter');
+  }
+
+  const end = raw.indexOf('\n---\n', 4);
+  if (end === -1) {
+    throw new Error('SKILL.md frontmatter is not closed');
+  }
+
+  const block = raw.slice(4, end);
+  let name: string | undefined;
+  let description: string | undefined;
+
+  for (const line of block.split('\n')) {
+    if (line.startsWith('name:')) {
+      name = line.slice('name:'.length).trim();
+      continue;
+    }
+    if (line.startsWith('description:')) {
+      description = line.slice('description:'.length).trim();
+    }
+  }
+
+  if (!name || !description) {
+    throw new Error('SKILL.md frontmatter requires name and description');
+  }
+
+  return { description, name };
+}
+
+function resolveSkillArtifactPath(url: string): string {
+  if (url.includes('\\') || url.includes('%') || url.includes('..')) {
+    throw new Error(`Unsafe skill url: ${url}`);
+  }
+
+  const pathname =
+    url.startsWith('https://') || url.startsWith('http://') ? new URL(url).pathname : url;
+
+  if (!pathname.startsWith('/.well-known/agent-skills/')) {
+    throw new Error(`Skill url must stay under /.well-known/agent-skills/: ${url}`);
+  }
+
+  const artifactPath = resolve(publicDir, pathname.slice(1));
+  const skillsRoot = resolve(skillsDir) + sep;
+  if (artifactPath !== resolve(skillsDir) && !artifactPath.startsWith(skillsRoot)) {
+    throw new Error(`Resolved skill path escapes skills directory: ${artifactPath}`);
+  }
+
+  return artifactPath;
+}
+
+function listSkillMdFiles(dir: string): Array<string> {
+  const entries = readdirSync(dir, { withFileTypes: true });
+  const files: Array<string> = [];
+
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...listSkillMdFiles(fullPath));
+      continue;
+    }
+    if (entry.isFile() && entry.name === 'SKILL.md') {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+describe('agent skills discovery', () => {
+  it('publishes a valid v0.2.0 index with matching skill artifacts', () => {
+    expect(existsSync(indexPath)).toBe(true);
+
+    const index = parseSkillIndex(readFileSync(indexPath, 'utf8'));
+    expect(index.$schema).toBe(DISCOVERY_SCHEMA);
+    expect(index.skills.length).toBeGreaterThan(0);
+
+    const indexedArtifactPaths = new Set<string>();
+
+    for (const skill of index.skills) {
+      expect(skill.name).toMatch(SKILL_NAME_PATTERN);
+      expect(skill.type).toBe('skill-md');
+      expect(skill.description.length).toBeLessThanOrEqual(1024);
+      expect(skill.digest).toMatch(DIGEST_PATTERN);
+
+      const artifactPath = resolveSkillArtifactPath(skill.url);
+      expect(existsSync(artifactPath)).toBe(true);
+      indexedArtifactPaths.add(artifactPath);
+
+      const artifactBytes = readFileSync(artifactPath);
+      const digest = `sha256:${createHash('sha256').update(artifactBytes).digest('hex')}`;
+      expect(digest).toBe(skill.digest);
+
+      const frontmatter = parseRequiredFrontmatter(artifactBytes.toString('utf8'));
+      expect(frontmatter.name).toBe(skill.name);
+      expect(frontmatter.description).toBe(skill.description);
+    }
+
+    const skillMdFiles = listSkillMdFiles(skillsDir);
+    for (const skillMdPath of skillMdFiles) {
+      expect(indexedArtifactPaths.has(skillMdPath)).toBe(true);
+    }
+
+    expect(skillMdFiles.map((path) => relative(skillsDir, path)).sort()).toEqual(
+      [...indexedArtifactPaths].map((path) => relative(skillsDir, path)).sort(),
+    );
+  });
+});

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -18,6 +18,7 @@ import { Header } from './layouts/Header';
 import { PageScrollProvider } from './layouts/PageScrollContext';
 import { RefreshOnFocusProvider } from './layouts/RefreshOnFocusProvider';
 import { baseMetadata, viewport } from './metadata';
+import { SiteWebMcp } from './webmcp/SiteWebMcp';
 
 export const metadata: Metadata = baseMetadata;
 export { viewport };
@@ -52,6 +53,7 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
                 </Section>
               </PageScrollProvider>
               <Footer />
+              <SiteWebMcp />
               <SpeedInsights />
               <Analytics />
             </GlobalStyleProvider>

--- a/apps/web/src/app/webmcp/SiteWebMcp.tsx
+++ b/apps/web/src/app/webmcp/SiteWebMcp.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+import { createPublicWebMcpTools } from './createPublicWebMcpTools';
+import { getBrowserModelContext, registerPublicWebMcpTools } from './registerPublicWebMcpTools';
+
+/**
+ * Site-wide WebMCP client leaf. Registers public discovery tools when the
+ * browser exposes modelContext; otherwise renders nothing.
+ */
+export function SiteWebMcp() {
+  const router = useRouter();
+
+  useEffect(() => {
+    return registerPublicWebMcpTools({
+      modelContext: getBrowserModelContext(),
+      tools: createPublicWebMcpTools({
+        fetch: (input) => fetch(input),
+        navigate: (path) => {
+          router.push(path);
+        },
+      }),
+    });
+  }, [router]);
+
+  return null;
+}

--- a/apps/web/src/app/webmcp/__tests__/createPublicWebMcpTools.test.ts
+++ b/apps/web/src/app/webmcp/__tests__/createPublicWebMcpTools.test.ts
@@ -1,0 +1,107 @@
+/**
+ * @jest-environment node
+ */
+
+import {
+  htmlPathToMarkdownPath,
+  llmsTxtRoute,
+  markdownPagePaths,
+  markdownPages,
+} from '@dg/shared-core/routes/app';
+import { createPublicWebMcpTools } from '../createPublicWebMcpTools';
+
+describe('createPublicWebMcpTools', () => {
+  it('exposes three tools with metadata shapes derived from the shared registry', () => {
+    const tools = createPublicWebMcpTools({
+      fetch: jest.fn(),
+      navigate: jest.fn(),
+    });
+
+    expect(tools.map((tool) => tool.name)).toEqual([
+      'list_public_markdown_pages',
+      'navigate_to_public_page',
+      'read_llms_txt',
+    ]);
+
+    for (const tool of tools) {
+      expect(typeof tool.description).toBe('string');
+      expect(tool.description.length).toBeGreaterThan(0);
+      expect(tool.inputSchema.type).toBe('object');
+      expect(typeof tool.execute).toBe('function');
+    }
+
+    const navigate = tools.find((tool) => tool.name === 'navigate_to_public_page');
+    expect(navigate?.inputSchema.required).toEqual(['path']);
+    expect(navigate?.inputSchema.properties?.path).toEqual({
+      description: 'Public HTML path to open',
+      enum: [...markdownPagePaths],
+      type: 'string',
+    });
+  });
+
+  it('lists pages from the shared markdown registry', async () => {
+    const tools = createPublicWebMcpTools({
+      fetch: jest.fn(),
+      navigate: jest.fn(),
+    });
+    const listTool = tools.find((tool) => tool.name === 'list_public_markdown_pages');
+    if (!listTool) {
+      throw new Error('missing list_public_markdown_pages tool');
+    }
+
+    const result = await listTool.execute({});
+    expect(result).toEqual({
+      pages: markdownPages.map((page) => ({
+        markdownPath: htmlPathToMarkdownPath(page.path),
+        path: page.path,
+        summary: page.summary,
+        title: page.title,
+      })),
+    });
+  });
+
+  it('rejects invalid navigation input and navigates for valid paths', async () => {
+    const navigate = jest.fn();
+    const tools = createPublicWebMcpTools({
+      fetch: jest.fn(),
+      navigate,
+    });
+    const navigateTool = tools.find((tool) => tool.name === 'navigate_to_public_page');
+    if (!navigateTool) {
+      throw new Error('missing navigate tool');
+    }
+
+    await expect(navigateTool.execute({})).rejects.toThrow(
+      'navigate_to_public_page requires a path',
+    );
+    await expect(navigateTool.execute({ path: '/dev-console' })).rejects.toThrow(
+      'navigate_to_public_page path must be a public markdown page',
+    );
+    expect(navigate).not.toHaveBeenCalled();
+
+    await expect(navigateTool.execute({ path: '/music' })).resolves.toEqual({ path: '/music' });
+    expect(navigate).toHaveBeenCalledWith('/music');
+  });
+
+  it('fetches live llms.txt and rejects non-OK responses', async () => {
+    const fetchMock = jest.fn(
+      async () => new Response('# Dylan Gattey\n', { status: 200, statusText: 'OK' }),
+    );
+    const tools = createPublicWebMcpTools({
+      fetch: fetchMock,
+      navigate: jest.fn(),
+    });
+    const readTool = tools.find((tool) => tool.name === 'read_llms_txt');
+    if (!readTool) {
+      throw new Error('missing read_llms_txt tool');
+    }
+
+    await expect(readTool.execute({})).resolves.toEqual({ text: '# Dylan Gattey\n' });
+    expect(fetchMock).toHaveBeenCalledWith(llmsTxtRoute);
+
+    fetchMock.mockResolvedValueOnce(
+      new Response('nope', { status: 503, statusText: 'Service Unavailable' }),
+    );
+    await expect(readTool.execute({})).rejects.toThrow(`Failed to fetch ${llmsTxtRoute}: 503`);
+  });
+});

--- a/apps/web/src/app/webmcp/__tests__/registerPublicWebMcpTools.test.ts
+++ b/apps/web/src/app/webmcp/__tests__/registerPublicWebMcpTools.test.ts
@@ -1,0 +1,85 @@
+/**
+ * @jest-environment node
+ */
+
+import {
+  registerPublicWebMcpTools,
+  resolveModelContext,
+} from '../registerPublicWebMcpTools';
+import type { ModelContext, WebMcpToolDefinition } from '../webMcpTypes';
+
+function createTool(name: string): WebMcpToolDefinition {
+  return {
+    description: `${name} description`,
+    execute: () => ({ ok: true }),
+    inputSchema: { additionalProperties: false, properties: {}, type: 'object' },
+    name,
+  };
+}
+
+describe('registerPublicWebMcpTools', () => {
+  it('prefers navigator.modelContext and falls back to document.modelContext', () => {
+    const navigatorContext: ModelContext = { registerTool: () => undefined };
+    const documentContext: ModelContext = { registerTool: () => undefined };
+
+    expect(
+      resolveModelContext({ modelContext: navigatorContext }, { modelContext: documentContext }),
+    ).toBe(navigatorContext);
+    expect(resolveModelContext({}, { modelContext: documentContext })).toBe(documentContext);
+    expect(resolveModelContext({}, {})).toBeNull();
+    expect(resolveModelContext(undefined, undefined)).toBeNull();
+  });
+
+  it('is a no-op when the browser API is unavailable', () => {
+    expect(() =>
+      registerPublicWebMcpTools({
+        modelContext: null,
+        tools: [createTool('list_public_markdown_pages')],
+      }),
+    ).not.toThrow();
+  });
+
+  it('registers every tool with one shared AbortSignal and aborts on cleanup', () => {
+    const registeredSignals: Array<AbortSignal> = [];
+    const modelContext: ModelContext = {
+      registerTool: (_tool, options) => {
+        if (options?.signal) {
+          registeredSignals.push(options.signal);
+        }
+        return Promise.resolve();
+      },
+    };
+    const tools = [
+      createTool('list_public_markdown_pages'),
+      createTool('navigate_to_public_page'),
+      createTool('read_llms_txt'),
+    ];
+
+    const unregister = registerPublicWebMcpTools({
+      modelContext,
+      tools,
+    });
+
+    expect(registeredSignals).toHaveLength(3);
+    expect(registeredSignals[0]).toBeInstanceOf(AbortSignal);
+    expect(new Set(registeredSignals).size).toBe(1);
+    expect(registeredSignals[0]?.aborted).toBe(false);
+
+    unregister();
+    expect(registeredSignals[0]?.aborted).toBe(true);
+  });
+
+  it('swallows rejected registration promises', async () => {
+    const modelContext: ModelContext = {
+      registerTool: () => Promise.reject(new Error('register failed')),
+    };
+
+    registerPublicWebMcpTools({
+      modelContext,
+      tools: [createTool('list_public_markdown_pages')],
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+});

--- a/apps/web/src/app/webmcp/__tests__/registerPublicWebMcpTools.test.ts
+++ b/apps/web/src/app/webmcp/__tests__/registerPublicWebMcpTools.test.ts
@@ -2,10 +2,7 @@
  * @jest-environment node
  */
 
-import {
-  registerPublicWebMcpTools,
-  resolveModelContext,
-} from '../registerPublicWebMcpTools';
+import { registerPublicWebMcpTools, resolveModelContext } from '../registerPublicWebMcpTools';
 import type { ModelContext, WebMcpToolDefinition } from '../webMcpTypes';
 
 function createTool(name: string): WebMcpToolDefinition {

--- a/apps/web/src/app/webmcp/createPublicWebMcpTools.ts
+++ b/apps/web/src/app/webmcp/createPublicWebMcpTools.ts
@@ -1,0 +1,85 @@
+import {
+  htmlPathToMarkdownPath,
+  isMarkdownPagePath,
+  llmsTxtRoute,
+  type MarkdownPagePath,
+  markdownPagePaths,
+  markdownPages,
+} from '@dg/shared-core/routes/app';
+import type { WebMcpToolDefinition } from './webMcpTypes';
+
+export type PublicWebMcpToolDeps = {
+  navigate: (path: MarkdownPagePath) => void | Promise<void>;
+  fetch: (input: string) => Promise<Response>;
+};
+
+const emptyObjectSchema = {
+  additionalProperties: false,
+  properties: {},
+  type: 'object',
+} as const;
+
+function parseNavigatePath(input: unknown): MarkdownPagePath {
+  if (typeof input !== 'object' || input === null || !('path' in input)) {
+    throw new Error('navigate_to_public_page requires a path');
+  }
+
+  const pathValue = Reflect.get(input, 'path');
+  if (typeof pathValue !== 'string' || !isMarkdownPagePath(pathValue)) {
+    throw new Error('navigate_to_public_page path must be a public markdown page');
+  }
+
+  return pathValue;
+}
+
+/** Typed WebMCP tools derived from the shared public Markdown registry. */
+export function createPublicWebMcpTools(deps: PublicWebMcpToolDeps): Array<WebMcpToolDefinition> {
+  return [
+    {
+      description: 'List public pages that expose Markdown twins for agent-friendly reading.',
+      execute: () => ({
+        pages: markdownPages.map((page) => ({
+          markdownPath: htmlPathToMarkdownPath(page.path),
+          path: page.path,
+          summary: page.summary,
+          title: page.title,
+        })),
+      }),
+      inputSchema: emptyObjectSchema,
+      name: 'list_public_markdown_pages',
+    },
+    {
+      description: 'Navigate the browser to a public HTML page from the Markdown page registry.',
+      execute: async (input: unknown) => {
+        const path = parseNavigatePath(input);
+        await deps.navigate(path);
+        return { path };
+      },
+      inputSchema: {
+        additionalProperties: false,
+        properties: {
+          path: {
+            description: 'Public HTML path to open',
+            enum: [...markdownPagePaths],
+            type: 'string',
+          },
+        },
+        required: ['path'],
+        type: 'object',
+      },
+      name: 'navigate_to_public_page',
+    },
+    {
+      description: 'Fetch the live public /llms.txt Markdown index for this site.',
+      execute: async () => {
+        const response = await deps.fetch(llmsTxtRoute);
+        if (!response.ok) {
+          throw new Error(`Failed to fetch ${llmsTxtRoute}: ${response.status}`);
+        }
+        return { text: await response.text() };
+      },
+      inputSchema: emptyObjectSchema,
+      name: 'read_llms_txt',
+    },
+  ];
+}

--- a/apps/web/src/app/webmcp/registerPublicWebMcpTools.ts
+++ b/apps/web/src/app/webmcp/registerPublicWebMcpTools.ts
@@ -1,0 +1,54 @@
+import type { ModelContext, WebMcpToolDefinition } from './webMcpTypes';
+
+type ModelContextHost = {
+  readonly modelContext?: ModelContext;
+};
+
+/** Prefer navigator.modelContext for scanners; fall back to document.modelContext. */
+export function resolveModelContext(
+  navigatorHost: ModelContextHost | null | undefined,
+  documentHost: ModelContextHost | null | undefined,
+): ModelContext | null {
+  const fromNavigator = navigatorHost?.modelContext;
+  if (fromNavigator && typeof fromNavigator.registerTool === 'function') {
+    return fromNavigator;
+  }
+
+  const fromDocument = documentHost?.modelContext;
+  if (fromDocument && typeof fromDocument.registerTool === 'function') {
+    return fromDocument;
+  }
+
+  return null;
+}
+
+export function getBrowserModelContext(): ModelContext | null {
+  const navigatorHost = typeof navigator === 'undefined' ? undefined : navigator;
+  const documentHost = typeof document === 'undefined' ? undefined : document;
+  return resolveModelContext(navigatorHost, documentHost);
+}
+
+/**
+ * Registers tools against a shared AbortSignal. Missing API is a no-op.
+ * Rejected registration promises are swallowed so cleanup cannot surface unhandled rejections.
+ */
+export function registerPublicWebMcpTools(args: {
+  modelContext: ModelContext | null;
+  tools: ReadonlyArray<WebMcpToolDefinition>;
+}): () => void {
+  const { modelContext, tools } = args;
+  if (!modelContext) {
+    return () => undefined;
+  }
+
+  const controller = new AbortController();
+  for (const tool of tools) {
+    void Promise.resolve(
+      modelContext.registerTool(tool, { signal: controller.signal }),
+    ).catch(() => undefined);
+  }
+
+  return () => {
+    controller.abort();
+  };
+}

--- a/apps/web/src/app/webmcp/registerPublicWebMcpTools.ts
+++ b/apps/web/src/app/webmcp/registerPublicWebMcpTools.ts
@@ -43,9 +43,9 @@ export function registerPublicWebMcpTools(args: {
 
   const controller = new AbortController();
   for (const tool of tools) {
-    void Promise.resolve(
-      modelContext.registerTool(tool, { signal: controller.signal }),
-    ).catch(() => undefined);
+    void Promise.resolve(modelContext.registerTool(tool, { signal: controller.signal })).catch(
+      () => undefined,
+    );
   }
 
   return () => {

--- a/apps/web/src/app/webmcp/webMcpTypes.ts
+++ b/apps/web/src/app/webmcp/webMcpTypes.ts
@@ -1,0 +1,35 @@
+/**
+ * Minimal ambient draft types for the WebMCP imperative API.
+ * Input to `execute` is always `unknown` and must be validated at the boundary.
+ */
+
+export type WebMcpJsonSchema = {
+  type: 'object';
+  properties?: Record<string, unknown>;
+  required?: ReadonlyArray<string>;
+  additionalProperties?: boolean;
+};
+
+export type WebMcpToolDefinition = {
+  name: string;
+  description: string;
+  inputSchema: WebMcpJsonSchema;
+  execute: (input: unknown) => unknown | Promise<unknown>;
+};
+
+export type ModelContext = {
+  registerTool: (
+    tool: WebMcpToolDefinition,
+    options?: { signal?: AbortSignal },
+  ) => void | Promise<void>;
+};
+
+declare global {
+  interface Navigator {
+    readonly modelContext?: ModelContext;
+  }
+
+  interface Document {
+    readonly modelContext?: ModelContext;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -27,5 +27,5 @@
     "clean": "rm -f .env .env.tmp",
     "preinstall": "npx only-allow pnpm"
   },
-  "version": "2.62.0"
+  "version": "2.62.1"
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# What changed?

- publish two real Agent Skills with an RFC v0.2.0 discovery index and verified SHA-256 digests
- register site-wide WebMCP tools for listing public Markdown pages, navigating to public pages, and reading `/llms.txt`
- validate discovery artifacts and WebMCP registration behavior with focused tests
- keep OAuth, authorization-server metadata, agent registration, private APIs, and MCP Server Cards out of scope

# Verification

- CI check, type-check, and test jobs pass
- Vercel preview deployment is ready
- local discovery responses return 200 with matching artifact digests
- isitagentready cannot inspect the Vercel preview because deployment protection redirects the scanner to Vercel SSO

# Release info

- [ ] Major
- [ ] Minor
- [x] Patch
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a1ed9d6-4692-4576-8e80-7a9df9a03856?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a1ed9d6-4692-4576-8e80-7a9df9a03856&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

