### PR TITLE
Cleanup: test DB docs, music sheet registry, Contentful cache helper

### DIFF
--- a/.cursor/rules/architecture-boundaries.mdc
+++ b/.cursor/rules/architecture-boundaries.mdc
@@ -37,6 +37,9 @@ app-only formatting. Avoid wrapper re-exports that just pass through to
 
 Runtime app code must not import `@dg/db`. Tests may import `@dg/db/testing`
 (for example `setupTestDatabase` from `@dg/db/testing/databaseSetup`).
+`apps/web` tests may also import `@dg/db` for Sequelize operators such as `Op`
+when asserting query shape. That is a test-only exception; runtime app code
+still goes through `@dg/services`.
 
 ```ts
 // ❌ Bad - app runtime importing db
@@ -44,6 +47,9 @@ import { db } from '@dg/db';
 
 // ✅ Good - tests using the db testing helpers
 import { setupTestDatabase } from '@dg/db/testing/databaseSetup';
+
+// ✅ Allowed in apps/web tests only - Sequelize operators
+import { Op } from '@dg/db';
 ```
 
 ## Server-only services

--- a/.cursor/rules/db-imports.mdc
+++ b/.cursor/rules/db-imports.mdc
@@ -33,6 +33,9 @@ const status = await getStravaOauthStatus();
 
 Runtime app code must not import `@dg/db`. Tests may import `@dg/db/testing`
 (for example `setupTestDatabase` from `@dg/db/testing/databaseSetup`).
+`apps/web` tests may also import `@dg/db` for Sequelize operators such as `Op`
+when asserting query shape. That is a test-only exception; runtime app code
+still goes through `@dg/services`.
 
 ```ts
 // ❌ Bad - app runtime importing db
@@ -40,4 +43,7 @@ import { db } from '@dg/db';
 
 // ✅ Good - tests using the db testing helpers
 import { setupTestDatabase } from '@dg/db/testing/databaseSetup';
+
+// ✅ Allowed in apps/web tests only - Sequelize operators
+import { Op } from '@dg/db';
 ```

--- a/apps/web/src/app/layouts/MusicFooterMenu.tsx
+++ b/apps/web/src/app/layouts/MusicFooterMenu.tsx
@@ -10,11 +10,7 @@ import { Disc3 } from 'lucide-react';
 import { usePathname } from 'next/navigation';
 import type { MouseEvent } from 'react';
 import { useId, useLayoutEffect, useRef, useState } from 'react';
-import {
-  MUSIC_FOOTER_DESTINATIONS,
-  MUSIC_SHEET_PATHS,
-  normalizeMusicPath,
-} from './musicFooterDestinations';
+import { isMusicSheetPath, MUSIC_SHEET_ROUTES } from './musicFooterDestinations';
 
 const triggerSx: SxObject = {
   alignItems: 'center',
@@ -65,7 +61,7 @@ export function MusicFooterMenu({ icon, title }: MusicFooterMenuProps) {
   const triggerRef = useRef<HTMLButtonElement>(null);
   const pathname = usePathname();
   const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
-  const sheetIsOpen = MUSIC_SHEET_PATHS.has(normalizeMusicPath(pathname));
+  const sheetIsOpen = isMusicSheetPath(pathname);
 
   useLayoutEffect(() => {
     if (!triggerRef.current) {
@@ -105,7 +101,7 @@ export function MusicFooterMenu({ icon, title }: MusicFooterMenuProps) {
         open={Boolean(menuAnchor)}
         transformOrigin={{ horizontal: 'center', vertical: 'bottom' }}
       >
-        {MUSIC_FOOTER_DESTINATIONS.map((destination) => (
+        {MUSIC_SHEET_ROUTES.map((destination) => (
           <MenuItem key={destination.href} onClick={handleClose} sx={menuItemSx}>
             <SheetOpenLink href={destination.href} sx={menuLinkSx} title={destination.label}>
               {destination.label}

--- a/apps/web/src/app/layouts/musicFooterDestinations.ts
+++ b/apps/web/src/app/layouts/musicFooterDestinations.ts
@@ -1,25 +1,39 @@
 import { favoriteAlbumsRoute, musicRoute } from '@dg/shared-core/routes/app';
 
-export type MusicDestination = {
+export type MusicSheetRoute = {
   href: string;
   label: string;
 };
 
-/** Music sheet destinations opened from the footer vinyl menu. Order is UI order. */
-export const MUSIC_FOOTER_DESTINATIONS: ReadonlyArray<MusicDestination> = [
+/**
+ * Registry of music sheet pages. One entry drives footer menu labels/hrefs,
+ * sheet open paths, and the title-morph path set. Add a page, then add a row.
+ */
+export const MUSIC_SHEET_ROUTES: ReadonlyArray<MusicSheetRoute> = [
   { href: favoriteAlbumsRoute, label: 'Favorite albums' },
   { href: musicRoute, label: 'Listening history' },
 ];
 
-export const MUSIC_SHEET_PATHS = new Set(
-  MUSIC_FOOTER_DESTINATIONS.map((destination) => destination.href),
-);
+export const MUSIC_SHEET_PATHS = new Set(MUSIC_SHEET_ROUTES.map((route) => route.href));
 
 export function normalizeMusicPath(path: string) {
   if (path.length > 1 && path.endsWith('/')) {
     return path.slice(0, -1);
   }
   return path;
+}
+
+export function isMusicSheetPath(path: string) {
+  return MUSIC_SHEET_PATHS.has(normalizeMusicPath(path));
+}
+
+export function musicSheetLabel(href: string): string {
+  const normalized = normalizeMusicPath(href);
+  const match = MUSIC_SHEET_ROUTES.find((route) => route.href === normalized);
+  if (!match) {
+    throw new Error(`Unknown music sheet route: ${href}`);
+  }
+  return match.label;
 }
 
 /** Contentful footer icon whose URL points at favorite albums. */

--- a/apps/web/src/app/music/albums/page.tsx
+++ b/apps/web/src/app/music/albums/page.tsx
@@ -7,10 +7,11 @@ import type { Metadata } from 'next';
 import { Suspense } from 'react';
 import { getFavoriteAlbums } from '../../../services/albums';
 import { markdownAlternates } from '../../layouts/markdownAlternates';
+import { musicSheetLabel } from '../../layouts/musicFooterDestinations';
 import { FavoriteAlbumsGrid } from './FavoriteAlbumsGrid';
 import { FavoriteAlbumsSkeleton } from './FavoriteAlbumsSkeleton';
 
-const TITLE = 'Favorite albums';
+const TITLE = musicSheetLabel(favoriteAlbumsRoute);
 
 export const metadata: Metadata = {
   alternates: markdownAlternates(favoriteAlbumsRoute),

--- a/apps/web/src/app/music/page.tsx
+++ b/apps/web/src/app/music/page.tsx
@@ -9,10 +9,11 @@ import { redirect } from 'next/navigation';
 import { Suspense } from 'react';
 import { getMusicHistory } from '../../services/music';
 import { markdownAlternates } from '../layouts/markdownAlternates';
+import { musicSheetLabel } from '../layouts/musicFooterDestinations';
 import { MusicHistorySkeleton } from './MusicHistorySkeleton';
 import { MusicInfiniteScroll } from './MusicInfiniteScroll';
 
-const TITLE = 'Listening history';
+const TITLE = musicSheetLabel(musicRoute);
 
 export const metadata: Metadata = {
   alternates: markdownAlternates(musicRoute),

--- a/apps/web/src/app/spotify/SpotifyHeaderCard.tsx
+++ b/apps/web/src/app/spotify/SpotifyHeaderCard.tsx
@@ -8,6 +8,7 @@ import type { SxObject } from '@dg/ui/theme';
 import { Box } from '@mui/material';
 import { usePathname } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
+import { musicSheetLabel } from '../layouts/musicFooterDestinations';
 import { usePageScrollProgress } from '../layouts/PageScrollContext';
 import { NOW_PLAYING_CARD_ID } from './SpotifyCardScrollTracker';
 import { TrackListing } from './TrackListing';
@@ -140,7 +141,7 @@ export function SpotifyHeaderCard({ track }: SpotifyHeaderCardProps) {
     <Box aria-hidden={!isVisible} sx={getWidthWrapperSx(isVisible)}>
       <Box sx={getCollapsibleInnerSx(isVisible)}>
         {opensMusicSheet ? (
-          <SheetOpenLink href={musicRoute} sx={musicLinkSx} title="Listening history">
+          <SheetOpenLink href={musicRoute} sx={musicLinkSx} title={musicSheetLabel(musicRoute)}>
             {card}
           </SheetOpenLink>
         ) : (

--- a/apps/web/src/services/contentful.ts
+++ b/apps/web/src/services/contentful.ts
@@ -10,32 +10,35 @@ import { cacheLife, cacheTag } from 'next/cache';
 
 const CONTENTFUL_TAG = 'contentful';
 
-export const getProjects = async () => {
-  'use cache';
+/**
+ * Shared Contentful cache life/tag. Each caller still owns its own `'use cache'`
+ * so Next keeps a distinct cache entry per wrapper (args alone are not enough
+ * when the fetcher callback is not serializable).
+ */
+async function cachedContentful<T>(fn: () => Promise<T>): Promise<T> {
   cacheLife('default');
   cacheTag(CONTENTFUL_TAG);
-  return await fetchProjects();
+  return await fn();
+}
+
+export const getProjects = async () => {
+  'use cache';
+  return await cachedContentful(fetchProjects);
 };
 
 export const getSideProjects = async () => {
   'use cache';
-  cacheLife('default');
-  cacheTag(CONTENTFUL_TAG);
-  return await fetchSideProjects();
+  return await cachedContentful(fetchSideProjects);
 };
 
 export const getIntroContent = async () => {
   'use cache';
-  cacheLife('default');
-  cacheTag(CONTENTFUL_TAG);
-  return await fetchIntroContent();
+  return await cachedContentful(fetchIntroContent);
 };
 
 export const getFooterLinks = async () => {
   'use cache';
-  cacheLife('default');
-  cacheTag(CONTENTFUL_TAG);
-  return await fetchFooterLinks();
+  return await cachedContentful(fetchFooterLinks);
 };
 
 /**
@@ -43,14 +46,10 @@ export const getFooterLinks = async () => {
  */
 export const getLinkByName = async (name: string) => {
   'use cache';
-  cacheLife('default');
-  cacheTag(CONTENTFUL_TAG);
-  return await fetchLinkByName(name);
+  return await cachedContentful(() => fetchLinkByName(name));
 };
 
 export const getCurrentLocation = async () => {
   'use cache';
-  cacheLife('default');
-  cacheTag(CONTENTFUL_TAG);
-  return await fetchCurrentLocation();
+  return await cachedContentful(fetchCurrentLocation);
 };

--- a/package.json
+++ b/package.json
@@ -27,5 +27,5 @@
     "clean": "rm -f .env .env.tmp",
     "preinstall": "npx only-allow pnpm"
   },
-  "version": "2.63.5"
+  "version": "2.63.6"
 }

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -31,7 +31,8 @@ The `getDatabaseUrl()` function looks up the correct URL based on `NODE_ENV` and
 ## Testing
 
 Test helpers live in this package under `@dg/db/testing`. Runtime app code still
-must not import `@dg/db`; tests may import `@dg/db/testing`.
+must not import `@dg/db`; tests may import `@dg/db/testing`. `apps/web` tests may
+also import `@dg/db` for Sequelize operators such as `Op` (test-only exception).
 
 ```ts
 import { setupTestDatabase } from '@dg/db/testing/databaseSetup';


### PR DESCRIPTION
## Summary
- Align rules/READMEs with the lazy test-DB path: runtime apps never import `@dg/db`; tests use `@dg/db/testing`; document the `apps/web` test `Op` exception.
- Promote `MUSIC_SHEET_ROUTES` as the registry for footer menu, sheet paths/title-morph set, and sheet page titles (plus Spotify header sheet label).
- Extract `cachedContentful` in the app Contentful wrappers for shared `cacheLife`/`cacheTag('contentful')`. Each export still owns `'use cache'` so cache entries stay distinct.

## Test plan
- [x] `turbo check --filter=@dg/web --filter=@dg/db`
- [x] `turbo check:types --filter=@dg/web --filter=@dg/db`
- [x] `turbo test --filter=@dg/web`


Made with [Cursor](https://cursor.com)