### PR TITLE
Restore header glass translucency behind pinned chrome

### DIFF
--- a/apps/web/src/app/layouts/Footer.tsx
+++ b/apps/web/src/app/layouts/Footer.tsx
@@ -2,7 +2,10 @@ import type { RenderableLink } from '@dg/content-models/contentful/renderables/l
 import { devConsoleRoute } from '@dg/shared-core/routes/app';
 import { Nav, NavGroup, NavItem } from '@dg/ui/core/Nav';
 import { Section } from '@dg/ui/core/Section';
-import { SITE_FOOTER_VIEW_TRANSITION_NAME } from '@dg/ui/core/sheet/sheetTransitions';
+import {
+  pinnedChromeSx,
+  SITE_FOOTER_VIEW_TRANSITION_NAME,
+} from '@dg/ui/core/sheet/sheetTransitions';
 import { Link } from '@dg/ui/dependent/Link';
 import type { SxObject } from '@dg/ui/theme';
 import { Box, Container, Divider, Stack, Typography } from '@mui/material';
@@ -36,9 +39,7 @@ const footerContainerSx: SxObject = {
   padding: 0,
 };
 
-const siteFooterSx: SxObject = {
-  viewTransitionName: SITE_FOOTER_VIEW_TRANSITION_NAME,
-};
+const siteFooterSx: SxObject = pinnedChromeSx(SITE_FOOTER_VIEW_TRANSITION_NAME);
 
 const dividerSx: SxObject = {
   marginBottom: 3,

--- a/apps/web/src/app/layouts/Header.tsx
+++ b/apps/web/src/app/layouts/Header.tsx
@@ -2,7 +2,10 @@ import { ColorSchemeToggleClient } from '@dg/ui/core/ColorSchemeToggleClient';
 import { MouseAwareGlassContainer } from '@dg/ui/core/MouseAwareGlassContainer';
 import { Nav, NavGroup, NavItem } from '@dg/ui/core/Nav';
 import { Section } from '@dg/ui/core/Section';
-import { SITE_HEADER_VIEW_TRANSITION_NAME } from '@dg/ui/core/sheet/sheetTransitions';
+import {
+  pinnedChromeSx,
+  SITE_HEADER_VIEW_TRANSITION_NAME,
+} from '@dg/ui/core/sheet/sheetTransitions';
 import type { SxObject } from '@dg/ui/theme';
 import { Box } from '@mui/material';
 import { Suspense } from 'react';
@@ -18,9 +21,7 @@ const stickyContainerSx: SxObject = {
   zIndex: 10, // Higher z-index to stay above grid content with transforms
 };
 
-const siteHeaderSx: SxObject = {
-  viewTransitionName: SITE_HEADER_VIEW_TRANSITION_NAME,
-};
+const siteHeaderSx: SxObject = pinnedChromeSx(SITE_HEADER_VIEW_TRANSITION_NAME);
 
 const navSx: SxObject = {
   columnGap: { sm: 2, xs: 1.5 },

--- a/package.json
+++ b/package.json
@@ -27,5 +27,5 @@
     "clean": "rm -f .env .env.tmp",
     "preinstall": "npx only-allow pnpm"
   },
-  "version": "2.63.6"
+  "version": "2.63.7"
 }

--- a/packages/ui/core/sheet/sheetTransitions.ts
+++ b/packages/ui/core/sheet/sheetTransitions.ts
@@ -1,3 +1,5 @@
+import type { SxObject } from '../../theme';
+
 export type SheetNavigationIntent = 'open' | 'close';
 
 const SHEET_TRANSITION_TYPES = {
@@ -13,6 +15,25 @@ export function sheetTransitionTypes(intent: SheetNavigationIntent): Array<Sheet
 
 export const SITE_HEADER_VIEW_TRANSITION_NAME = 'site-header';
 export const SITE_FOOTER_VIEW_TRANSITION_NAME = 'site-footer';
+
+/**
+ * Chrome that has to stay pinned across a sheet navigation needs a
+ * view-transition-name, but a named element is also a backdrop root: any
+ * `backdrop-filter` inside it samples that element instead of the page, so
+ * glass surfaces in the header flatten out to a plain tint. The name is only
+ * read while a transition is capturing, so it is claimed only then and the
+ * glass keeps the page as its backdrop the rest of the time.
+ *
+ * The selector leads with `html` rather than `:root`, which Emotion would read
+ * as a pseudo-class on this element and never match.
+ */
+export function pinnedChromeSx(name: string): SxObject {
+  return {
+    'html:active-view-transition &': {
+      viewTransitionName: name,
+    },
+  };
+}
 
 /**
  * Shared between the sheet's heading and the one control allowed to morph into


### PR DESCRIPTION
The header pill and the theme switcher stopped looking like glass — they went
flat and near-opaque instead of blurring the page behind them.

## Root cause

`backdrop-filter` samples the backdrop of its nearest *backdrop root*, and in
Chromium an element with a `view-transition-name` is one. #552 pinned the header
with `viewTransitionName: site-header` (and the footer with `site-footer`) so
sheet navigations would not ghost the chrome. That name silently cut the glass
inside the header off from the page: `blur(12px) saturate(150%)` had nothing
left to sample, so all that remained was the 70%-alpha background colour. Page
content showed through razor sharp and unsaturated, which reads as a flat tint.

The names are only needed while a transition is actually capturing, so they are
now claimed only then, via `:active-view-transition`. Nothing about the sheet
motion changes — the header and footer still get their own snapshot groups and
still animate exactly as before.

## What changed

- `packages/ui/core/sheet/sheetTransitions.ts` — new `pinnedChromeSx(name)`
  helper that applies the view-transition-name under
  `html:active-view-transition &`. (Leading with `html` rather than `:root`
  matters: Emotion reads a leading pseudo-class as belonging to the element
  itself and the rule never matches.)
- `apps/web/src/app/layouts/Header.tsx` and `Footer.tsx` — use the helper
  instead of setting `viewTransitionName` unconditionally.

The footer has no glass surfaces today, so it looked fine; it gets the same
treatment so the trap does not come back the moment one is added.

## How this was verified

Local dev in a clean worktree, headless Chrome over CDP, homepage scrolled so
the header overlaps the photo and the map:

- Dark and light themes both show the page properly blurred and saturated
  through the header pill and the theme switcher again.
- Computed style at rest: `view-transition-name: none`,
  `backdrop-filter: blur(12px) saturate(1.5)`.
- Real sheet close navigation from `/music`: `html` matches
  `:active-view-transition`, the header computes to `site-header`, and
  `::view-transition-group(site-header)` plus `(site-footer)` are created — so
  the pinning behaviour is intact.
- Theme switcher still switches (`light dark` → `light` → back to system).
- `turbo check`, `turbo check:types`, `turbo test` pass. One Spotify DB test in
  `@dg/services` flakes under `turbo test`; it flakes the same way on a clean
  `main` and passes when jest is run directly.

# Release info

- [ ] Major
- [ ] Minor
- [x] Patch
