### PR TITLE
Cleanup docs, music redirect, and WebhookType

### DIFF
--- a/.cursor/rules/architecture-boundaries.mdc
+++ b/.cursor/rules/architecture-boundaries.mdc
@@ -35,14 +35,15 @@ app-only formatting. Avoid wrapper re-exports that just pass through to
 
 ### Testing
 
-For test database setup, use `@dg/services/testing/setupTestDatabase`:
+Runtime app code must not import `@dg/db`. Tests may import `@dg/db/testing`
+(for example `setupTestDatabase` from `@dg/db/testing/databaseSetup`).
 
 ```ts
-// ❌ Bad - test importing db directly
-import { setupTestDatabase } from '@dg/db/testing';
+// ❌ Bad - app runtime importing db
+import { db } from '@dg/db';
 
-// ✅ Good - test imports from services
-import { setupTestDatabase } from '@dg/services/testing/setupTestDatabase';
+// ✅ Good - tests using the db testing helpers
+import { setupTestDatabase } from '@dg/db/testing/databaseSetup';
 ```
 
 ## Server-only services

--- a/.cursor/rules/db-imports.mdc
+++ b/.cursor/rules/db-imports.mdc
@@ -31,12 +31,13 @@ const status = await getStravaOauthStatus();
 
 ## Testing
 
-For test database setup, use `@dg/services/testing/setupTestDatabase`:
+Runtime app code must not import `@dg/db`. Tests may import `@dg/db/testing`
+(for example `setupTestDatabase` from `@dg/db/testing/databaseSetup`).
 
 ```ts
-// ❌ Bad - test importing db directly
-import { setupTestDatabase } from '@dg/db/testing';
+// ❌ Bad - app runtime importing db
+import { db } from '@dg/db';
 
-// ✅ Good - test imports from services
-import { setupTestDatabase } from '@dg/services/testing/setupTestDatabase';
+// ✅ Good - tests using the db testing helpers
+import { setupTestDatabase } from '@dg/db/testing/databaseSetup';
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ This is `dg`, a single Next.js 16 app (`@dg/web`) in a pnpm + Turbo monorepo. Se
 
 ### Environment / secrets
 - Runtime config comes from env vars, not a checked-in file. Normally `turbo dev`/`turbo migrate` run a `dg#env` step that generates `.env` from 1Password via the `op` CLI; `op` is not installed here, so that step logs "1Password CLI not found, skipping .env generation" and is a harmless no-op. The app instead reads the injected secret env vars directly.
+- Feature flags use Vercel Flags (`FLAGS` on Vercel via `apps/web/src/flags.ts`). That is separate from 1Password/`turbo env` secrets; do not fold `FLAGS` into `config/env.secrets.keys` without an explicit product decision.
 - Real secrets for Contentful, Spotify, Strava, OAuth callback, and Turbo cache are injected as env vars, so the homepage renders real CMS content and OAuth flows redirect to the real providers.
 - The dev console lives at `/dev-console`. Basic auth is only enforced when `DEV_CONSOLE_BASIC_AUTH_USER`/`_PASS` are set; otherwise it is open in development.
 - `STADIA_API_KEY` may be absent; the homepage still renders (only the watercolor map tiles are affected).

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ If `turbo` is not found, ensure `~/.nodenv/shims` is on PATH, then `nodenv rehas
 
 `.env` is generated from 1Password (vault `dg`) using `[config/env.secrets.keys](config/env.secrets.keys)`. Each key must be an item with the same name and the value stored in the `value` field. To regenerate after vault changes: `turbo clean && turbo dev` or delete `.env` and re-run `turbo dev`.
 
+Feature flags are separate: Vercel Flags (`FLAGS` on Vercel, see `apps/web/src/flags.ts`). Local OAuth/webhook debugging lives at `/dev-console`.
+
 ## :memo: Pull Requests
 
 Feature branches squash onto main, and Linear is used for ticket tracking.

--- a/apps/web/src/app/music/page.tsx
+++ b/apps/web/src/app/music/page.tsx
@@ -1,7 +1,7 @@
 import 'server-only';
 
 import { isMissingTokenError } from '@dg/shared-core/errors/MissingTokenError';
-import { homeRoute, musicRoute } from '@dg/shared-core/routes/app';
+import { devConsoleRoute, homeRoute, musicRoute } from '@dg/shared-core/routes/app';
 import { Sheet } from '@dg/ui/core/sheet/Sheet';
 import { Stack } from '@mui/material';
 import type { Metadata } from 'next';
@@ -29,9 +29,9 @@ async function MusicHistory() {
     tracks = result.tracks;
     nextCursor = result.nextCursor;
   } catch (error) {
-    // In development, redirect to the dev page to set up OAuth
+    // In development, redirect to the dev console to set up OAuth
     if (isMissingTokenError(error) && process.env.NODE_ENV === 'development') {
-      redirect('/dev');
+      redirect(devConsoleRoute);
     }
     throw error;
   }

--- a/apps/web/src/services/strava.actions.ts
+++ b/apps/web/src/services/strava.actions.ts
@@ -21,7 +21,7 @@ type WebhookActionResult = {
 export async function createWebhookSubscription(): Promise<WebhookActionResult> {
   return withDevConsoleAuth(async () => {
     try {
-      await createSubscription('strava');
+      await createSubscription();
       revalidatePath(devConsoleRoute);
       return { success: true };
     } catch (error) {
@@ -41,14 +41,14 @@ export async function createWebhookSubscription(): Promise<WebhookActionResult> 
 export async function deleteWebhookSubscription(): Promise<WebhookActionResult> {
   return withDevConsoleAuth(async () => {
     try {
-      const subscriptions = await listSubscriptions('strava');
+      const subscriptions = await listSubscriptions();
       const subscription = subscriptions[0];
 
       if (!subscription) {
         return { error: 'No subscription found to delete', success: false };
       }
 
-      await deleteSubscription('strava', subscription.id);
+      await deleteSubscription(subscription.id);
       revalidatePath(devConsoleRoute);
       return { success: true };
     } catch (error) {

--- a/package.json
+++ b/package.json
@@ -27,5 +27,5 @@
     "clean": "rm -f .env .env.tmp",
     "preinstall": "npx only-allow pnpm"
   },
-  "version": "2.63.1"
+  "version": "2.63.2"
 }

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -30,21 +30,23 @@ The `getDatabaseUrl()` function looks up the correct URL based on `NODE_ENV` and
 
 ## Testing
 
-For test database setup, use `@dg/testing`:
+Test helpers live in this package under `@dg/db/testing`. Runtime app code still
+must not import `@dg/db`; tests may import `@dg/db/testing`.
 
 ```ts
-import { setupTestDatabase } from '@dg/testing/databaseSetup';
-import { setupMockLifecycle } from '@dg/testing/mocks';
+import { setupTestDatabase } from '@dg/db/testing/databaseSetup';
 
-const db = setupTestDatabase({ truncate: ['StravaActivity'] });
-setupMockLifecycle();
+const db = setupTestDatabase();
 
 it('creates an activity', async () => {
   await db.StravaActivity.create({ ... });
 });
 ```
 
-See `packages/testing/README.md` for full documentation.
+`setupTestDatabase()` wraps each test in a transaction (BEGIN/ROLLBACK). Use
+`resetTestDatabase()` when you need a full truncate. Jest shared config is
+`@dg/db/testing/jest.config.base`. Mocks and other non-DB test utilities live in
+`@dg/testing` (see `packages/testing/README.md`).
 
 ## Gotchas
 

--- a/packages/services/README.md
+++ b/packages/services/README.md
@@ -11,17 +11,18 @@ Server-side API integrations and data fetching for external services. This packa
 | `content-models` | Types, schemas, validation, pure transforms | `RenderableLink`, `Track`, Valibot schemas |
 
 
-**Rule of thumb**: If it makes an HTTP request, touches the database, or requires `server-only`, it belongs here. If it's a type, schema, or pure function on data shapes, it belongs in `content-models`.
+**Rule of thumb**: If it makes an HTTP request, touches the database, or requires `server-only`, it belongs here. If it's a type, schema, or pure function on data shapes, it belongs in `content-models`. The `content-models` name covers validated external payloads (Contentful, Spotify, Strava), not CMS-only types.
 
 ## Structure
 
 ```
 services/
+├── auth/             # Dev-console basic auth helpers
 ├── clients/          # Reusable HTTP client utilities
-├── images/           # Server-side image utilities
 ├── contentful/       # Contentful CMS integration
-├── spotify/          # Spotify API integration
-├── strava/           # Strava API integration
+├── oauth/            # Shared OAuth flows (Spotify + Strava)
+├── spotify/          # Spotify API + history sync
+├── strava/           # Strava API + webhooks
 ```
 
 ## Clients
@@ -37,6 +38,21 @@ Low-level HTTP client utilities used by service integrations:
 | `refreshedAccessToken.ts`       | Token refresh logic for OAuth flows     |
 | `RefreshTokenConfig.ts`         | Configuration type for token refresh    |
 | `getStatus.ts`                  | HTTP status code helpers                |
+
+
+## OAuth
+
+Shared OAuth orchestration under `oauth/`:
+
+
+| Export                           | Description                                      |
+| -------------------------------- | ------------------------------------------------ |
+| `initiateOauthFlow()`            | Starts an OAuth redirect for a provider          |
+| `completeOauthFlow()`            | Finishes the callback and stores tokens          |
+| `exchangeSpotifyCodeForToken()`  | Spotify PKCE code exchange                       |
+| `exchangeStravaCodeForToken()`   | Strava client-secret code exchange               |
+| `getOauthStatus()`               | Connection status for a provider                 |
+| `forceRefreshToken()`            | Forces a token refresh                           |
 
 
 ## Contentful
@@ -65,16 +81,20 @@ CMS integration for site content. Uses GraphQL with Valibot-validated responses.
 
 ## Spotify
 
-Spotify API integration for currently playing/recently played tracks.
+Spotify API integration for currently playing, history, and albums.
 
 
-| Export                  | Description                                             |
-| ----------------------- | ------------------------------------------------------- |
-| `fetchRecentlyPlayed()` | Gets recently played or currently playing track         |
-| `spotifyClient`         | Configured REST client with token refresh               |
-| `CurrentlyPlaying`      | Type in `@dg/content-models/spotify/CurrentlyPlaying`   |
-| `RecentlyPlayed`        | Type in `@dg/content-models/spotify/RecentlyPlayed`     |
-| `Track`                 | Shared track type in `@dg/content-models/spotify/Track` |
+| Export                       | Description                                           |
+| ---------------------------- | ----------------------------------------------------- |
+| `fetchRecentlyPlayed()`      | Recently played or currently playing track            |
+| `fetchMusicHistoryPage()`    | Paginated listening history from the DB               |
+| `fetchPlaylistAlbums()`      | Favorite albums from a playlist                       |
+| `syncSpotifyHistory()`       | Incremental history sync                              |
+| `importSpotifyHistory()`     | Bulk import path                                      |
+| `spotifyClient`              | Configured REST client with token refresh             |
+| `CurrentlyPlaying`           | Type in `@dg/content-models/spotify/CurrentlyPlaying` |
+| `RecentlyPlayed`             | Type in `@dg/content-models/spotify/RecentlyPlayed`   |
+| `Track`                      | Shared track type in `@dg/content-models/spotify/Track` |
 
 
 ## Strava
@@ -88,23 +108,22 @@ Strava API integration for activity data and webhooks.
 | `fetchStravaActivityFromApi()`      | Fetches activity directly from Strava API              |
 | `syncStravaWebhookUpdateWithDb()`   | Syncs webhook updates to database                      |
 | `echoStravaChallengeIfValid()`      | Handles Strava webhook verification                    |
-| `exchangeCodeForToken()`            | Exchanges an OAuth code for tokens                     |
 | `mapActivityFromApi()`              | Converts API response (snake_case) to domain format    |
 | `stravaClient`                      | Configured REST client with token refresh              |
 | `stravaTokenExchangeClient`         | Client for OAuth token exchange                        |
 | `StravaWebhookEvent`                | Type in `@dg/content-models/strava/StravaWebhookEvent` |
 
 
-### Webhook Subscription Management
+### Webhook subscription management
 
 Functions for managing Strava webhook subscriptions (in `strava/webhooks/`):
 
 
-| Export                         | Description                          |
-| ------------------------------ | ------------------------------------ |
-| `listSubscriptions(type)`      | Lists all webhook subscriptions      |
-| `createSubscription(type)`     | Creates a new webhook subscription   |
-| `deleteSubscription(type, id)` | Deletes a webhook subscription by ID |
+| Export                     | Description                          |
+| -------------------------- | ------------------------------------ |
+| `listSubscriptions()`      | Lists all webhook subscriptions      |
+| `createSubscription()`     | Creates a new webhook subscription   |
+| `deleteSubscription(id)`   | Deletes a webhook subscription by ID |
 
 
 ## Environment Variables
@@ -124,4 +143,3 @@ Required environment variables (see `config/env.secrets.keys`):
 - `shared-core` - Shared utilities
 - `graphql-request` - GraphQL client
 - `wretch` - Fetch wrapper for REST APIs
-

--- a/packages/services/strava/webhooks/WebhookType.ts
+++ b/packages/services/strava/webhooks/WebhookType.ts
@@ -1,4 +1,0 @@
-/**
- * We only support Strava webhooks right now
- */
-export type WebhookType = 'strava';

--- a/packages/services/strava/webhooks/createSubscription.ts
+++ b/packages/services/strava/webhooks/createSubscription.ts
@@ -4,16 +4,15 @@ import { StravaApiError } from '@dg/shared-core/errors/StravaApiError';
 import { log } from '@dg/shared-core/logging/log';
 import type { WebhookSubscription } from './listSubscriptions';
 import { parseStravaError } from './parseStravaError';
-import type { WebhookType } from './WebhookType';
 import { getWebhookSubscriptionConfig, standardParams } from './webhookSubscriptionConfigs';
 
 /**
- * Creates a webhook subscription.
+ * Creates a Strava webhook subscription.
  * Assumes there's something running at the callback URL for the webhook to call back to.
  * Returns the created subscription, or throws a `StravaApiError` on refusal.
  */
-export async function createSubscription(type: WebhookType): Promise<WebhookSubscription> {
-  const config = getWebhookSubscriptionConfig(type);
+export async function createSubscription(): Promise<WebhookSubscription> {
+  const config = getWebhookSubscriptionConfig();
   const { endpoint, verifyToken, callbackUrl, headers } = config;
 
   if (!verifyToken || !callbackUrl) {
@@ -34,7 +33,6 @@ export async function createSubscription(type: WebhookType): Promise<WebhookSubs
       client_id: config.id,
       verify_token: verifyToken,
     },
-    type,
     verifyToken,
   });
 
@@ -50,7 +48,6 @@ export async function createSubscription(type: WebhookType): Promise<WebhookSubs
       body: errorBody,
       callbackUrl,
       status: response.status,
-      type,
     });
     const userMessage = parseStravaError(response.status, errorBody, callbackUrl);
     throw new StravaApiError(userMessage, response.status);

--- a/packages/services/strava/webhooks/deleteSubscription.ts
+++ b/packages/services/strava/webhooks/deleteSubscription.ts
@@ -1,18 +1,14 @@
 import 'server-only';
 
 import { log } from '@dg/shared-core/logging/log';
-import type { WebhookType } from './WebhookType';
 import { getWebhookSubscriptionConfig, standardParams } from './webhookSubscriptionConfigs';
 
 /**
- * Deletes a webhook subscription with a given id.
+ * Deletes a Strava webhook subscription with a given id.
  * Returns true on success, or throws on error.
  */
-export async function deleteSubscription(
-  type: WebhookType,
-  subscriptionId: number,
-): Promise<boolean> {
-  const config = getWebhookSubscriptionConfig(type);
+export async function deleteSubscription(subscriptionId: number): Promise<boolean> {
+  const config = getWebhookSubscriptionConfig();
   const { endpoint, headers } = config;
 
   const url = new URL(`${endpoint}/${subscriptionId}`);
@@ -29,10 +25,9 @@ export async function deleteSubscription(
       body: errorBody,
       status: response.status,
       subscriptionId,
-      type,
     });
     throw new Error(
-      `Failed to delete ${type} webhook subscription ${subscriptionId}: ${response.status}`,
+      `Failed to delete Strava webhook subscription ${subscriptionId}: ${response.status}`,
     );
   }
 

--- a/packages/services/strava/webhooks/getWebhookSubscriptions.ts
+++ b/packages/services/strava/webhooks/getWebhookSubscriptions.ts
@@ -28,7 +28,7 @@ export type WebhookSubscriptionsStatus = {
  */
 export async function getWebhookSubscriptions(): Promise<WebhookSubscriptionsStatus> {
   try {
-    const subscriptions = await listSubscriptions('strava');
+    const subscriptions = await listSubscriptions();
     return {
       error: null,
       subscriptions: subscriptions.map((subscription) => ({

--- a/packages/services/strava/webhooks/isValidSubscriptionId.ts
+++ b/packages/services/strava/webhooks/isValidSubscriptionId.ts
@@ -8,7 +8,7 @@ import { listSubscriptions } from './listSubscriptions';
  */
 export async function isValidSubscriptionId(subscriptionId: number): Promise<boolean> {
   try {
-    const subscriptions = await listSubscriptions('strava');
+    const subscriptions = await listSubscriptions();
     return subscriptions.some((subscription) => subscription.id === subscriptionId);
   } catch (error) {
     log.error('Failed to validate subscription ID', { error });

--- a/packages/services/strava/webhooks/listSubscriptions.ts
+++ b/packages/services/strava/webhooks/listSubscriptions.ts
@@ -3,7 +3,6 @@ import 'server-only';
 import { StravaApiError } from '@dg/shared-core/errors/StravaApiError';
 import { log } from '@dg/shared-core/logging/log';
 import { parseStravaError } from './parseStravaError';
-import type { WebhookType } from './WebhookType';
 import { getWebhookSubscriptionConfig, standardParams } from './webhookSubscriptionConfigs';
 
 /**
@@ -18,12 +17,12 @@ export type WebhookSubscription = {
 };
 
 /**
- * Lists all current subscriptions for a webhook type.
+ * Lists all current Strava webhook subscriptions.
  * Returns an array of subscriptions, or throws a `StravaApiError` when Strava
  * rejects the request so callers can tell an API refusal apart from a bug.
  */
-export async function listSubscriptions(type: WebhookType): Promise<Array<WebhookSubscription>> {
-  const config = getWebhookSubscriptionConfig(type);
+export async function listSubscriptions(): Promise<Array<WebhookSubscription>> {
+  const config = getWebhookSubscriptionConfig();
   const { endpoint, headers } = config;
 
   const url = new URL(endpoint);
@@ -39,7 +38,6 @@ export async function listSubscriptions(type: WebhookType): Promise<Array<Webhoo
     log.error('Failed to list webhook subscriptions', {
       body: errorBody,
       status: response.status,
-      type,
     });
     throw new StravaApiError(parseStravaError(response.status, errorBody), response.status);
   }

--- a/packages/services/strava/webhooks/webhookSubscriptionConfigs.ts
+++ b/packages/services/strava/webhooks/webhookSubscriptionConfigs.ts
@@ -1,7 +1,6 @@
 import 'server-only';
 
 import type { WebhookSubscriptionConfig } from './WebhookSubscriptionConfig';
-import type { WebhookType } from './WebhookType';
 
 /**
  * These are the standard parameters that go into the body of
@@ -19,22 +18,19 @@ export const standardParams = (config: WebhookSubscriptionConfig) => {
 };
 
 /**
- * Returns webhook subscription configs, reading env vars at call time
+ * Returns the Strava webhook subscription config, reading env vars at call time
  * so tests can set mock values before the config is evaluated.
  */
-export function getWebhookSubscriptionConfig(type: WebhookType): WebhookSubscriptionConfig {
-  switch (type) {
-    case 'strava':
-      return {
-        callbackUrl: process.env.STRAVA_WEBHOOK_CALLBACK_URL,
-        endpoint: 'https://www.strava.com/api/v3/push_subscriptions',
-        headers: {
-          Accept: 'application/json',
-          'Content-Type': 'application/x-www-form-urlencoded',
-        },
-        id: process.env.STRAVA_CLIENT_ID,
-        secret: process.env.STRAVA_CLIENT_SECRET,
-        verifyToken: process.env.STRAVA_VERIFY_TOKEN,
-      };
-  }
+export function getWebhookSubscriptionConfig(): WebhookSubscriptionConfig {
+  return {
+    callbackUrl: process.env.STRAVA_WEBHOOK_CALLBACK_URL,
+    endpoint: 'https://www.strava.com/api/v3/push_subscriptions',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    id: process.env.STRAVA_CLIENT_ID,
+    secret: process.env.STRAVA_CLIENT_SECRET,
+    verifyToken: process.env.STRAVA_VERIFY_TOKEN,
+  };
 }


### PR DESCRIPTION
Audit slices A–C (plus optional Flags note). Docs and a tiny API flatten. No music footer / albums sheet / VT work.

**What changed**
- Cursor rules and `packages/db` README cite `@dg/db/testing/databaseSetup`; tests may import `@dg/db/testing`, app runtime may not. No new `@dg/services/testing` re-export.
- `/music` missing-token redirect uses `devConsoleRoute` instead of `'/dev'`.
- `packages/services` README matches the tree (`oauth/`, `auth/`, real export names, Strava-only webhook signatures).
- Deleted single-value `WebhookType`; list/create/delete/getWebhookSubscriptionConfig take no type param. Callers updated.
- README/AGENTS one-liner: FLAGS is Vercel-only; secrets stay on 1Password via `turbo env`.

**Verify**
- `turbo check` / `check:types` for `@dg/services`, `@dg/web`, `@dg/db` (and root check)
- `turbo test --filter=@dg/services --filter=@dg/web` (233 tests)

Do not merge until reviewed.

Made with [Cursor](https://cursor.com)