### PR TITLE
Open favorite albums as a sheet from a footer music menu

### DIFF
--- a/apps/web/src/app/layouts/Footer.tsx
+++ b/apps/web/src/app/layouts/Footer.tsx
@@ -11,7 +11,8 @@ import { Suspense } from 'react';
 import { interactiveRedesign } from '../../flags';
 import { getFooterLinks } from '../../services/contentful';
 import { getAppVersionInfo } from '../../services/version';
-import { isFavoriteAlbumsFooterUrl, MusicFooterMenu } from './MusicFooterMenu';
+import { MusicFooterMenu } from './MusicFooterMenu';
+import { isFavoriteAlbumsFooterUrl } from './musicFooterDestinations';
 
 const navItemNoPaddingSx: SxObject = {
   padding: 0,

--- a/apps/web/src/app/layouts/Footer.tsx
+++ b/apps/web/src/app/layouts/Footer.tsx
@@ -1,8 +1,7 @@
 import type { RenderableLink } from '@dg/content-models/contentful/renderables/links';
-import { devConsoleRoute, musicRoute } from '@dg/shared-core/routes/app';
+import { devConsoleRoute } from '@dg/shared-core/routes/app';
 import { Nav, NavGroup, NavItem } from '@dg/ui/core/Nav';
 import { Section } from '@dg/ui/core/Section';
-import { SheetOpenLink } from '@dg/ui/core/sheet/SheetOpenLink';
 import { SITE_FOOTER_VIEW_TRANSITION_NAME } from '@dg/ui/core/sheet/sheetTransitions';
 import { Link } from '@dg/ui/dependent/Link';
 import type { SxObject } from '@dg/ui/theme';
@@ -12,6 +11,7 @@ import { Suspense } from 'react';
 import { interactiveRedesign } from '../../flags';
 import { getFooterLinks } from '../../services/contentful';
 import { getAppVersionInfo } from '../../services/version';
+import { isFavoriteAlbumsFooterUrl, MusicFooterMenu } from './MusicFooterMenu';
 
 const navItemNoPaddingSx: SxObject = {
   padding: 0,
@@ -163,18 +163,6 @@ export async function Footer() {
                   </NavItem>
                 </>
               ) : null}
-              <NavItem sx={navItemNoPaddingSx}>•</NavItem>
-              <NavItem>
-                <SheetOpenLink
-                  color="inherit"
-                  href={musicRoute}
-                  morphsTitle
-                  title="Listening history"
-                  variant="caption"
-                >
-                  Listening history
-                </SheetOpenLink>
-              </NavItem>
               <Suspense fallback={null}>
                 <RedesignBadge />
               </Suspense>
@@ -203,9 +191,13 @@ export async function Footer() {
                 ))}
               </Stack>
               <Stack component="ul" direction="row" sx={footerIconLinkListSx}>
-                {iconFooterLinks?.map((link) => (
-                  <FooterLink key={link.url} link={link} />
-                ))}
+                {iconFooterLinks?.map((link) =>
+                  isFavoriteAlbumsFooterUrl(link.url) ? (
+                    <MusicFooterMenu icon={link.icon} key={link.url} title={link.title} />
+                  ) : (
+                    <FooterLink key={link.url} link={link} />
+                  ),
+                )}
               </Stack>
             </NavGroup>
           </Nav>

--- a/apps/web/src/app/layouts/MusicFooterMenu.tsx
+++ b/apps/web/src/app/layouts/MusicFooterMenu.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import { favoriteAlbumsRoute, musicRoute } from '@dg/shared-core/routes/app';
+import { NavItem } from '@dg/ui/core/Nav';
+import { SheetOpenLink } from '@dg/ui/core/sheet/SheetOpenLink';
+import { sheetTitleMorphName } from '@dg/ui/core/sheet/sheetTransitions';
+import { Tooltip } from '@dg/ui/core/Tooltip';
+import type { SxObject } from '@dg/ui/theme';
+import { IconButton, Menu, MenuItem } from '@mui/material';
+import { Disc3 } from 'lucide-react';
+import { usePathname } from 'next/navigation';
+import type { MouseEvent } from 'react';
+import { useId, useLayoutEffect, useRef, useState } from 'react';
+
+export type MusicDestination = {
+  href: string;
+  label: string;
+};
+
+/** Music sheet destinations opened from the footer vinyl menu. Order is UI order. */
+export const MUSIC_FOOTER_DESTINATIONS: ReadonlyArray<MusicDestination> = [
+  { href: favoriteAlbumsRoute, label: 'Favorite albums' },
+  { href: musicRoute, label: 'Listening history' },
+];
+
+const MUSIC_SHEET_PATHS = new Set(MUSIC_FOOTER_DESTINATIONS.map((destination) => destination.href));
+
+const triggerSx: SxObject = {
+  alignItems: 'center',
+  color: 'secondary.main',
+  display: 'flex',
+  fontSize: '1.25em',
+  justifyContent: 'center',
+  minHeight: 40,
+  minWidth: 40,
+  padding: 0,
+};
+
+const menuLinkSx: SxObject = {
+  color: 'inherit',
+  display: 'block',
+  px: 2,
+  py: 1,
+  textDecoration: 'none',
+  width: '100%',
+};
+
+const menuItemSx: SxObject = {
+  p: 0,
+};
+
+function normalizePath(path: string) {
+  if (path.length > 1 && path.endsWith('/')) {
+    return path.slice(0, -1);
+  }
+  return path;
+}
+
+/** Contentful footer icon whose URL points at favorite albums. */
+export function isFavoriteAlbumsFooterUrl(url: string) {
+  return normalizePath(url) === favoriteAlbumsRoute;
+}
+
+function resolveTriggerIcon(icon?: string | null) {
+  if (icon === 'albums') {
+    return <Disc3 size="1em" />;
+  }
+  if (icon) {
+    // biome-ignore lint/security/noDangerouslySetInnerHtml: Contentful may send inline SVG markup
+    return <span dangerouslySetInnerHTML={{ __html: icon }} />;
+  }
+  return <Disc3 size="1em" />;
+}
+
+type MusicFooterMenuProps = {
+  icon?: string | null;
+  title: string;
+};
+
+/**
+ * Footer vinyl control: opens a small menu of music sheets. The trigger alone
+ * owns the sheet-title view-transition name so menu item links never collide.
+ */
+export function MusicFooterMenu({ icon, title }: MusicFooterMenuProps) {
+  const menuId = useId();
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const pathname = usePathname();
+  const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
+  const sheetIsOpen = MUSIC_SHEET_PATHS.has(normalizePath(pathname));
+
+  useLayoutEffect(() => {
+    if (!triggerRef.current) {
+      return;
+    }
+    triggerRef.current.style.viewTransitionName = sheetTitleMorphName(sheetIsOpen);
+  }, [sheetIsOpen]);
+
+  const handleOpen = (event: MouseEvent<HTMLButtonElement>) => {
+    setMenuAnchor(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setMenuAnchor(null);
+  };
+
+  return (
+    <NavItem sx={{ padding: 0 }}>
+      <Tooltip placement="top" title={title}>
+        <IconButton
+          aria-controls={menuAnchor ? menuId : undefined}
+          aria-expanded={menuAnchor ? 'true' : undefined}
+          aria-haspopup="menu"
+          aria-label={title}
+          onClick={handleOpen}
+          ref={triggerRef}
+          sx={triggerSx}
+        >
+          {resolveTriggerIcon(icon)}
+        </IconButton>
+      </Tooltip>
+      <Menu
+        anchorEl={menuAnchor}
+        anchorOrigin={{ horizontal: 'center', vertical: 'top' }}
+        id={menuId}
+        onClose={handleClose}
+        open={Boolean(menuAnchor)}
+        transformOrigin={{ horizontal: 'center', vertical: 'bottom' }}
+      >
+        {MUSIC_FOOTER_DESTINATIONS.map((destination) => (
+          <MenuItem key={destination.href} onClick={handleClose} sx={menuItemSx}>
+            <SheetOpenLink href={destination.href} sx={menuLinkSx} title={destination.label}>
+              {destination.label}
+            </SheetOpenLink>
+          </MenuItem>
+        ))}
+      </Menu>
+    </NavItem>
+  );
+}

--- a/apps/web/src/app/layouts/MusicFooterMenu.tsx
+++ b/apps/web/src/app/layouts/MusicFooterMenu.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { favoriteAlbumsRoute, musicRoute } from '@dg/shared-core/routes/app';
 import { NavItem } from '@dg/ui/core/Nav';
 import { SheetOpenLink } from '@dg/ui/core/sheet/SheetOpenLink';
 import { sheetTitleMorphName } from '@dg/ui/core/sheet/sheetTransitions';
@@ -11,19 +10,11 @@ import { Disc3 } from 'lucide-react';
 import { usePathname } from 'next/navigation';
 import type { MouseEvent } from 'react';
 import { useId, useLayoutEffect, useRef, useState } from 'react';
-
-export type MusicDestination = {
-  href: string;
-  label: string;
-};
-
-/** Music sheet destinations opened from the footer vinyl menu. Order is UI order. */
-export const MUSIC_FOOTER_DESTINATIONS: ReadonlyArray<MusicDestination> = [
-  { href: favoriteAlbumsRoute, label: 'Favorite albums' },
-  { href: musicRoute, label: 'Listening history' },
-];
-
-const MUSIC_SHEET_PATHS = new Set(MUSIC_FOOTER_DESTINATIONS.map((destination) => destination.href));
+import {
+  MUSIC_FOOTER_DESTINATIONS,
+  MUSIC_SHEET_PATHS,
+  normalizeMusicPath,
+} from './musicFooterDestinations';
 
 const triggerSx: SxObject = {
   alignItems: 'center',
@@ -48,18 +39,6 @@ const menuLinkSx: SxObject = {
 const menuItemSx: SxObject = {
   p: 0,
 };
-
-function normalizePath(path: string) {
-  if (path.length > 1 && path.endsWith('/')) {
-    return path.slice(0, -1);
-  }
-  return path;
-}
-
-/** Contentful footer icon whose URL points at favorite albums. */
-export function isFavoriteAlbumsFooterUrl(url: string) {
-  return normalizePath(url) === favoriteAlbumsRoute;
-}
 
 function resolveTriggerIcon(icon?: string | null) {
   if (icon === 'albums') {
@@ -86,7 +65,7 @@ export function MusicFooterMenu({ icon, title }: MusicFooterMenuProps) {
   const triggerRef = useRef<HTMLButtonElement>(null);
   const pathname = usePathname();
   const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
-  const sheetIsOpen = MUSIC_SHEET_PATHS.has(normalizePath(pathname));
+  const sheetIsOpen = MUSIC_SHEET_PATHS.has(normalizeMusicPath(pathname));
 
   useLayoutEffect(() => {
     if (!triggerRef.current) {

--- a/apps/web/src/app/layouts/__tests__/Footer.test.tsx
+++ b/apps/web/src/app/layouts/__tests__/Footer.test.tsx
@@ -2,7 +2,9 @@
  * @jest-environment jsdom
  */
 
+import { favoriteAlbumsRoute, musicRoute } from '@dg/shared-core/routes/app';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 jest.mock('../../../flags', () => ({
   interactiveRedesign: jest.fn(),
@@ -20,16 +22,34 @@ jest.mock('next/cache', () => ({
   cacheLife: jest.fn(),
 }));
 
+jest.mock('next/navigation', () => ({
+  usePathname: jest.fn(() => '/'),
+}));
+
 jest.mock('@dg/ui/core/sheet/SheetOpenLink', () => ({
-  SheetOpenLink: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  SheetOpenLink: ({
+    children,
+    href,
+    title,
+  }: {
+    children: React.ReactNode;
+    href: string;
+    title: string;
+  }) => (
+    <a href={href} title={title}>
+      {children}
+    </a>
+  ),
 }));
 
 import { interactiveRedesign } from '../../../flags';
+import { getFooterLinks } from '../../../services/contentful';
 import { Footer, RedesignBadge } from '../Footer';
 
 const mockInteractiveRedesign = interactiveRedesign as jest.MockedFunction<
   typeof interactiveRedesign
 >;
+const mockGetFooterLinks = getFooterLinks as jest.MockedFunction<typeof getFooterLinks>;
 
 describe('Footer redesign badge', () => {
   afterEach(() => {
@@ -48,10 +68,42 @@ describe('Footer redesign badge', () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it('renders the footer shell without awaiting the badge', async () => {
+  it('renders the footer shell without a listening-history text link', async () => {
     mockInteractiveRedesign.mockResolvedValue(false);
+    mockGetFooterLinks.mockResolvedValue([]);
     render(await Footer());
     expect(screen.getByText(/Dylan Gattey/)).toBeInTheDocument();
-    expect(screen.getByText('Listening history')).toBeInTheDocument();
+    expect(screen.queryByText('Listening history')).not.toBeInTheDocument();
+  });
+
+  it('turns the favorite-albums icon into the music menu', async () => {
+    const user = userEvent.setup();
+    mockInteractiveRedesign.mockResolvedValue(false);
+    mockGetFooterLinks.mockResolvedValue([
+      { icon: 'albums', title: 'Favorite albums', url: favoriteAlbumsRoute },
+      { icon: 'github', title: 'GitHub', url: 'https://github.com/dgattey' },
+    ]);
+    render(await Footer());
+
+    expect(screen.getByRole('link', { name: 'GitHub' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Favorite albums' }));
+    expect(screen.getByRole('link', { name: 'Favorite albums' })).toHaveAttribute(
+      'href',
+      favoriteAlbumsRoute,
+    );
+    expect(screen.getByRole('link', { name: 'Listening history' })).toHaveAttribute(
+      'href',
+      musicRoute,
+    );
+  });
+
+  it('matches favorite-albums URLs with a trailing slash', async () => {
+    mockInteractiveRedesign.mockResolvedValue(false);
+    mockGetFooterLinks.mockResolvedValue([
+      { icon: 'albums', title: 'Favorite albums', url: `${favoriteAlbumsRoute}/` },
+    ]);
+    render(await Footer());
+    expect(screen.getByRole('button', { name: 'Favorite albums' })).toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/layouts/__tests__/MusicFooterMenu.test.tsx
+++ b/apps/web/src/app/layouts/__tests__/MusicFooterMenu.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { favoriteAlbumsRoute, musicRoute } from '@dg/shared-core/routes/app';
+import {
+  SHEET_TITLE_SLOT_VIEW_TRANSITION_NAME,
+  SHEET_TITLE_VIEW_TRANSITION_NAME,
+} from '@dg/ui/core/sheet/sheetTransitions';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+jest.mock('next/navigation', () => ({
+  usePathname: jest.fn(() => '/'),
+}));
+
+jest.mock('@dg/ui/core/sheet/sheetScrollMemory', () => ({
+  rememberSheetOrigin: jest.fn(),
+}));
+
+import { usePathname } from 'next/navigation';
+import { isFavoriteAlbumsFooterUrl, MusicFooterMenu } from '../MusicFooterMenu';
+
+const mockUsePathname = usePathname as jest.MockedFunction<typeof usePathname>;
+
+describe('MusicFooterMenu', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    mockUsePathname.mockReturnValue('/');
+  });
+
+  it('opens a menu with both music destinations in order', async () => {
+    const user = userEvent.setup();
+    render(<MusicFooterMenu icon="albums" title="Favorite albums" />);
+
+    const trigger = screen.getByRole('button', { name: 'Favorite albums' });
+    expect(trigger).toHaveAttribute('aria-haspopup', 'menu');
+    expect(trigger).not.toHaveAttribute('aria-expanded', 'true');
+
+    await user.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+    const links = screen.getAllByRole('link');
+    expect(links.map((link) => link.getAttribute('href'))).toEqual([
+      favoriteAlbumsRoute,
+      musicRoute,
+    ]);
+    expect(links.map((link) => link.textContent)).toEqual(['Favorite albums', 'Listening history']);
+  });
+
+  it('gives only the trigger the sheet-title name while the menu is open', async () => {
+    const user = userEvent.setup();
+    mockUsePathname.mockReturnValue('/');
+    render(<MusicFooterMenu icon="albums" title="Favorite albums" />);
+
+    const trigger = screen.getByRole('button', { name: 'Favorite albums' });
+    expect(trigger.style.viewTransitionName).toBe(SHEET_TITLE_VIEW_TRANSITION_NAME);
+
+    await user.click(trigger);
+    const menuLinks = screen.getAllByRole('link');
+    expect(menuLinks).toHaveLength(2);
+    for (const link of menuLinks) {
+      expect(link.style.viewTransitionName).toBe('');
+    }
+
+    const named = [trigger, ...menuLinks].filter(
+      (element) => element.style.viewTransitionName === SHEET_TITLE_VIEW_TRANSITION_NAME,
+    );
+    expect(named).toHaveLength(1);
+  });
+
+  it('switches the trigger to the slot name on either music sheet', () => {
+    mockUsePathname.mockReturnValue(musicRoute);
+    const { rerender } = render(<MusicFooterMenu icon="albums" title="Favorite albums" />);
+    expect(screen.getByRole('button', { name: 'Favorite albums' }).style.viewTransitionName).toBe(
+      SHEET_TITLE_SLOT_VIEW_TRANSITION_NAME,
+    );
+
+    mockUsePathname.mockReturnValue(favoriteAlbumsRoute);
+    rerender(<MusicFooterMenu icon="albums" title="Favorite albums" />);
+    expect(screen.getByRole('button', { name: 'Favorite albums' }).style.viewTransitionName).toBe(
+      SHEET_TITLE_SLOT_VIEW_TRANSITION_NAME,
+    );
+  });
+
+  it('recognizes favorite-albums footer URLs with a trailing slash', () => {
+    expect(isFavoriteAlbumsFooterUrl(favoriteAlbumsRoute)).toBe(true);
+    expect(isFavoriteAlbumsFooterUrl(`${favoriteAlbumsRoute}/`)).toBe(true);
+    expect(isFavoriteAlbumsFooterUrl(musicRoute)).toBe(false);
+  });
+});

--- a/apps/web/src/app/layouts/__tests__/MusicFooterMenu.test.tsx
+++ b/apps/web/src/app/layouts/__tests__/MusicFooterMenu.test.tsx
@@ -19,7 +19,8 @@ jest.mock('@dg/ui/core/sheet/sheetScrollMemory', () => ({
 }));
 
 import { usePathname } from 'next/navigation';
-import { isFavoriteAlbumsFooterUrl, MusicFooterMenu } from '../MusicFooterMenu';
+import { MusicFooterMenu } from '../MusicFooterMenu';
+import { isFavoriteAlbumsFooterUrl } from '../musicFooterDestinations';
 
 const mockUsePathname = usePathname as jest.MockedFunction<typeof usePathname>;
 

--- a/apps/web/src/app/layouts/musicFooterDestinations.ts
+++ b/apps/web/src/app/layouts/musicFooterDestinations.ts
@@ -1,0 +1,28 @@
+import { favoriteAlbumsRoute, musicRoute } from '@dg/shared-core/routes/app';
+
+export type MusicDestination = {
+  href: string;
+  label: string;
+};
+
+/** Music sheet destinations opened from the footer vinyl menu. Order is UI order. */
+export const MUSIC_FOOTER_DESTINATIONS: ReadonlyArray<MusicDestination> = [
+  { href: favoriteAlbumsRoute, label: 'Favorite albums' },
+  { href: musicRoute, label: 'Listening history' },
+];
+
+export const MUSIC_SHEET_PATHS = new Set(
+  MUSIC_FOOTER_DESTINATIONS.map((destination) => destination.href),
+);
+
+export function normalizeMusicPath(path: string) {
+  if (path.length > 1 && path.endsWith('/')) {
+    return path.slice(0, -1);
+  }
+  return path;
+}
+
+/** Contentful footer icon whose URL points at favorite albums. */
+export function isFavoriteAlbumsFooterUrl(url: string) {
+  return normalizeMusicPath(url) === favoriteAlbumsRoute;
+}

--- a/apps/web/src/app/music/albums/FavoriteAlbumsSkeleton.tsx
+++ b/apps/web/src/app/music/albums/FavoriteAlbumsSkeleton.tsx
@@ -1,0 +1,46 @@
+import type { SxObject } from '@dg/ui/theme';
+import { Box, Skeleton, Stack } from '@mui/material';
+
+const gridSx: SxObject = {
+  display: 'grid',
+  gap: 2,
+  gridTemplateColumns: {
+    lg: 'repeat(6, 1fr)',
+    md: 'repeat(4, 1fr)',
+    sm: 'repeat(3, 1fr)',
+    xs: 'repeat(2, 1fr)',
+  },
+};
+
+const sortSwitcherSx: SxObject = {
+  borderRadius: 999,
+  height: 52,
+  maxWidth: 420,
+  width: '100%',
+};
+
+const thumbnailSx: SxObject = {
+  aspectRatio: '1',
+  borderRadius: 2,
+  height: 'auto',
+  width: '100%',
+};
+
+const PLACEHOLDER_TILES = Array.from({ length: 12 }, (_, tile) => `album-${tile}`);
+
+/**
+ * Occupies the same space the loaded grid will, so the sheet does not resize
+ * under the view transition when albums stream in.
+ */
+export function FavoriteAlbumsSkeleton() {
+  return (
+    <Stack spacing={2}>
+      <Skeleton sx={sortSwitcherSx} variant="rectangular" />
+      <Box sx={gridSx}>
+        {PLACEHOLDER_TILES.map((tile) => (
+          <Skeleton key={tile} sx={thumbnailSx} variant="rectangular" />
+        ))}
+      </Box>
+    </Stack>
+  );
+}

--- a/apps/web/src/app/music/albums/__tests__/page.test.ts
+++ b/apps/web/src/app/music/albums/__tests__/page.test.ts
@@ -2,10 +2,9 @@ import { homeRoute } from '@dg/shared-core/routes/app';
 import type { ReactElement } from 'react';
 
 jest.mock('@dg/ui/core/sheet/Sheet', () => ({
-  Sheet: Object.assign(
-    ({ children }: { children: React.ReactNode }) => children,
-    { displayName: 'Sheet' },
-  ),
+  Sheet: Object.assign(({ children }: { children: React.ReactNode }) => children, {
+    displayName: 'Sheet',
+  }),
 }));
 
 import { Sheet } from '@dg/ui/core/sheet/Sheet';

--- a/apps/web/src/app/music/albums/__tests__/page.test.ts
+++ b/apps/web/src/app/music/albums/__tests__/page.test.ts
@@ -1,0 +1,24 @@
+import { homeRoute } from '@dg/shared-core/routes/app';
+import type { ReactElement } from 'react';
+
+jest.mock('@dg/ui/core/sheet/Sheet', () => ({
+  Sheet: Object.assign(
+    ({ children }: { children: React.ReactNode }) => children,
+    { displayName: 'Sheet' },
+  ),
+}));
+
+import { Sheet } from '@dg/ui/core/sheet/Sheet';
+import FavoriteAlbumsPage from '../page';
+
+describe('Favorite albums page', () => {
+  it('wraps content in a home-closing sheet without awaiting at the page root', () => {
+    const element = FavoriteAlbumsPage() as ReactElement<{
+      closeHref: string;
+      title: string;
+    }>;
+    expect(element.type).toBe(Sheet);
+    expect(element.props.title).toBe('Favorite albums');
+    expect(element.props.closeHref).toBe(homeRoute);
+  });
+});

--- a/apps/web/src/app/music/albums/page.tsx
+++ b/apps/web/src/app/music/albums/page.tsx
@@ -1,30 +1,44 @@
 import 'server-only';
 
-import { favoriteAlbumsRoute } from '@dg/shared-core/routes/app';
-import { Stack, Typography } from '@mui/material';
+import { favoriteAlbumsRoute, homeRoute } from '@dg/shared-core/routes/app';
+import { Sheet } from '@dg/ui/core/sheet/Sheet';
+import { Typography } from '@mui/material';
 import type { Metadata } from 'next';
+import { Suspense } from 'react';
 import { getFavoriteAlbums } from '../../../services/albums';
 import { markdownAlternates } from '../../layouts/markdownAlternates';
 import { FavoriteAlbumsGrid } from './FavoriteAlbumsGrid';
+import { FavoriteAlbumsSkeleton } from './FavoriteAlbumsSkeleton';
+
+const TITLE = 'Favorite albums';
 
 export const metadata: Metadata = {
   alternates: markdownAlternates(favoriteAlbumsRoute),
-  title: 'Favorite albums',
+  title: TITLE,
 };
 
-export default async function FavoriteAlbumsPage() {
+async function FavoriteAlbums() {
   const albums = await getFavoriteAlbums();
 
+  if (!albums?.length) {
+    return <Typography color="text.secondary">No albums right now. Check back soon.</Typography>;
+  }
+
+  return <FavoriteAlbumsGrid albums={albums} />;
+}
+
+/**
+ * The sheet shell stays synchronous so it commits in the same render as the
+ * outgoing page. Awaiting here instead would suspend the whole route, the old
+ * page would already be unmounted by the time the sheet arrives, and the view
+ * transition would have nothing to animate away from.
+ */
+export default function FavoriteAlbumsPage() {
   return (
-    <main>
-      <Stack spacing={2}>
-        <Typography variant="h1">Favorite albums</Typography>
-        {albums?.length ? (
-          <FavoriteAlbumsGrid albums={albums} />
-        ) : (
-          <Typography color="text.secondary">No albums right now. Check back soon.</Typography>
-        )}
-      </Stack>
-    </main>
+    <Sheet closeHref={homeRoute} title={TITLE}>
+      <Suspense fallback={<FavoriteAlbumsSkeleton />}>
+        <FavoriteAlbums />
+      </Suspense>
+    </Sheet>
   );
 }

--- a/package.json
+++ b/package.json
@@ -27,5 +27,5 @@
     "clean": "rm -f .env .env.tmp",
     "preinstall": "npx only-allow pnpm"
   },
-  "version": "2.63.2"
+  "version": "2.63.3"
 }

--- a/packages/ui/core/sheet/SheetOpenLink.tsx
+++ b/packages/ui/core/sheet/SheetOpenLink.tsx
@@ -6,23 +6,7 @@ import { useLayoutEffect, useRef } from 'react';
 import { Link } from '../../dependent/Link';
 import type { SxProps } from '../../theme';
 import { rememberSheetOrigin } from './sheetScrollMemory';
-import {
-  SHEET_TITLE_SLOT_VIEW_TRANSITION_NAME,
-  SHEET_TITLE_VIEW_TRANSITION_NAME,
-  sheetTransitionTypes,
-} from './sheetTransitions';
-
-/**
- * The sheet's own heading owns the shared name while the sheet is open, so the
- * control holds the placeholder name then and the shared one the rest of the
- * time. Either way it stays out of the surrounding chrome's snapshot.
- */
-function titleName(morphsTitle: boolean, isSheetOpen: boolean) {
-  if (!morphsTitle) {
-    return '';
-  }
-  return isSheetOpen ? SHEET_TITLE_SLOT_VIEW_TRANSITION_NAME : SHEET_TITLE_VIEW_TRANSITION_NAME;
-}
+import { sheetTitleMorphName, sheetTransitionTypes } from './sheetTransitions';
 
 export type SheetOpenLinkProps = {
   children?: ReactNode;
@@ -63,7 +47,9 @@ export function SheetOpenLink({
     if (!anchor.current) {
       return;
     }
-    anchor.current.style.viewTransitionName = titleName(morphsTitle, pathname === href);
+    anchor.current.style.viewTransitionName = morphsTitle
+      ? sheetTitleMorphName(pathname === href)
+      : '';
   }, [href, morphsTitle, pathname]);
 
   return (

--- a/packages/ui/core/sheet/sheetTransitions.ts
+++ b/packages/ui/core/sheet/sheetTransitions.ts
@@ -31,6 +31,15 @@ export const SHEET_TITLE_VIEW_TRANSITION_NAME = 'sheet-title';
 export const SHEET_TITLE_SLOT_VIEW_TRANSITION_NAME = 'sheet-title-slot';
 
 /**
+ * Name for the single control that morphs into the sheet heading. While any
+ * sheet that shares that control is open, the control holds the slot name so
+ * the heading alone owns `sheet-title` at capture time.
+ */
+export function sheetTitleMorphName(sheetIsOpen: boolean): string {
+  return sheetIsOpen ? SHEET_TITLE_SLOT_VIEW_TRANSITION_NAME : SHEET_TITLE_VIEW_TRANSITION_NAME;
+}
+
+/**
  * One boundary owns page content, and the intent of the navigation decides
  * whether the arriving route is a sheet rising over the page it covers or the
  * page coming back out from under it. Classes are matched in


### PR DESCRIPTION
## Summary
- Wrap `/music/albums` in the same synchronous `Sheet` + Suspense pattern as Listening history so open/close uses sheet view transitions.
- Replace the footer "Listening history" text link and vinyl icon with a small music popup menu (Favorite albums, then Listening history).
- Give the vinyl trigger sole ownership of `sheet-title` / `sheet-title-slot` so menu item links never duplicate the view-transition name at capture time.

## Test plan
- [ ] Click the footer vinyl icon; confirm the menu lists Favorite albums then Listening history
- [ ] Open each destination and confirm the sheet panel morphs in; close returns home with the close animation
- [ ] Confirm other footer icon links are unchanged
- [ ] `turbo check --filter=@dg/web --filter=@dg/ui`
- [ ] `turbo check:types --filter=@dg/web --filter=@dg/ui`
- [ ] `turbo test --filter=@dg/web --filter=@dg/ui` (with `DATABASE_URL_TEST` set)


Made with [Cursor](https://cursor.com)