### PR TITLE
Extract album art colors without sharp so / stops 500ing

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -107,7 +107,7 @@
   },
   "overrides": [
     {
-      "includes": ["packages/shared-core/logging/log.ts"],
+      "includes": ["packages/shared-core/logging/log.ts", "scripts/**"],
       "linter": {
         "rules": {
           "suspicious": {

--- a/package.json
+++ b/package.json
@@ -27,5 +27,5 @@
     "clean": "rm -f .env .env.tmp",
     "preinstall": "npx only-allow pnpm"
   },
-  "version": "2.62.1"
+  "version": "2.62.4"
 }

--- a/packages/services/README.md
+++ b/packages/services/README.md
@@ -44,9 +44,10 @@ Low-level HTTP client utilities used by service integrations:
 Server-side image utilities for creating UI-friendly derived data.
 
 
-| Export                                 | Description                                                  |
-| -------------------------------------- | ------------------------------------------------------------ |
-| `getImageGradientInformationFromUrl()` | Builds a CSS gradient + contrast text hint from an image URL |
+| Export                                 | Description                                                         |
+| -------------------------------------- | ------------------------------------------------------------------- |
+| `getImageGradientInformation()`        | Builds a CSS gradient + contrast text hint from decoded RGBA pixels |
+| `getImageGradientInformationFromUrl()` | Fetches a JPEG and builds its CSS gradient + contrast text hint     |
 
 
 ## Contentful

--- a/packages/services/images/__tests__/getImageGradient.test.ts
+++ b/packages/services/images/__tests__/getImageGradient.test.ts
@@ -48,18 +48,18 @@ describe('getImageGradient color extraction', () => {
 
   describe('black/grayscale images', () => {
     it('extracts dark gray gradient from mostly black image', () => {
-      const pixels = createUniformPixels(20, 20, 20, 100);
+      const pixels = createUniformPixels(20, 20, 20, 100); // 10x10 dark gray
       const result = processTestImage(pixels, 10, 10);
 
       expect(result.backgroundGradient).not.toBeNull();
-      expect(result.contrastSetting).toBe('dark');
+      expect(result.contrastSetting).toBe('dark'); // Dark background = light text
     });
 
     it('extracts gray gradient from grayscale image', () => {
       const pixels = mixPixels(
-        { color: [30, 30, 30], count: 40 },
-        { color: [80, 80, 80], count: 40 },
-        { color: [50, 50, 50], count: 20 },
+        { color: [30, 30, 30], count: 40 }, // Dark gray
+        { color: [80, 80, 80], count: 40 }, // Medium gray
+        { color: [50, 50, 50], count: 20 }, // Mid-dark gray
       );
       const result = processTestImage(pixels, 10, 10);
 
@@ -69,6 +69,8 @@ describe('getImageGradient color extraction', () => {
 
   describe('cream/off-white images (Rumours album case)', () => {
     it('extracts subtle cream gradient, NOT bright yellow', () => {
+      // Cream color: RGB ~255, 253, 240 (very light, slight yellow tint)
+      // In HSL: hue ~45, saturation ~0.1, lightness ~0.97
       const pixels = createUniformPixels(255, 253, 240, 100);
       const result = processTestImage(pixels, 10, 10);
 
@@ -76,9 +78,10 @@ describe('getImageGradient color extraction', () => {
     });
 
     it('handles mix of black clothing and cream background (like Rumours)', () => {
+      // Simulating Rumours: ~60% black clothing, ~40% cream background
       const pixels = mixPixels(
-        { color: [20, 20, 20], count: 60 },
-        { color: [255, 250, 235], count: 40 },
+        { color: [20, 20, 20], count: 60 }, // Black clothing
+        { color: [255, 250, 235], count: 40 }, // Cream background
       );
       const result = processTestImage(pixels, 10, 10);
 
@@ -89,6 +92,7 @@ describe('getImageGradient color extraction', () => {
       ];
       const saturations = satMatches.map((m) => parseFloat(m[1] ?? '0'));
 
+      // All saturations should be under 30% (muted, not vibrant yellow)
       saturations.forEach((sat) => {
         expect(sat).toBeLessThan(30);
       });
@@ -97,6 +101,7 @@ describe('getImageGradient color extraction', () => {
 
   describe('vibrant colored images', () => {
     it('extracts red from predominantly red image', () => {
+      // Vibrant red: RGB 220, 50, 50
       const pixels = createUniformPixels(220, 50, 50, 100);
       const result = processTestImage(pixels, 10, 10);
 
@@ -105,10 +110,10 @@ describe('getImageGradient color extraction', () => {
 
     it('extracts multiple colors from colorful image', () => {
       const pixels = mixPixels(
-        { color: [220, 50, 50], count: 30 },
-        { color: [50, 50, 220], count: 30 },
-        { color: [50, 180, 50], count: 20 },
-        { color: [200, 200, 50], count: 20 },
+        { color: [220, 50, 50], count: 30 }, // Red
+        { color: [50, 50, 220], count: 30 }, // Blue
+        { color: [50, 180, 50], count: 20 }, // Green
+        { color: [200, 200, 50], count: 20 }, // Yellow
       );
       const result = processTestImage(pixels, 10, 10);
 
@@ -125,6 +130,7 @@ describe('getImageGradient color extraction', () => {
     });
 
     it('handles image with slight yellow tint that should NOT become neon', () => {
+      // RGB 250, 248, 243 is a subtle cream (~30% saturation in HSL)
       const pixels = createUniformPixels(250, 248, 243, 100);
       const result = processTestImage(pixels, 10, 10);
 
@@ -135,21 +141,25 @@ describe('getImageGradient color extraction', () => {
       ];
       const saturations = satMatches.map((m) => parseFloat(m[1] ?? '0'));
 
+      // Extract all saturation percentages - should stay low
       saturations.forEach((sat) => {
         expect(sat).toBeLessThan(50);
       });
     });
 
     it('chroma scoring prefers mid-tone vibrant colors over light colors when mixed', () => {
+      // When vibrant red competes with cream, red should dominate
       const pixels = mixPixels(
-        { color: [220, 50, 50], count: 40 },
-        { color: [255, 250, 235], count: 60 },
+        { color: [220, 50, 50], count: 40 }, // Vibrant red (mid-tone)
+        { color: [255, 250, 235], count: 60 }, // Cream (high lightness)
       );
       const result = processTestImage(pixels, 10, 10);
 
+      // Extract first (most prominent) color's hue - should be red (~0°), not yellow (~45°)
       const hueMatch = result.backgroundGradient?.match(/hsla\(([\d.]+),/);
       const hue = hueMatch?.[1] ? parseFloat(hueMatch[1]) : -1;
 
+      // Hue should be in red range (0-30° or 330-360°), not yellow range (40-60°)
       const isRed = hue < 30 || hue > 330;
       expect(isRed).toBe(true);
     });

--- a/packages/services/images/__tests__/getImageGradient.test.ts
+++ b/packages/services/images/__tests__/getImageGradient.test.ts
@@ -1,119 +1,94 @@
-import sharp from 'sharp';
-import { getImageGradientInformationFromUrl } from '../getImageGradient';
+import { encode } from 'jpeg-js';
+import {
+  getImageGradientInformation,
+  getImageGradientInformationFromUrl,
+  type RgbaImage,
+} from '../getImageGradient';
 
-// Mock fetch
-global.fetch = jest.fn();
-
-// Helper to create a mock image buffer with specific RGB pixels
-function createMockImageBuffer(pixels: Array<[number, number, number]>): Buffer {
-  // Create raw RGB buffer from pixel array
-  const data = new Uint8Array(pixels.length * 3);
+function imageFromPixels(
+  pixels: Array<[number, number, number]>,
+  width: number,
+  height: number,
+): RgbaImage {
+  const data = new Uint8Array(pixels.length * 4);
   pixels.forEach(([r, g, b], i) => {
-    data[i * 3] = r;
-    data[i * 3 + 1] = g;
-    data[i * 3 + 2] = b;
+    data[i * 4] = r;
+    data[i * 4 + 1] = g;
+    data[i * 4 + 2] = b;
+    data[i * 4 + 3] = 255;
   });
-  return Buffer.from(data);
+  return { data, height, width };
 }
 
-// Helper to create uniform color image (all same pixel)
 function createUniformPixels(
   r: number,
   g: number,
   b: number,
   count: number,
 ): Array<[number, number, number]> {
-  return Array(count).fill([r, g, b]) as Array<[number, number, number]>;
+  return Array.from({ length: count }, (): [number, number, number] => [r, g, b]);
 }
 
-// Helper to mix pixels of different colors
 function mixPixels(
   ...groups: Array<{ color: [number, number, number]; count: number }>
 ): Array<[number, number, number]> {
-  return groups.flatMap(({ color, count }) => Array(count).fill(color)) as Array<
-    [number, number, number]
-  >;
+  return groups.flatMap(({ color, count }) =>
+    Array.from({ length: count }, (): [number, number, number] => color),
+  );
 }
 
 describe('getImageGradient color extraction', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
-  // Test helper that processes an image and returns extracted info for inspection
-  async function processTestImage(
+  function processTestImage(
     pixels: Array<[number, number, number]>,
     width: number,
     height: number,
   ) {
-    const rawBuffer = createMockImageBuffer(pixels);
-
-    // Create actual sharp image from raw pixel data
-    const imageBuffer = await sharp(rawBuffer, {
-      raw: { channels: 3, height, width },
-    })
-      .png()
-      .toBuffer();
-
-    // Mock fetch to return our test image
-    (global.fetch as jest.Mock).mockResolvedValueOnce({
-      arrayBuffer: () => Promise.resolve(imageBuffer),
-      ok: true,
-    });
-
-    return getImageGradientInformationFromUrl('https://test.com/image.png');
+    return getImageGradientInformation(imageFromPixels(pixels, width, height));
   }
 
   describe('black/grayscale images', () => {
-    it('extracts dark gray gradient from mostly black image', async () => {
-      // Pure black pixels (RGB: 0, 0, 0)
-      const pixels = createUniformPixels(20, 20, 20, 100); // 10x10 dark gray
-      const result = await processTestImage(pixels, 10, 10);
+    it('extracts dark gray gradient from mostly black image', () => {
+      const pixels = createUniformPixels(20, 20, 20, 100);
+      const result = processTestImage(pixels, 10, 10);
 
       expect(result.backgroundGradient).not.toBeNull();
-      expect(result.contrastSetting).toBe('dark'); // Dark background = light text
+      expect(result.contrastSetting).toBe('dark');
     });
 
-    it('extracts gray gradient from grayscale image', async () => {
-      // Mix of grays
+    it('extracts gray gradient from grayscale image', () => {
       const pixels = mixPixels(
-        { color: [30, 30, 30], count: 40 }, // Dark gray
-        { color: [80, 80, 80], count: 40 }, // Medium gray
-        { color: [50, 50, 50], count: 20 }, // Mid-dark gray
+        { color: [30, 30, 30], count: 40 },
+        { color: [80, 80, 80], count: 40 },
+        { color: [50, 50, 50], count: 20 },
       );
-      const result = await processTestImage(pixels, 10, 10);
+      const result = processTestImage(pixels, 10, 10);
 
       expect(result.backgroundGradient).not.toBeNull();
     });
   });
 
   describe('cream/off-white images (Rumours album case)', () => {
-    it('extracts subtle cream gradient, NOT bright yellow', async () => {
-      // Cream color: RGB ~255, 253, 240 (very light, slight yellow tint)
-      // In HSL: hue ~45, saturation ~0.1, lightness ~0.97
+    it('extracts subtle cream gradient, NOT bright yellow', () => {
       const pixels = createUniformPixels(255, 253, 240, 100);
-      const result = await processTestImage(pixels, 10, 10);
+      const result = processTestImage(pixels, 10, 10);
 
       expect(result.backgroundGradient).not.toBeNull();
     });
 
-    it('handles mix of black clothing and cream background (like Rumours)', async () => {
-      // Simulating Rumours: ~60% black clothing, ~40% cream background
+    it('handles mix of black clothing and cream background (like Rumours)', () => {
       const pixels = mixPixels(
-        { color: [20, 20, 20], count: 60 }, // Black clothing
-        { color: [255, 250, 235], count: 40 }, // Cream background
+        { color: [20, 20, 20], count: 60 },
+        { color: [255, 250, 235], count: 40 },
       );
-      const result = await processTestImage(pixels, 10, 10);
+      const result = processTestImage(pixels, 10, 10);
 
       expect(result.backgroundGradient).not.toBeNull();
 
-      // Extract saturation values - should be low (not bright yellow)
       const satMatches = [
         ...(result.backgroundGradient?.matchAll(/hsla\([^,]+,\s*([\d.]+)%/g) ?? []),
       ];
       const saturations = satMatches.map((m) => parseFloat(m[1] ?? '0'));
 
-      // All saturations should be under 30% (muted, not vibrant yellow)
       saturations.forEach((sat) => {
         expect(sat).toBeLessThan(30);
       });
@@ -121,44 +96,40 @@ describe('getImageGradient color extraction', () => {
   });
 
   describe('vibrant colored images', () => {
-    it('extracts red from predominantly red image', async () => {
-      // Vibrant red: RGB 220, 50, 50
+    it('extracts red from predominantly red image', () => {
       const pixels = createUniformPixels(220, 50, 50, 100);
-      const result = await processTestImage(pixels, 10, 10);
+      const result = processTestImage(pixels, 10, 10);
 
       expect(result.backgroundGradient).not.toBeNull();
     });
 
-    it('extracts multiple colors from colorful image', async () => {
-      // Mix of vibrant colors
+    it('extracts multiple colors from colorful image', () => {
       const pixels = mixPixels(
-        { color: [220, 50, 50], count: 30 }, // Red
-        { color: [50, 50, 220], count: 30 }, // Blue
-        { color: [50, 180, 50], count: 20 }, // Green
-        { color: [200, 200, 50], count: 20 }, // Yellow
+        { color: [220, 50, 50], count: 30 },
+        { color: [50, 50, 220], count: 30 },
+        { color: [50, 180, 50], count: 20 },
+        { color: [200, 200, 50], count: 20 },
       );
-      const result = await processTestImage(pixels, 10, 10);
+      const result = processTestImage(pixels, 10, 10);
 
       expect(result.backgroundGradient).not.toBeNull();
     });
   });
 
   describe('edge cases', () => {
-    it('handles pure white image', async () => {
+    it('handles pure white image', () => {
       const pixels = createUniformPixels(255, 255, 255, 100);
-      const result = await processTestImage(pixels, 10, 10);
+      const result = processTestImage(pixels, 10, 10);
 
       expect(result.backgroundGradient).not.toBeNull();
     });
 
-    it('handles image with slight yellow tint that should NOT become neon', async () => {
-      // RGB 250, 248, 243 is a subtle cream (~30% saturation in HSL)
+    it('handles image with slight yellow tint that should NOT become neon', () => {
       const pixels = createUniformPixels(250, 248, 243, 100);
-      const result = await processTestImage(pixels, 10, 10);
+      const result = processTestImage(pixels, 10, 10);
 
       expect(result.backgroundGradient).not.toBeNull();
 
-      // Extract all saturation percentages - should stay low
       const satMatches = [
         ...(result.backgroundGradient?.matchAll(/hsla\([^,]+,\s*([\d.]+)%/g) ?? []),
       ];
@@ -169,21 +140,66 @@ describe('getImageGradient color extraction', () => {
       });
     });
 
-    it('chroma scoring prefers mid-tone vibrant colors over light colors when mixed', async () => {
-      // When vibrant red competes with cream, red should dominate
+    it('chroma scoring prefers mid-tone vibrant colors over light colors when mixed', () => {
       const pixels = mixPixels(
-        { color: [220, 50, 50], count: 40 }, // Vibrant red (mid-tone)
-        { color: [255, 250, 235], count: 60 }, // Cream (high lightness)
+        { color: [220, 50, 50], count: 40 },
+        { color: [255, 250, 235], count: 60 },
       );
-      const result = await processTestImage(pixels, 10, 10);
+      const result = processTestImage(pixels, 10, 10);
 
-      // Extract first (most prominent) color's hue - should be red (~0°), not yellow (~45°)
       const hueMatch = result.backgroundGradient?.match(/hsla\(([\d.]+),/);
       const hue = hueMatch?.[1] ? parseFloat(hueMatch[1]) : -1;
 
-      // Hue should be in red range (0-30° or 330-360°), not yellow range (40-60°)
       const isRed = hue < 30 || hue > 330;
       expect(isRed).toBe(true);
+    });
+  });
+});
+
+describe('getImageGradientInformationFromUrl', () => {
+  const fetchMock = jest.spyOn(global, 'fetch');
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+  });
+
+  afterAll(() => {
+    fetchMock.mockRestore();
+  });
+
+  it('extracts a gradient from JPEG bytes', async () => {
+    const image = imageFromPixels(createUniformPixels(220, 50, 50, 64), 8, 8);
+    const jpeg = encode(image, 90);
+    fetchMock.mockResolvedValueOnce(
+      new Response(Uint8Array.from(jpeg.data).buffer, { status: 200 }),
+    );
+
+    const result = await getImageGradientInformationFromUrl('https://test.com/image.jpg');
+
+    expect(result.backgroundGradient).not.toBeNull();
+  });
+
+  it('returns null gradient information for a non-ok response', async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 404 }));
+
+    const result = await getImageGradientInformationFromUrl('https://test.com/missing.jpg');
+
+    expect(result).toEqual({
+      backgroundGradient: null,
+      contrastSetting: null,
+    });
+  });
+
+  it('returns null gradient information for non-JPEG bytes', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(Uint8Array.from([0, 1, 2, 3]).buffer, { status: 200 }),
+    );
+
+    const result = await getImageGradientInformationFromUrl('https://test.com/not-an-image.jpg');
+
+    expect(result).toEqual({
+      backgroundGradient: null,
+      contrastSetting: null,
     });
   });
 });

--- a/packages/services/images/getImageGradient.ts
+++ b/packages/services/images/getImageGradient.ts
@@ -2,9 +2,16 @@ import 'server-only';
 
 import { invariant } from '@dg/shared-core/assertions/invariant';
 import { log } from '@dg/shared-core/logging/log';
-import sharp, { type Stats } from 'sharp';
+import { decode } from 'jpeg-js';
 
 import { type Hsl, rgbToHsl } from './colorConversion';
+
+export type RgbaImage = {
+  /** Row-major RGBA bytes, four per pixel */
+  data: Uint8Array;
+  height: number;
+  width: number;
+};
 
 type Hsla = Hsl & {
   /** Alpha, 0-1 */
@@ -42,8 +49,6 @@ const OPTIONS = {
   lightnessMax: 0.5,
   /** Lightness clamp range for final gradient colors */
   lightnessMin: 0.2,
-  /** Size of downsampled image for color extraction */
-  sampleSize: 40,
 } as const;
 
 const clamp = (value: number, min: number, max: number) => Math.max(min, Math.min(max, value));
@@ -146,11 +151,11 @@ function contrastSettingForGradient(colors: FourItemHsla): ContrastSetting {
 }
 
 /**
- * Downsample, bucket by hue AND lightness, and keep the most vibrant colors.
+ * Bucket by hue AND lightness, and keep the most vibrant colors.
  * Bucketing by both dimensions allows images that are predominantly one hue
  * (e.g., mostly red) to yield multiple shades of that hue.
  */
-async function getVibrantColors(buffer: Buffer): Promise<Array<Hsl>> {
+function getVibrantColors(image: RgbaImage): Array<Hsl> {
   const {
     hueBucketSize,
     lightnessBands,
@@ -158,27 +163,19 @@ async function getVibrantColors(buffer: Buffer): Promise<Array<Hsl>> {
     lightnessMin,
     extractionLightnessMultiplier,
     extractionLightnessBuffer,
-    sampleSize,
   } = OPTIONS;
-
-  // Smaller image for performance
-  const { data, info } = await sharp(buffer)
-    .resize(sampleSize, sampleSize, { fit: 'inside' })
-    .raw()
-    .toBuffer({ resolveWithObject: true });
-  const hasAlpha = info.channels === 4;
-  invariant(info.channels >= 3, 'Not an image buffer!');
 
   // Bucket colors by hue AND lightness - allows multiple shades of the same hue
   const buckets = new Map<string, { count: number; hSum: number; sSum: number; lSum: number }>();
+  const pixelDataLength = image.width * image.height * 4;
 
-  for (let index = 0; index < data.length; index += info.channels) {
-    const r = data[index] ?? 0;
-    const g = data[index + 1] ?? 0;
-    const b = data[index + 2] ?? 0;
+  for (let index = 0; index < pixelDataLength; index += 4) {
+    const r = image.data[index] ?? 0;
+    const g = image.data[index + 1] ?? 0;
+    const b = image.data[index + 2] ?? 0;
 
     // Skip transparent colors
-    const alpha = hasAlpha ? (data[index + 3] ?? 0) : 255;
+    const alpha = image.data[index + 3] ?? 0;
     if (alpha < 10) {
       continue;
     }
@@ -231,57 +228,91 @@ async function getVibrantColors(buffer: Buffer): Promise<Array<Hsl>> {
     .map(({ color }) => color);
 }
 
-/**
- * Gets dominant color from sharp stats and converts to HSL
- */
-function getDominantHsl(stats: Stats): Hsl | null {
-  if (stats.dominant && typeof stats.dominant.r === 'number') {
-    return rgbToHsl({
-      b: stats.dominant.b,
-      g: stats.dominant.g,
-      r: stats.dominant.r,
-    });
-  }
-  return null;
-}
+type HistogramBin = {
+  bSum: number;
+  count: number;
+  gSum: number;
+  rSum: number;
+};
 
 /**
- * Gets mean color from sharp stats and converts to HSL
+ * Most populous bin of a 16x16x16 RGB histogram, averaged over the pixels in it.
  */
-function getMeanHsl(stats: Stats): Hsl {
-  const [rChannel, gChannel, bChannel] = stats.channels;
-  invariant(rChannel && gChannel && bChannel, 'Malformed image');
+function getDominantHsl(image: RgbaImage): Hsl {
+  const histogram = new Map<number, HistogramBin>();
+  const pixelDataLength = image.width * image.height * 4;
+
+  for (let index = 0; index < pixelDataLength; index += 4) {
+    const r = image.data[index] ?? 0;
+    const g = image.data[index + 1] ?? 0;
+    const b = image.data[index + 2] ?? 0;
+    const binKey = (r >> 4) * 256 + (g >> 4) * 16 + (b >> 4);
+    const bin = histogram.get(binKey);
+
+    if (bin) {
+      bin.bSum += b;
+      bin.count += 1;
+      bin.gSum += g;
+      bin.rSum += r;
+    } else {
+      histogram.set(binKey, {
+        bSum: b,
+        count: 1,
+        gSum: g,
+        rSum: r,
+      });
+    }
+  }
+
+  let dominantBin: HistogramBin | null = null;
+  for (const bin of histogram.values()) {
+    if (!dominantBin || bin.count > dominantBin.count) {
+      dominantBin = bin;
+    }
+  }
+  invariant(dominantBin, 'Image has no pixels');
+
   return rgbToHsl({
-    b: Math.round(bChannel.mean),
-    g: Math.round(gChannel.mean),
-    r: Math.round(rChannel.mean),
+    b: dominantBin.bSum / dominantBin.count,
+    g: dominantBin.gSum / dominantBin.count,
+    r: dominantBin.rSum / dominantBin.count,
   });
 }
 
 /**
- * Returns an up-to-4-color radial gradient from the processed image URL, and indicator boolean for
+ * Returns an up-to-4-color radial gradient from decoded pixels, and an indicator for the
  * recommended text color when used on top of the gradient.
+ */
+export function getImageGradientInformation(image: RgbaImage): ImageGradientInformation {
+  invariant(
+    image.width > 0 && image.height > 0 && image.data.length >= image.width * image.height * 4,
+    'Malformed image',
+  );
+
+  const colors = ensureQuadColorArray(getVibrantColors(image), getDominantHsl(image));
+  return {
+    backgroundGradient: buildRadialGradient(colors),
+    contrastSetting: contrastSettingForGradient(colors),
+  };
+}
+
+/**
+ * Fetches a JPEG and returns its gradient information. Decoding is capped well above album art
+ * (640x640 is 0.41MP) so a hostile response can't exhaust the function's memory.
  */
 export async function getImageGradientInformationFromUrl(
   url: string,
 ): Promise<ImageGradientInformation> {
   try {
-    // Fetch image, convert to buffer + stats
     const imageResponse = await fetch(url);
     invariant(imageResponse.ok, `Couldn't fetch image: ${imageResponse.status}`);
-    const buffer = Buffer.from(await imageResponse.arrayBuffer());
-    const stats = await sharp(buffer).stats();
-
-    // Get vibrant colors in HSL
-    const vibrantColors = await getVibrantColors(buffer);
-    const fallbackColor = getDominantHsl(stats) ?? getMeanHsl(stats);
-
-    // Get a 4 color radial stack, potentially falling back to the dominant color
-    const colors = ensureQuadColorArray(vibrantColors, fallbackColor);
-    return {
-      backgroundGradient: buildRadialGradient(colors),
-      contrastSetting: contrastSettingForGradient(colors),
-    };
+    const bytes = new Uint8Array(await imageResponse.arrayBuffer());
+    const decoded = decode(bytes, {
+      maxMemoryUsageInMB: 64,
+      maxResolutionInMP: 1,
+      useTArray: true,
+    });
+    return getImageGradientInformation(decoded);
   } catch (error) {
     log.warn("Couldn't get image gradient", {
       error,

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -4,8 +4,8 @@
     "@dg/db": "workspace:*",
     "@dg/shared-core": "workspace:*",
     "graphql-request": "catalog:",
+    "jpeg-js": "catalog:",
     "server-only": "catalog:",
-    "sharp": "catalog:",
     "valibot": "catalog:",
     "wretch": "catalog:"
   },

--- a/packages/services/spotify/fetchRecentlyPlayed.ts
+++ b/packages/services/spotify/fetchRecentlyPlayed.ts
@@ -77,11 +77,22 @@ async function fetchLastPlayed(): Promise<null | Track> {
 }
 
 /**
+ * Color bucketing doesn't need the 640px art the card displays, and Spotify's 64px variant
+ * decodes roughly forty times faster while still giving more samples than the buckets use.
+ */
+function getGradientImageUrl(track: Track): string {
+  const smallestImage = track.album.images
+    .filter((image) => image.width >= 64)
+    .sort((a, b) => a.width - b.width)[0];
+  return smallestImage?.url ?? track.albumImage.url;
+}
+
+/**
  * Augments the response with gradient information for the track
  */
 async function withAlbumGradientInfo(track: Track): Promise<Track> {
   const { backgroundGradient, contrastSetting } = await getImageGradientInformationFromUrl(
-    track.albumImage.url,
+    getGradientImageUrl(track),
   );
   return {
     ...track,

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -12,8 +12,7 @@
     "@mui/utils": "catalog:",
     "lucide-react": "catalog:",
     "next": "catalog:",
-    "react": "catalog:",
-    "sharp": "catalog:"
+    "react": "catalog:"
   },
   "devDependencies": {
     "@dg/testing": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ catalogs:
     jest-environment-jsdom:
       specifier: 30.4.1
       version: 30.4.1
+    jpeg-js:
+      specifier: 0.4.4
+      version: 0.4.4
     lucide-react:
       specifier: 1.25.0
       version: 1.25.0
@@ -75,9 +78,6 @@ catalogs:
     server-only:
       specifier: 0.0.1
       version: 0.0.1
-    sharp:
-      specifier: 0.35.3
-      version: 0.35.3
     tsx:
       specifier: 4.23.1
       version: 4.23.1
@@ -450,12 +450,12 @@ importers:
       graphql-request:
         specifier: 'catalog:'
         version: 7.4.0(graphql@16.14.2)
+      jpeg-js:
+        specifier: 'catalog:'
+        version: 0.4.4
       server-only:
         specifier: 'catalog:'
         version: 0.0.1
-      sharp:
-        specifier: 'catalog:'
-        version: 0.35.3(@types/node@26.1.1)
       valibot:
         specifier: 'catalog:'
         version: 1.4.2(@typescript/typescript6@6.0.2)
@@ -598,9 +598,6 @@ importers:
       react:
         specifier: 'catalog:'
         version: 19.2.7
-      sharp:
-        specifier: 'catalog:'
-        version: 0.35.3(@types/node@26.1.1)
     devDependencies:
       '@dg/testing':
         specifier: workspace:*
@@ -1334,36 +1331,14 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-darwin-arm64@0.35.3':
-    resolution: {integrity: sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==}
-    engines: {node: '>=20.9.0'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@img/sharp-darwin-x64@0.34.5':
     resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-darwin-x64@0.35.3':
-    resolution: {integrity: sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==}
-    engines: {node: '>=20.9.0'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@img/sharp-freebsd-wasm32@0.35.3':
-    resolution: {integrity: sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==}
-    engines: {node: '>=20.9.0'}
-    os: [freebsd]
-
   '@img/sharp-libvips-darwin-arm64@1.2.4':
     resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@img/sharp-libvips-darwin-arm64@1.3.2':
-    resolution: {integrity: sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==}
     cpu: [arm64]
     os: [darwin]
 
@@ -1372,19 +1347,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-x64@1.3.2':
-    resolution: {integrity: sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==}
-    cpu: [x64]
-    os: [darwin]
-
   '@img/sharp-libvips-linux-arm64@1.2.4':
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linux-arm64@1.3.2':
-    resolution: {integrity: sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -1395,20 +1359,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-arm@1.3.2':
-    resolution: {integrity: sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==}
-    cpu: [arm]
-    os: [linux]
-    libc: [glibc]
-
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linux-ppc64@1.3.2':
-    resolution: {integrity: sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
@@ -1419,20 +1371,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-riscv64@1.3.2':
-    resolution: {integrity: sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linux-s390x@1.3.2':
-    resolution: {integrity: sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
@@ -1443,32 +1383,14 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-x64@1.3.2':
-    resolution: {integrity: sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
-    resolution: {integrity: sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@img/sharp-libvips-linuxmusl-x64@1.3.2':
-    resolution: {integrity: sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
@@ -1480,23 +1402,9 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-arm64@0.35.3':
-    resolution: {integrity: sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==}
-    engines: {node: '>=20.9.0'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linux-arm@0.35.3':
-    resolution: {integrity: sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==}
-    engines: {node: '>=20.9.0'}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
@@ -1508,23 +1416,9 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-ppc64@0.35.3':
-    resolution: {integrity: sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==}
-    engines: {node: '>=20.9.0'}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linux-riscv64@0.35.3':
-    resolution: {integrity: sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==}
-    engines: {node: '>=20.9.0'}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
@@ -1536,23 +1430,9 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-s390x@0.35.3':
-    resolution: {integrity: sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==}
-    engines: {node: '>=20.9.0'}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linux-x64@0.35.3':
-    resolution: {integrity: sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==}
-    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -1564,23 +1444,9 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-linuxmusl-arm64@0.35.3':
-    resolution: {integrity: sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==}
-    engines: {node: '>=20.9.0'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@img/sharp-linuxmusl-x64@0.35.3':
-    resolution: {integrity: sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==}
-    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
@@ -1590,24 +1456,9 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [wasm32]
 
-  '@img/sharp-wasm32@0.35.3':
-    resolution: {integrity: sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==}
-    engines: {node: '>=20.9.0'}
-
-  '@img/sharp-webcontainers-wasm32@0.35.3':
-    resolution: {integrity: sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==}
-    engines: {node: '>=20.9.0'}
-    cpu: [wasm32]
-
   '@img/sharp-win32-arm64@0.34.5':
     resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [win32]
-
-  '@img/sharp-win32-arm64@0.35.3':
-    resolution: {integrity: sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==}
-    engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [win32]
 
@@ -1617,21 +1468,9 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@img/sharp-win32-ia32@0.35.3':
-    resolution: {integrity: sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==}
-    engines: {node: ^20.9.0}
-    cpu: [ia32]
-    os: [win32]
-
   '@img/sharp-win32-x64@0.34.5':
     resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [win32]
-
-  '@img/sharp-win32-x64@0.35.3':
-    resolution: {integrity: sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==}
-    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [win32]
 
@@ -3498,6 +3337,9 @@ packages:
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
+  jpeg-js@0.4.4:
+    resolution: {integrity: sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==}
+
   js-beautify@1.15.4:
     resolution: {integrity: sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==}
     engines: {node: '>=14'}
@@ -4109,15 +3951,6 @@ packages:
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-
-  sharp@0.35.3:
-    resolution: {integrity: sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==}
-    engines: {node: '>=20.9.0'}
-    peerDependencies:
-      '@types/node': '*'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -5187,16 +5020,12 @@ snapshots:
     dependencies:
       graphql: 16.14.2
 
-  '@img/colour@1.1.0': {}
+  '@img/colour@1.1.0':
+    optional: true
 
   '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-darwin-arm64': 1.2.4
-    optional: true
-
-  '@img/sharp-darwin-arm64@0.35.3':
-    optionalDependencies:
-      '@img/sharp-libvips-darwin-arm64': 1.3.2
     optional: true
 
   '@img/sharp-darwin-x64@0.34.5':
@@ -5204,74 +5033,34 @@ snapshots:
       '@img/sharp-libvips-darwin-x64': 1.2.4
     optional: true
 
-  '@img/sharp-darwin-x64@0.35.3':
-    optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.3.2
-    optional: true
-
-  '@img/sharp-freebsd-wasm32@0.35.3':
-    dependencies:
-      '@img/sharp-wasm32': 0.35.3
-    optional: true
-
   '@img/sharp-libvips-darwin-arm64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-darwin-arm64@1.3.2':
     optional: true
 
   '@img/sharp-libvips-darwin-x64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-darwin-x64@1.3.2':
-    optional: true
-
   '@img/sharp-libvips-linux-arm64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-arm64@1.3.2':
     optional: true
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-arm@1.3.2':
-    optional: true
-
   '@img/sharp-libvips-linux-ppc64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-ppc64@1.3.2':
     optional: true
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-riscv64@1.3.2':
-    optional: true
-
   '@img/sharp-libvips-linux-s390x@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-s390x@1.3.2':
     optional: true
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-x64@1.3.2':
-    optional: true
-
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
-    optional: true
-
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linuxmusl-x64@1.3.2':
     optional: true
 
   '@img/sharp-linux-arm64@0.34.5':
@@ -5279,19 +5068,9 @@ snapshots:
       '@img/sharp-libvips-linux-arm64': 1.2.4
     optional: true
 
-  '@img/sharp-linux-arm64@0.35.3':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-arm64': 1.3.2
-    optional: true
-
   '@img/sharp-linux-arm@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-arm': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-arm@0.35.3':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.3.2
     optional: true
 
   '@img/sharp-linux-ppc64@0.34.5':
@@ -5299,19 +5078,9 @@ snapshots:
       '@img/sharp-libvips-linux-ppc64': 1.2.4
     optional: true
 
-  '@img/sharp-linux-ppc64@0.35.3':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-ppc64': 1.3.2
-    optional: true
-
   '@img/sharp-linux-riscv64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-riscv64': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-riscv64@0.35.3':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-riscv64': 1.3.2
     optional: true
 
   '@img/sharp-linux-s390x@0.34.5':
@@ -5319,19 +5088,9 @@ snapshots:
       '@img/sharp-libvips-linux-s390x': 1.2.4
     optional: true
 
-  '@img/sharp-linux-s390x@0.35.3':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-s390x': 1.3.2
-    optional: true
-
   '@img/sharp-linux-x64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-x64': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-x64@0.35.3':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.3.2
     optional: true
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
@@ -5339,19 +5098,9 @@ snapshots:
       '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
     optional: true
 
-  '@img/sharp-linuxmusl-arm64@0.35.3':
-    optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
-    optional: true
-
   '@img/sharp-linuxmusl-x64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linuxmusl-x64': 1.2.4
-    optional: true
-
-  '@img/sharp-linuxmusl-x64@0.35.3':
-    optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
     optional: true
 
   '@img/sharp-wasm32@0.34.5':
@@ -5359,32 +5108,13 @@ snapshots:
       '@emnapi/runtime': 1.11.2
     optional: true
 
-  '@img/sharp-wasm32@0.35.3':
-    dependencies:
-      '@emnapi/runtime': 1.11.2
-    optional: true
-
-  '@img/sharp-webcontainers-wasm32@0.35.3':
-    dependencies:
-      '@img/sharp-wasm32': 0.35.3
-    optional: true
-
   '@img/sharp-win32-arm64@0.34.5':
-    optional: true
-
-  '@img/sharp-win32-arm64@0.35.3':
     optional: true
 
   '@img/sharp-win32-ia32@0.34.5':
     optional: true
 
-  '@img/sharp-win32-ia32@0.35.3':
-    optional: true
-
   '@img/sharp-win32-x64@0.34.5':
-    optional: true
-
-  '@img/sharp-win32-x64@0.35.3':
     optional: true
 
   '@isaacs/balanced-match@4.0.1': {}
@@ -6585,7 +6315,8 @@ snapshots:
 
   dequal@2.0.3: {}
 
-  detect-libc@2.1.2: {}
+  detect-libc@2.1.2:
+    optional: true
 
   detect-newline@3.1.0: {}
 
@@ -7316,6 +7047,8 @@ snapshots:
 
   jose@6.2.3: {}
 
+  jpeg-js@0.4.4: {}
+
   js-beautify@1.15.4:
     dependencies:
       config-chain: 1.1.13
@@ -7918,39 +7651,6 @@ snapshots:
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
     optional: true
-
-  sharp@0.35.3(@types/node@26.1.1):
-    dependencies:
-      '@img/colour': 1.1.0
-      detect-libc: 2.1.2
-      semver: 7.8.5
-    optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.35.3
-      '@img/sharp-darwin-x64': 0.35.3
-      '@img/sharp-freebsd-wasm32': 0.35.3
-      '@img/sharp-libvips-darwin-arm64': 1.3.2
-      '@img/sharp-libvips-darwin-x64': 1.3.2
-      '@img/sharp-libvips-linux-arm': 1.3.2
-      '@img/sharp-libvips-linux-arm64': 1.3.2
-      '@img/sharp-libvips-linux-ppc64': 1.3.2
-      '@img/sharp-libvips-linux-riscv64': 1.3.2
-      '@img/sharp-libvips-linux-s390x': 1.3.2
-      '@img/sharp-libvips-linux-x64': 1.3.2
-      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
-      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
-      '@img/sharp-linux-arm': 0.35.3
-      '@img/sharp-linux-arm64': 0.35.3
-      '@img/sharp-linux-ppc64': 0.35.3
-      '@img/sharp-linux-riscv64': 0.35.3
-      '@img/sharp-linux-s390x': 0.35.3
-      '@img/sharp-linux-x64': 0.35.3
-      '@img/sharp-linuxmusl-arm64': 0.35.3
-      '@img/sharp-linuxmusl-x64': 0.35.3
-      '@img/sharp-webcontainers-wasm32': 0.35.3
-      '@img/sharp-win32-arm64': 0.35.3
-      '@img/sharp-win32-ia32': 0.35.3
-      '@img/sharp-win32-x64': 0.35.3
-      '@types/node': 26.1.1
 
   shebang-command@2.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -45,11 +45,11 @@ catalog:
   graphql-request: 7.4.0
   jest: 30.4.2
   jest-environment-jsdom: 30.4.1
+  jpeg-js: 0.4.4
   lucide-react: 1.25.0
   next: 16.2.10
   react: 19.2.7
   server-only: 0.0.1
-  sharp: 0.35.3
   tsx: 4.23.1
   typescript: npm:@typescript/typescript6@6.0.2
   valibot: 1.4.2

--- a/scripts/checkRouteTraces.mjs
+++ b/scripts/checkRouteTraces.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+
+/**
+ * Fails when a built route bundle traces a native addon.
+ *
+ * Vercel prunes each function to the files `@vercel/nft` traced, and nft cannot
+ * read an addon's ELF `DT_NEEDED` entries, so a `.node` file usually arrives
+ * without the shared libraries it dlopens and the route 500s at runtime. Run
+ * this against a production build:
+ *
+ *   pnpm --filter @dg/web exec next build --turbopack
+ *   node scripts/checkRouteTraces.mjs
+ */
+
+import { glob, readFile } from 'node:fs/promises';
+import { dirname, join, relative, resolve } from 'node:path';
+
+const appDir = resolve(process.argv[2] ?? 'apps/web');
+const serverDir = join(appDir, '.next/server');
+const appRouteDir = join(serverDir, 'app');
+
+const routeName = (traceFile) => {
+  const rel = relative(appRouteDir, traceFile).replace(/\.js\.nft\.json$/, '');
+  if (rel.startsWith('..')) {
+    return relative(serverDir, traceFile).replace(/\.js\.nft\.json$/, '');
+  }
+  return `/${rel.replace(/(^|\/)(page|route)$/, '')}`.replace(/\/$/, '') || '/';
+};
+
+const traces = [];
+for await (const traceFile of glob(`${serverDir}/**/*.nft.json`)) {
+  const { files } = JSON.parse(await readFile(traceFile, 'utf8'));
+  traces.push({
+    addons: files
+      .map((entry) => relative(appDir, resolve(dirname(traceFile), entry)))
+      .filter((entry) => entry.endsWith('.node')),
+    route: routeName(traceFile),
+  });
+}
+
+if (traces.length === 0) {
+  console.error(`No route traces under ${serverDir}. Build first.`);
+  process.exit(1);
+}
+
+const offenders = traces.filter(({ addons }) => addons.length > 0);
+for (const { route, addons } of offenders.sort((a, b) => a.route.localeCompare(b.route))) {
+  console.log(`${route}`);
+  for (const addon of addons) {
+    console.log(`  ${addon}`);
+  }
+}
+
+console.log(
+  offenders.length === 0
+    ? `ok: none of ${traces.length} route traces reference a native addon`
+    : `fail: ${offenders.length} of ${traces.length} route traces reference a native addon`,
+);
+process.exit(offenders.length === 0 ? 0 : 1);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# What changed?

Supersedes #557, which fixed this by shipping libvips into the function bundle. Dylan's call was right. The interesting question is why we were pulling a native library in at all.

Answer: one decorative gradient. `getImageGradient.ts` used sharp to downsample album art and read its channel stats, `fetchRecentlyPlayed` called it, and `Header` renders the latest song from the root layout. So sharp sat in the module graph of `/` and every other page, and Vercel's tracer shipped its `.node` addon without the `libvips-cpp.so` that addon dlopens. First request to a cold function, `ERR_DLOPEN_FAILED`, dead stream.

This drops sharp. `jpeg-js` decodes the art in pure JavaScript, and the color math it already had runs over the decoded pixels. Nothing native is left to trace.

## Why not precompute the gradient during the Spotify sync

That was the first plan and it does not work. I wired `getImageGradientInformationFromUrl` into `/api/spotify/sync`, rebuilt, and read that route's trace:

```
sync route traced files: 790
.node addons: ['@img/sharp-linux-x64@0.35.3/lib/sharp-linux-x64-0.35.3.node']
libvips .so: []
```

Same broken artifact, different route. Moving the call moves the crash from `/` to the cron and leaves every gradient null forever. The tracer's blind spot has nothing to do with which function does the work.

Persisting the result had a second problem anyway. The cron writes `SpotifyPlay` rows only. `MusicAlbum` rows appear lazily on the `/music` read path, so the album playing right now often has no row to read a cached gradient from, and the cron runs every 30 minutes.

## What the code does now

Extraction reads Spotify's 64px art instead of downsampling the 640px art. That is 4096 samples where the old sharp resize gave 1600, and it decodes in about 0.5ms against sharp's 1.7ms on the same image. The 640px art still renders in the card.

`getImageGradientInformation(image)` is the pure half and takes decoded RGBA. `getImageGradientInformationFromUrl(url)` is the boundary: fetch, decode, delegate. jpeg-js gets a 1MP / 64MB ceiling so a hostile response cannot exhaust the function, and the existing try/catch still turns any failure into no gradient.

sharp's `stats()` had supplied the fallback color for images with no vibrant buckets. A 16x16x16 histogram over the decoded pixels gives the same dominant color. That made the mean-color second fallback unreachable, so it is gone.

`packages/ui` declared sharp and never imported it. Gone too.

## Verification

`scripts/checkRouteTraces.mjs` reads every `.nft.json` a build emits and fails when a route traces a `.node` addon. It is the first commit here because it is red on `main`:

```
$ node scripts/checkRouteTraces.mjs
/
  @img/sharp-linux-x64@0.35.3/lib/sharp-linux-x64-0.35.3.node
/_not-found
/dev-console
/music
/music/albums
fail: 5 of 15 route traces reference a native addon
```

Green on this branch:

```
$ node scripts/checkRouteTraces.mjs
ok: none of 15 route traces reference a native addon
```

The homepage function's trace has zero entries matching `sharp` or `libvips`, down from 41. The decoder is not a traced file at all because Turbopack bundles it straight into the SSR chunk the function loads, which is the whole point: plain JavaScript gets bundled, native addons cannot be.

### Gradients still work

Built with `NOW_BUILDER=1`, served with `next start`, and asked a temporary route (not committed) for real Spotify art on linux-x64:

```
$ curl 'localhost:3000/api/gradient-probe?url=.../ab67616d00004851...519a7'
{"backgroundGradient":"radial-gradient(circle at top right, hsla(55.7, 9.1%, 50.0%, 0.85) 0%, ...",
 "contrastSetting":"dark","ms":129}

igor 64px  ms=34 contrast=dark first=radial-gradient(circle at top right, hsla(341.5, 26.1%, 50.0%,
igor 64px  ms=34 contrast=dark ...
missing art -> {"backgroundGradient":null,"contrastSetting":null}
```

No `ERR_DLOPEN_FAILED`. The 34ms is nearly all CDN fetch.

Against six real albums, the new gradients land within 2.6 degrees of hue and 1.5 points of saturation of what sharp produced, with identical lightness clamps and identical contrast settings. A 404 degrades the same way in both:

![Six albums, sharp gradient beside pure JS gradient, visually identical](https://cursor.com/artifacts/c/art-0ed0b95e-c8ef-429d-9de4-45b2b28f8828)

`turbo check:ci check:types test` passes 27/27 tasks locally, 145 tests in `@dg/services` and 84 in `@dg/web`. The gradient tests now feed raw pixels to the pure function instead of round-tripping fixtures through sharp, and three new cases cover the fetch boundary.

## Notes for review

- The trace check is a standalone script, not wired into `turbo build`. Wiring it in is a reasonable follow-up if you want it gated.
- Local builds used `--experimental-build-mode compile` because I have no Contentful credentials. Tracing happens in the compile phase, so the `.nft.json` output is the same either way, and the Vercel preview build of the full thing passed.
- `next` keeps its own optional sharp for local image optimization. Vercel optimizes images on the platform, so nothing in our functions needs it.
- GitHub Actions ran CI on `f87796c` and passed. It did not pick up the last commit, which only restores comments in the test file, so that one is covered by the local run above rather than by a CI run.

# Release info

- [ ] Major
- [ ] Minor
- [x] Patch
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a9b19be6-f060-4f11-b0e7-11c9a7e1f8c5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9b19be6-f060-4f11-b0e7-11c9a7e1f8c5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

