### PR TITLE
Stack repeated album plays in listening history

### DIFF
--- a/apps/web/src/app/music/AlbumStack.tsx
+++ b/apps/web/src/app/music/AlbumStack.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import { Tooltip } from '@dg/ui/core/Tooltip';
+import { Image } from '@dg/ui/dependent/Image';
+import { Link } from '@dg/ui/dependent/Link';
+import { createBouncyTransition } from '@dg/ui/helpers/bouncyTransition';
+import type { SxObject } from '@dg/ui/theme';
+import { Box, Typography } from '@mui/material';
+import { ALBUM_ART_HOVER_SCALE, ALBUM_ART_SIZE } from '../spotify/albumArtStyles';
+
+/** Sleeves drawn per stack, including the front cover. */
+const MAX_LAYERS = 3;
+
+/** How far each sleeve shifts from its neighbour, as a percent of the cell. */
+const LAYER_STEP = 4;
+
+/** Slack left in the cell so rotated corners never cross into the grid gap. */
+const LAYER_INSET = 2;
+
+/** Degrees of fan added per sleeve sitting behind the front cover. */
+const LAYER_TILT = 1.5;
+
+/** How much wider the fan spreads while hovered or focused. */
+const HOVER_SPREAD = 1.5;
+
+/** Percent of the page background mixed into each sleeve behind the front. */
+const LAYER_RECESSION = 22;
+
+const linkSx: SxObject = {
+  '--album-stack-spread': 1,
+  '&:focus-visible, &:hover': {
+    '--album-stack-spread': HOVER_SPREAD,
+    transform: `scale(${ALBUM_ART_HOVER_SCALE})`,
+    zIndex: 1,
+  },
+  display: 'block',
+  maxWidth: ALBUM_ART_SIZE,
+  position: 'relative',
+  width: '100%',
+  ...createBouncyTransition('transform'),
+};
+
+const stackSx: SxObject = {
+  aspectRatio: '1 / 1',
+  position: 'relative',
+  width: '100%',
+};
+
+const countChipSx: SxObject = {
+  backdropFilter: 'blur(12px) saturate(150%)',
+  backgroundColor: 'color-mix(in srgb, var(--mui-palette-background-default) 70%, transparent)',
+  border: 'thin solid var(--mui-palette-card-border)',
+  borderRadius: 999,
+  bottom: 8,
+  color: 'var(--mui-palette-text-primary)',
+  insetInlineStart: 8,
+  lineHeight: 1.4,
+  paddingInline: 0.75,
+  position: 'absolute',
+  whiteSpace: 'nowrap',
+};
+
+/**
+ * Sleeves share the front cover's radius and shadow so a stack reads as the
+ * same object as a single tile, just repeated. Depth is carried by the offset,
+ * the fan, and a scrim that mixes the page background into the sleeves behind.
+ */
+function layerSx(depth: number, layerCount: number): SxObject {
+  const shift = (depth - (layerCount - 1) / 2) * LAYER_STEP;
+  const scale = (100 - (layerCount - 1) * LAYER_STEP - LAYER_INSET) / 100;
+  const spread = 'var(--album-stack-spread)';
+
+  return {
+    borderRadius: 2,
+    boxShadow: 'var(--mui-extraShadows-card-main)',
+    inset: 0,
+    lineHeight: 0,
+    overflow: 'hidden',
+    position: 'absolute',
+    transform: `translate(calc(${shift}% * ${spread}), calc(${-shift}% * ${spread})) rotate(${depth * LAYER_TILT}deg) scale(${scale})`,
+    ...(depth > 0 ? { border: 'thin solid var(--mui-palette-card-border)' } : {}),
+    ...createBouncyTransition('transform'),
+  };
+}
+
+const scrimSx = (depth: number): SxObject => ({
+  backgroundColor: `color-mix(in srgb, var(--mui-palette-background-default) ${depth * LAYER_RECESSION}%, transparent)`,
+  inset: 0,
+  position: 'absolute',
+});
+
+type Props = {
+  /** Album art URL, shared by every sleeve in the stack. */
+  imageUrl: string;
+  albumName: string;
+  artistNames: string;
+  /** Where the whole stack navigates — the album, not any one track. */
+  linkUrl: string;
+  /** Number of plays collapsed into this stack. */
+  trackCount: number;
+};
+
+/**
+ * A run of consecutive plays from one album, drawn as a stack of sleeves.
+ *
+ * The front cover is styled exactly like a single-track tile, with up to two
+ * more sleeves fanned behind it so a full album listen reads as one object
+ * instead of a dozen identical squares.
+ */
+export function AlbumStack({ imageUrl, albumName, artistNames, linkUrl, trackCount }: Props) {
+  const layerCount = Math.min(trackCount, MAX_LAYERS);
+  const countLabel = `${trackCount} ${trackCount === 1 ? 'track' : 'tracks'}`;
+  const label = `${albumName} – ${artistNames}, ${countLabel}`;
+
+  // Back to front, so the front cover paints last and sits on top.
+  const depths = Array.from({ length: layerCount }, (_, index) => layerCount - 1 - index);
+
+  return (
+    <Tooltip title={label}>
+      <Link href={linkUrl} isExternal={true} sx={linkSx} title={label}>
+        <Box sx={stackSx}>
+          {depths.map((depth) => (
+            <Box aria-hidden={depth > 0 || undefined} key={depth} sx={layerSx(depth, layerCount)}>
+              <Image
+                alt={depth === 0 ? albumName : ''}
+                fill={true}
+                height={ALBUM_ART_SIZE}
+                sizes={{ extraLarge: ALBUM_ART_SIZE }}
+                url={imageUrl}
+                width={ALBUM_ART_SIZE}
+              />
+              {depth > 0 ? <Box sx={scrimSx(depth)} /> : null}
+            </Box>
+          ))}
+          <Typography component="span" sx={countChipSx} variant="caption">
+            {countLabel}
+          </Typography>
+        </Box>
+      </Link>
+    </Tooltip>
+  );
+}

--- a/apps/web/src/app/music/MusicGrid.tsx
+++ b/apps/web/src/app/music/MusicGrid.tsx
@@ -4,6 +4,8 @@ import type { HistoryTrack } from '@dg/services/spotify/fetchMusicHistoryPage';
 import type { SxObject } from '@dg/ui/theme';
 import { Box } from '@mui/material';
 import { AlbumThumbnail } from '../spotify/AlbumThumbnail';
+import { AlbumStack } from './AlbumStack';
+import { groupAdjacentAlbumPlays } from './groupAdjacentAlbumPlays';
 
 type Props = {
   tracks: Array<HistoryTrack>;
@@ -21,20 +23,38 @@ const gridSx: SxObject = {
 };
 
 /**
- * Grid of music track thumbnails with responsive columns.
+ * Grid of music track thumbnails with responsive columns. Consecutive plays
+ * from one album collapse into a single stacked cell.
  */
 export function MusicGrid({ tracks }: Props) {
+  const runs = groupAdjacentAlbumPlays(tracks);
+
   return (
     <Box sx={gridSx}>
-      {tracks.map((track) => (
-        <AlbumThumbnail
-          albumName={track.albumName}
-          imageUrl={track.albumImageUrl}
-          key={`${track.playedAt}-${track.trackId}`}
-          linkUrl={track.url}
-          tooltip={`${track.trackName} – ${track.artistNames}`}
-        />
-      ))}
+      {runs.map((run) => {
+        if (run.tracks.length > 1) {
+          return (
+            <AlbumStack
+              albumName={run.albumName}
+              artistNames={run.artistNames}
+              imageUrl={run.albumImageUrl}
+              key={run.key}
+              linkUrl={run.linkUrl}
+              trackCount={run.tracks.length}
+            />
+          );
+        }
+        const [track] = run.tracks;
+        return track ? (
+          <AlbumThumbnail
+            albumName={track.albumName}
+            imageUrl={track.albumImageUrl}
+            key={run.key}
+            linkUrl={track.url}
+            tooltip={`${track.trackName} – ${track.artistNames}`}
+          />
+        ) : null;
+      })}
     </Box>
   );
 }

--- a/apps/web/src/app/music/__tests__/AlbumStack.test.tsx
+++ b/apps/web/src/app/music/__tests__/AlbumStack.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AlbumStack } from '../AlbumStack';
+
+const props = {
+  albumName: 'Feet of Clay',
+  artistNames: 'Earl Sweatshirt',
+  imageUrl: 'https://i.scdn.co/image/clay',
+  linkUrl: 'https://open.spotify.com/album/clay',
+  trackCount: 12,
+};
+
+describe('AlbumStack', () => {
+  it('exposes one link to the album with the run described in its label', () => {
+    render(<AlbumStack {...props} />);
+
+    const links = screen.getAllByRole('link');
+    expect(links).toHaveLength(1);
+    expect(links[0]).toHaveAccessibleName('Feet of Clay – Earl Sweatshirt, 12 tracks');
+    expect(links[0]).toHaveAttribute('href', 'https://open.spotify.com/album/clay');
+    expect(links[0]).toHaveAttribute('target', '_blank');
+  });
+
+  it('shows the play count in sentence case', () => {
+    render(<AlbumStack {...props} />);
+
+    expect(screen.getByText('12 tracks')).toBeInTheDocument();
+  });
+
+  it('names only the front cover, leaving the sleeves behind it decorative', () => {
+    render(<AlbumStack {...props} />);
+
+    expect(screen.getAllByRole('img').map((image) => image.getAttribute('alt'))).toEqual([
+      'Feet of Clay',
+    ]);
+  });
+
+  it('caps the sleeves it draws no matter how long the run is', () => {
+    const { container } = render(<AlbumStack {...props} trackCount={40} />);
+
+    expect(container.querySelectorAll('img')).toHaveLength(3);
+    expect(screen.getByText('40 tracks')).toBeInTheDocument();
+  });
+
+  it('draws one sleeve behind the cover for a run of two', () => {
+    const { container } = render(<AlbumStack {...props} trackCount={2} />);
+
+    expect(container.querySelectorAll('img')).toHaveLength(2);
+    expect(screen.getByText('2 tracks')).toBeInTheDocument();
+  });
+
+  it('reveals the tooltip on keyboard focus', async () => {
+    const user = userEvent.setup();
+    render(<AlbumStack {...props} />);
+
+    await user.tab();
+
+    expect(screen.getByRole('link')).toHaveFocus();
+    expect(screen.getByRole('tooltip')).toHaveTextContent(
+      'Feet of Clay – Earl Sweatshirt, 12 tracks',
+    );
+  });
+});

--- a/apps/web/src/app/music/__tests__/MusicGrid.test.tsx
+++ b/apps/web/src/app/music/__tests__/MusicGrid.test.tsx
@@ -1,0 +1,73 @@
+import type { HistoryTrack } from '@dg/services/spotify/fetchMusicHistoryPage';
+import { render, screen } from '@testing-library/react';
+import { MusicGrid } from '../MusicGrid';
+
+let playCounter = 0;
+
+function play(album: string, track: string): HistoryTrack {
+  playCounter += 1;
+  return {
+    albumId: `album-${album}`,
+    albumImageUrl: `https://i.scdn.co/image/${album}`,
+    albumName: album,
+    albumUrl: `https://open.spotify.com/album/${album}`,
+    artistNames: `${album} artist`,
+    playedAt: `2026-08-04T12:${String(playCounter).padStart(2, '0')}:00.000Z`,
+    trackId: `track-${track}`,
+    trackName: track,
+    url: `https://open.spotify.com/track/${track}`,
+  };
+}
+
+const linkNames = () => screen.getAllByRole('link').map((link) => link.getAttribute('aria-label'));
+
+describe('MusicGrid', () => {
+  it('renders a repeated album as one stack and single plays as tiles', () => {
+    render(
+      <MusicGrid
+        tracks={[
+          play('Bloom', 'One'),
+          play('Bloom', 'Two'),
+          play('Bloom', 'Three'),
+          play('Clay', 'Four'),
+        ]}
+      />,
+    );
+
+    expect(linkNames()).toEqual(['Bloom – Bloom artist, 3 tracks', 'Clay']);
+    expect(screen.getByText('3 tracks')).toBeInTheDocument();
+  });
+
+  it('sends a stack to the album and a single tile to its track', () => {
+    render(
+      <MusicGrid tracks={[play('Bloom', 'One'), play('Bloom', 'Two'), play('Clay', 'Solo')]} />,
+    );
+
+    expect(screen.getByRole('link', { name: /Bloom/ })).toHaveAttribute(
+      'href',
+      'https://open.spotify.com/album/Bloom',
+    );
+    expect(screen.getByRole('link', { name: 'Clay' })).toHaveAttribute(
+      'href',
+      'https://open.spotify.com/track/Solo',
+    );
+  });
+
+  it('grows an existing stack when infinite scroll appends more of the same album', () => {
+    const firstPage = [play('Bloom', 'One'), play('Bloom', 'Two')];
+    const { rerender } = render(<MusicGrid tracks={firstPage} />);
+
+    expect(screen.getByText('2 tracks')).toBeInTheDocument();
+
+    rerender(<MusicGrid tracks={[...firstPage, play('Bloom', 'Three'), play('Clay', 'Four')]} />);
+
+    expect(screen.getByText('3 tracks')).toBeInTheDocument();
+    expect(linkNames()).toEqual(['Bloom – Bloom artist, 3 tracks', 'Clay']);
+  });
+
+  it('renders nothing for an empty section', () => {
+    render(<MusicGrid tracks={[]} />);
+
+    expect(screen.queryAllByRole('link')).toHaveLength(0);
+  });
+});

--- a/apps/web/src/app/music/__tests__/groupAdjacentAlbumPlays.test.ts
+++ b/apps/web/src/app/music/__tests__/groupAdjacentAlbumPlays.test.ts
@@ -1,0 +1,146 @@
+import type { HistoryTrack } from '@dg/services/spotify/fetchMusicHistoryPage';
+import { groupAdjacentAlbumPlays } from '../groupAdjacentAlbumPlays';
+
+type PlayOptions = {
+  album: string;
+  track: string;
+  playedAt?: string;
+  albumUrl?: string;
+};
+
+let playCounter = 0;
+
+function play({ album, track, playedAt, albumUrl }: PlayOptions): HistoryTrack {
+  playCounter += 1;
+  return {
+    albumId: `album-${album}`,
+    albumImageUrl: `https://i.scdn.co/image/${album}`,
+    albumName: album,
+    albumUrl: albumUrl ?? `https://open.spotify.com/album/${album}`,
+    artistNames: `${album} artist`,
+    playedAt: playedAt ?? `2026-08-04T12:${String(playCounter).padStart(2, '0')}:00.000Z`,
+    trackId: `track-${track}`,
+    trackName: track,
+    url: `https://open.spotify.com/track/${track}`,
+  };
+}
+
+const runShape = (tracks: Array<HistoryTrack>) =>
+  groupAdjacentAlbumPlays(tracks).map((run) => [run.albumName, run.tracks.length]);
+
+describe('groupAdjacentAlbumPlays', () => {
+  it('returns nothing for an empty list', () => {
+    expect(groupAdjacentAlbumPlays([])).toEqual([]);
+  });
+
+  it('keeps standalone plays as runs of one', () => {
+    const tracks = [
+      play({ album: 'Bloom', track: 'One' }),
+      play({ album: 'Clay', track: 'Two' }),
+      play({ album: 'Dusk', track: 'Three' }),
+    ];
+
+    expect(runShape(tracks)).toEqual([
+      ['Bloom', 1],
+      ['Clay', 1],
+      ['Dusk', 1],
+    ]);
+  });
+
+  it('collapses a straight album listen into one run', () => {
+    const tracks = [
+      play({ album: 'Bloom', track: 'One' }),
+      play({ album: 'Bloom', track: 'Two' }),
+      play({ album: 'Bloom', track: 'Three' }),
+      play({ album: 'Clay', track: 'Four' }),
+    ];
+
+    expect(runShape(tracks)).toEqual([
+      ['Bloom', 3],
+      ['Clay', 1],
+    ]);
+  });
+
+  it('only merges plays that sit next to each other', () => {
+    const tracks = [
+      play({ album: 'Bloom', track: 'One' }),
+      play({ album: 'Bloom', track: 'Two' }),
+      play({ album: 'Clay', track: 'Three' }),
+      play({ album: 'Bloom', track: 'Four' }),
+      play({ album: 'Bloom', track: 'Five' }),
+    ];
+
+    expect(runShape(tracks)).toEqual([
+      ['Bloom', 2],
+      ['Clay', 1],
+      ['Bloom', 2],
+    ]);
+  });
+
+  it('merges a run that straddles an infinite scroll page boundary', () => {
+    const firstPage = [
+      play({ album: 'Bloom', track: 'One' }),
+      play({ album: 'Bloom', track: 'Two' }),
+    ];
+    const secondPage = [
+      play({ album: 'Bloom', track: 'Three' }),
+      play({ album: 'Clay', track: 'Four' }),
+    ];
+
+    expect(runShape([...firstPage, ...secondPage])).toEqual([
+      ['Bloom', 3],
+      ['Clay', 1],
+    ]);
+  });
+
+  it('keeps the opening play as the run key so appended pages reuse the cell', () => {
+    const firstPage = [play({ album: 'Bloom', track: 'One' })];
+    const secondPage = [play({ album: 'Bloom', track: 'Two' })];
+
+    const [beforeRun] = groupAdjacentAlbumPlays(firstPage);
+    const [afterRun] = groupAdjacentAlbumPlays([...firstPage, ...secondPage]);
+
+    expect(afterRun?.key).toBe(beforeRun?.key);
+  });
+
+  it('points a run at the album rather than any single track', () => {
+    const [run] = groupAdjacentAlbumPlays([
+      play({ album: 'Bloom', track: 'One' }),
+      play({ album: 'Bloom', track: 'Two' }),
+    ]);
+
+    expect(run?.linkUrl).toBe('https://open.spotify.com/album/Bloom');
+  });
+
+  it('falls back to the opening track when the album has no page', () => {
+    const [run] = groupAdjacentAlbumPlays([
+      play({ album: 'Bloom', albumUrl: '', track: 'One' }),
+      play({ album: 'Bloom', albumUrl: '', track: 'Two' }),
+    ]);
+
+    expect(run?.linkUrl).toBe('https://open.spotify.com/track/One');
+  });
+
+  it('separates same-named albums that have different IDs', () => {
+    const live = { ...play({ album: 'Bloom', track: 'One' }), albumId: 'album-Bloom-live' };
+    const studio = play({ album: 'Bloom', track: 'Two' });
+
+    expect(runShape([live, studio])).toEqual([
+      ['Bloom', 1],
+      ['Bloom', 1],
+    ]);
+  });
+
+  it('groups legacy rows without an album ID by name and art', () => {
+    const withoutIds = [
+      { ...play({ album: 'Bloom', track: 'One' }), albumId: '' },
+      { ...play({ album: 'Bloom', track: 'Two' }), albumId: '' },
+      { ...play({ album: 'Clay', track: 'Three' }), albumId: '' },
+    ];
+
+    expect(runShape(withoutIds)).toEqual([
+      ['Bloom', 2],
+      ['Clay', 1],
+    ]);
+  });
+});

--- a/apps/web/src/app/music/groupAdjacentAlbumPlays.ts
+++ b/apps/web/src/app/music/groupAdjacentAlbumPlays.ts
@@ -1,0 +1,71 @@
+import type { HistoryTrack } from '@dg/services/spotify/fetchMusicHistoryPage';
+
+/**
+ * A run of consecutive plays from the same album. A one-off play is a run of
+ * one, so callers can treat every grid cell uniformly.
+ */
+export type AlbumPlayRun = {
+  /** Stable React key, taken from the play that opened the run. */
+  key: string;
+  albumId: string;
+  albumName: string;
+  albumImageUrl: string;
+  artistNames: string;
+  /** Spotify album page, falling back to the opening track when unknown. */
+  linkUrl: string;
+  tracks: Array<HistoryTrack>;
+};
+
+/**
+ * Identity used to decide whether two adjacent plays belong to the same album.
+ * Album IDs are the real identity; the name/art pair only covers rows written
+ * before we started storing an ID.
+ */
+function albumIdentity(track: HistoryTrack): string {
+  return track.albumId || `${track.albumName}|${track.albumImageUrl}`;
+}
+
+function startRun(track: HistoryTrack): AlbumPlayRun {
+  return {
+    albumId: track.albumId,
+    albumImageUrl: track.albumImageUrl,
+    albumName: track.albumName,
+    artistNames: track.artistNames,
+    key: `${track.playedAt}-${track.trackId}`,
+    linkUrl: track.albumUrl || track.url,
+    tracks: [track],
+  };
+}
+
+/**
+ * Collapses temporally adjacent plays of one album into a single run.
+ *
+ * Listening to an album start to finish otherwise paints the same cover across
+ * ten grid cells. Runs are purely positional: only plays that sit next to each
+ * other in the list merge, so the same album listened to twice in a day stays
+ * two runs.
+ *
+ * Callers pass the accumulated track list for one date section. Because
+ * infinite scroll appends to that list before grouping runs, a run that
+ * straddles a page boundary merges into one; because each date section groups
+ * separately, a run never spans "Today" into "This week".
+ */
+export function groupAdjacentAlbumPlays(tracks: Array<HistoryTrack>): Array<AlbumPlayRun> {
+  const runs: Array<AlbumPlayRun> = [];
+  let currentIdentity: string | null = null;
+
+  for (const track of tracks) {
+    const identity = albumIdentity(track);
+    const currentRun = runs.at(-1);
+
+    if (currentRun && identity === currentIdentity) {
+      currentRun.tracks.push(track);
+      continue;
+    }
+
+    currentIdentity = identity;
+    runs.push(startRun(track));
+  }
+
+  return runs;
+}

--- a/package.json
+++ b/package.json
@@ -27,5 +27,5 @@
     "clean": "rm -f .env .env.tmp",
     "preinstall": "npx only-allow pnpm"
   },
-  "version": "2.65.0"
+  "version": "2.66.0"
 }

--- a/packages/services/spotify/fetchMusicHistoryPage.ts
+++ b/packages/services/spotify/fetchMusicHistoryPage.ts
@@ -15,8 +15,11 @@ import { fetchTrackDisplayData, type TrackDisplayData } from './trackMetadataSin
  * Uses valibot for schema definition and runtime validation.
  */
 export const historyTrackSchema = v.object({
+  albumId: v.string(),
   albumImageUrl: v.string(),
   albumName: v.string(),
+  /** Spotify album page, empty when we never captured one. */
+  albumUrl: v.string(),
   artistNames: v.string(),
   playedAt: v.string(),
   trackId: v.string(),
@@ -186,8 +189,10 @@ function toHistoryTrack(
   const artistNames = sortedArtists.map((a) => a.name).join(', ');
 
   return v.parse(historyTrackSchema, {
+    albumId: cached.album.id,
     albumImageUrl: cached.album.imageUrl,
     albumName: cached.album.name,
+    albumUrl: cached.album.url ?? '',
     artistNames,
     playedAt: playedAt.toISOString(),
     trackId: cached.track.id,
@@ -206,8 +211,10 @@ function displayDataToHistoryTrack(data: TrackDisplayData, playedAt: Date): Hist
     .join(', ');
 
   return v.parse(historyTrackSchema, {
+    albumId: data.album.id,
     albumImageUrl: data.album.imageUrl,
     albumName: data.album.name,
+    albumUrl: data.album.url,
     artistNames,
     playedAt: playedAt.toISOString(),
     trackId: data.track.id,


### PR DESCRIPTION
# What changed?

Listening to an album start to finish rendered one tile per play, so the same cover repeated ten or more times in a row and the grid looked broken. Consecutive plays of one album now collapse into a single grid cell drawn as a stack of sleeves.

- `groupAdjacentAlbumPlays` (new, tested) turns a section's plays into runs. **A run is a maximal set of temporally adjacent plays sharing an album ID** — purely positional, so the same album listened to twice in a day stays two stacks. Grouping runs over the accumulated track list inside each date section, which means a run straddling an infinite-scroll page boundary merges into one stack instead of splitting, and a run never spans "Today" into "This week" (a play belongs to exactly one section, so a merged stack would have to lie about when it happened).
- `AlbumStack` (new) draws up to three sleeves — the run length hints at depth but never renders more than three. Sleeves share the front cover's border radius, card shadow, and bouncy hover transition, fan up and to the right with a slight tilt, and mix the page background into the sleeves behind so they recede in both light and dark. The whole stack is inscribed in its cell, so nothing collides with neighbours at any breakpoint. Hovering or focusing spreads the fan wider alongside the existing scale.
- A glass chip on the cover surfaces the play count ("12 tracks"). One link target per stack, pointing at the **album** rather than any single track — a follow-up will make album clicks navigate in-app. The tooltip, `aria-label`, and front-cover alt text all name the album, artists, and count; the sleeves behind are `aria-hidden`.
- `HistoryTrack` gained `albumId` and `albumUrl` so grouping keys off real album identity instead of a name string, and so the stack has an album to link to.

Single-track cells are untouched and still link to the track.

# Verification

`turbo check`, `turbo check:types`, and `turbo test` are green for `@dg/web`, `@dg/ui`, and `@dg/services`. Verified in a browser against real listening history at 1280 and 390 widths in both light and dark, including scrolling far enough to load several more pages: a run that crossed a page boundary grew from 8 to 11 tracks in place rather than splitting into two stacks. Sticky section headers, the sticky fade, and page transitions in and out of `/music` are unchanged.

Screenshots are in the agent store under `media/album-stacks-*.png`.

# Release info

- [ ] Major
- [x] Minor
- [ ] Patch

Made with [Cursor](https://cursor.com)