### PR TITLE
Add Cursor link to the site footer

### DIFF
--- a/apps/web/src/app/layouts/Footer.tsx
+++ b/apps/web/src/app/layouts/Footer.tsx
@@ -14,7 +14,7 @@ import { Suspense } from 'react';
 import { interactiveRedesign } from '../../flags';
 import { getFooterLinks } from '../../services/contentful';
 import { getAppVersionInfo } from '../../services/version';
-import { FOOTER_ICON_FONT_SIZE } from './footerIconSize';
+import { FOOTER_ICON_DESKTOP_FONT_SIZE, FOOTER_ICON_FONT_SIZE } from './footerIconSize';
 import { MusicFooterMenu } from './MusicFooterMenu';
 import { isFavoriteAlbumsFooterUrl } from './musicFooterDestinations';
 
@@ -25,7 +25,7 @@ const navItemNoPaddingSx: SxObject = {
 const getFooterLinkSx = (hasIcon: boolean): SxObject => ({
   alignItems: 'center',
   display: 'flex',
-  fontSize: hasIcon ? FOOTER_ICON_FONT_SIZE : undefined,
+  fontSize: hasIcon ? { sm: FOOTER_ICON_DESKTOP_FONT_SIZE, xs: FOOTER_ICON_FONT_SIZE } : undefined,
   justifyContent: 'center',
   // Slightly tighter on mobile so an extra icon still fits; 36px is below the
   // ideal 44px a11y target (desktop stays at 40, already a trade-off).
@@ -48,28 +48,43 @@ const dividerSx: SxObject = {
 };
 
 const footerNavSx: SxObject = {
-  alignItems: { sm: 'center', xs: 'stretch' },
-  columnGap: 3,
-  flexDirection: { sm: 'row', xs: 'column-reverse' },
-  flexWrap: 'wrap-reverse',
+  alignItems: 'stretch',
+  flexDirection: 'column',
+  rowGap: 1,
 };
 
-const footerNavGroupSx: SxObject = {
-  columnGap: 2,
+const footerLinksGroupSx: SxObject = {
+  alignItems: 'stretch',
+  flexDirection: 'column',
+  height: 'auto',
+  rowGap: 1,
+  width: '100%',
 };
 
 const footerLinkListSx: SxObject = {
+  justifyContent: 'flex-start',
   margin: 0,
   padding: 0,
+  width: '100%',
 };
 
 const footerIconLinkListSx: SxObject = {
-  flex: 1,
   justifyContent: 'space-between',
   margin: 0,
-  // Pull further into container padding on mobile so the extra icon fits.
-  marginLeft: { sm: -2.5, xs: -3 },
-  marginRight: { sm: -1.5, xs: -2 },
+  padding: 0,
+  width: '100%',
+};
+
+const footerMetaSx: SxObject = {
+  columnGap: 1.5,
+  flexGrow: 0,
+  height: 'auto',
+  justifyContent: 'flex-start',
+  rowGap: 0.5,
+  width: '100%',
+};
+
+const footerMetaItemSx: SxObject = {
   padding: 0,
 };
 
@@ -115,14 +130,12 @@ export async function RedesignBadge() {
     return null;
   }
   return (
-    <>
-      <NavItem sx={navItemNoPaddingSx}>•</NavItem>
-      <NavItem>
-        <Typography color="text.secondary" component="span" variant="caption">
-          redesign on
-        </Typography>
-      </NavItem>
-    </>
+    <NavItem sx={footerMetaItemSx}>
+      •{' '}
+      <Typography color="text.secondary" component="span" variant="caption">
+        redesign on
+      </Typography>
+    </NavItem>
   );
 }
 
@@ -145,57 +158,13 @@ export async function Footer() {
         <Box component="footer" sx={siteFooterSx}>
           <Divider sx={dividerSx} />
           <Nav sx={footerNavSx}>
-            <NavGroup>
-              <NavItem>© {currentYear} Dylan Gattey</NavItem>
-              {version ? (
-                <>
-                  <NavItem sx={navItemNoPaddingSx}>•</NavItem>
-                  <NavItem>
-                    {releaseUrl ? (
-                      <Link
-                        aria-label={`GitHub release ${version}`}
-                        color="inherit"
-                        href={releaseUrl}
-                        isExternal
-                        title={`GitHub release ${version}`}
-                        variant="caption"
-                      >
-                        {version}
-                      </Link>
-                    ) : (
-                      version
-                    )}
-                  </NavItem>
-                </>
-              ) : null}
-              <Suspense fallback={null}>
-                <RedesignBadge />
-              </Suspense>
-              {process.env.NODE_ENV !== 'production' ? (
-                <>
-                  <NavItem sx={navItemNoPaddingSx}>•</NavItem>
-                  <NavItem>
-                    <Link
-                      aria-label="Developer tools"
-                      color="inherit"
-                      forcePageNavigation
-                      href={devConsoleRoute}
-                      title="Developer tools"
-                      variant="caption"
-                    >
-                      Dev console
-                    </Link>
-                  </NavItem>
-                </>
-              ) : null}
-            </NavGroup>
-            <NavGroup component="div" sx={footerNavGroupSx}>
-              <Stack component="ul" direction="row" sx={footerLinkListSx}>
-                {nonIconFooterLinks?.map((link) => (
-                  <FooterLink key={link.url} link={link} />
-                ))}
-              </Stack>
-              <Stack component="ul" direction="row" sx={footerIconLinkListSx}>
+            <NavGroup component="div" sx={footerLinksGroupSx}>
+              <Stack
+                aria-label="Footer icon links"
+                component="ul"
+                direction="row"
+                sx={footerIconLinkListSx}
+              >
                 {iconFooterLinks?.map((link) =>
                   isFavoriteAlbumsFooterUrl(link.url) ? (
                     <MusicFooterMenu icon={link.icon} key={link.url} />
@@ -204,6 +173,58 @@ export async function Footer() {
                   ),
                 )}
               </Stack>
+              {nonIconFooterLinks.length > 0 ? (
+                <Stack
+                  aria-label="Footer text links"
+                  component="ul"
+                  direction="row"
+                  sx={footerLinkListSx}
+                >
+                  {nonIconFooterLinks.map((link) => (
+                    <FooterLink key={link.url} link={link} />
+                  ))}
+                </Stack>
+              ) : null}
+            </NavGroup>
+            <NavGroup aria-label="Site information" sx={footerMetaSx}>
+              <NavItem sx={footerMetaItemSx}>© {currentYear} Dylan Gattey</NavItem>
+              {version ? (
+                <NavItem sx={footerMetaItemSx}>
+                  •{' '}
+                  {releaseUrl ? (
+                    <Link
+                      aria-label={`GitHub release ${version}`}
+                      color="inherit"
+                      href={releaseUrl}
+                      isExternal
+                      title={`GitHub release ${version}`}
+                      variant="caption"
+                    >
+                      {version}
+                    </Link>
+                  ) : (
+                    version
+                  )}
+                </NavItem>
+              ) : null}
+              <Suspense fallback={null}>
+                <RedesignBadge />
+              </Suspense>
+              {process.env.NODE_ENV !== 'production' ? (
+                <NavItem sx={footerMetaItemSx}>
+                  •{' '}
+                  <Link
+                    aria-label="Developer tools"
+                    color="inherit"
+                    forcePageNavigation
+                    href={devConsoleRoute}
+                    title="Developer tools"
+                    variant="caption"
+                  >
+                    Dev console
+                  </Link>
+                </NavItem>
+              ) : null}
             </NavGroup>
           </Nav>
         </Box>

--- a/apps/web/src/app/layouts/Footer.tsx
+++ b/apps/web/src/app/layouts/Footer.tsx
@@ -27,9 +27,10 @@ const getFooterLinkSx = (hasIcon: boolean): SxObject => ({
   display: 'flex',
   fontSize: hasIcon ? FOOTER_ICON_FONT_SIZE : undefined,
   justifyContent: 'center',
-  minHeight: 40,
-  // Min tap target size
-  minWidth: 40,
+  // Slightly tighter on mobile so an extra icon still fits; 36px is below the
+  // ideal 44px a11y target (desktop stays at 40, already a trade-off).
+  minHeight: { sm: 40, xs: 36 },
+  minWidth: { sm: 40, xs: 36 },
 });
 
 const footerSectionSx: SxObject = {
@@ -66,8 +67,9 @@ const footerIconLinkListSx: SxObject = {
   flex: 1,
   justifyContent: 'space-between',
   margin: 0,
-  marginLeft: -2.5,
-  marginRight: -1.5,
+  // Pull further into container padding on mobile so the extra icon fits.
+  marginLeft: { sm: -2.5, xs: -3 },
+  marginRight: { sm: -1.5, xs: -2 },
   padding: 0,
 };
 

--- a/apps/web/src/app/layouts/Footer.tsx
+++ b/apps/web/src/app/layouts/Footer.tsx
@@ -14,7 +14,7 @@ import { Suspense } from 'react';
 import { interactiveRedesign } from '../../flags';
 import { getFooterLinks } from '../../services/contentful';
 import { getAppVersionInfo } from '../../services/version';
-import { FOOTER_ICON_FONT_SIZE } from './footerIconSize';
+import { FOOTER_ICON_DESKTOP_FONT_SIZE, FOOTER_ICON_FONT_SIZE } from './footerIconSize';
 import { MusicFooterMenu } from './MusicFooterMenu';
 import { isFavoriteAlbumsFooterUrl } from './musicFooterDestinations';
 
@@ -25,7 +25,7 @@ const navItemNoPaddingSx: SxObject = {
 const getFooterLinkSx = (hasIcon: boolean): SxObject => ({
   alignItems: 'center',
   display: 'flex',
-  fontSize: hasIcon ? FOOTER_ICON_FONT_SIZE : undefined,
+  fontSize: hasIcon ? { sm: FOOTER_ICON_DESKTOP_FONT_SIZE, xs: FOOTER_ICON_FONT_SIZE } : undefined,
   justifyContent: 'center',
   // Slightly tighter on mobile so an extra icon still fits; 36px is below the
   // ideal 44px a11y target (desktop stays at 40, already a trade-off).

--- a/apps/web/src/app/layouts/Footer.tsx
+++ b/apps/web/src/app/layouts/Footer.tsx
@@ -14,7 +14,7 @@ import { Suspense } from 'react';
 import { interactiveRedesign } from '../../flags';
 import { getFooterLinks } from '../../services/contentful';
 import { getAppVersionInfo } from '../../services/version';
-import { FOOTER_ICON_DESKTOP_FONT_SIZE, FOOTER_ICON_FONT_SIZE } from './footerIconSize';
+import { FOOTER_ICON_FONT_SIZE } from './footerIconSize';
 import { MusicFooterMenu } from './MusicFooterMenu';
 import { isFavoriteAlbumsFooterUrl } from './musicFooterDestinations';
 
@@ -25,7 +25,7 @@ const navItemNoPaddingSx: SxObject = {
 const getFooterLinkSx = (hasIcon: boolean): SxObject => ({
   alignItems: 'center',
   display: 'flex',
-  fontSize: hasIcon ? { sm: FOOTER_ICON_DESKTOP_FONT_SIZE, xs: FOOTER_ICON_FONT_SIZE } : undefined,
+  fontSize: hasIcon ? FOOTER_ICON_FONT_SIZE : undefined,
   justifyContent: 'center',
   // Slightly tighter on mobile so an extra icon still fits; 36px is below the
   // ideal 44px a11y target (desktop stays at 40, already a trade-off).
@@ -48,43 +48,28 @@ const dividerSx: SxObject = {
 };
 
 const footerNavSx: SxObject = {
-  alignItems: 'stretch',
-  flexDirection: 'column',
-  rowGap: 1,
+  alignItems: { sm: 'center', xs: 'stretch' },
+  columnGap: 3,
+  flexDirection: { sm: 'row', xs: 'column-reverse' },
+  flexWrap: 'wrap-reverse',
 };
 
-const footerLinksGroupSx: SxObject = {
-  alignItems: 'stretch',
-  flexDirection: 'column',
-  height: 'auto',
-  rowGap: 1,
-  width: '100%',
+const footerNavGroupSx: SxObject = {
+  columnGap: 2,
 };
 
 const footerLinkListSx: SxObject = {
-  justifyContent: 'flex-start',
   margin: 0,
   padding: 0,
-  width: '100%',
 };
 
 const footerIconLinkListSx: SxObject = {
+  flex: 1,
   justifyContent: 'space-between',
   margin: 0,
-  padding: 0,
-  width: '100%',
-};
-
-const footerMetaSx: SxObject = {
-  columnGap: 1.5,
-  flexGrow: 0,
-  height: 'auto',
-  justifyContent: 'flex-start',
-  rowGap: 0.5,
-  width: '100%',
-};
-
-const footerMetaItemSx: SxObject = {
+  // Pull further into container padding on mobile so the extra icon fits.
+  marginLeft: { sm: -2.5, xs: -3 },
+  marginRight: { sm: -1.5, xs: -2 },
   padding: 0,
 };
 
@@ -130,12 +115,14 @@ export async function RedesignBadge() {
     return null;
   }
   return (
-    <NavItem sx={footerMetaItemSx}>
-      •{' '}
-      <Typography color="text.secondary" component="span" variant="caption">
-        redesign on
-      </Typography>
-    </NavItem>
+    <>
+      <NavItem sx={navItemNoPaddingSx}>•</NavItem>
+      <NavItem>
+        <Typography color="text.secondary" component="span" variant="caption">
+          redesign on
+        </Typography>
+      </NavItem>
+    </>
   );
 }
 
@@ -158,13 +145,57 @@ export async function Footer() {
         <Box component="footer" sx={siteFooterSx}>
           <Divider sx={dividerSx} />
           <Nav sx={footerNavSx}>
-            <NavGroup component="div" sx={footerLinksGroupSx}>
-              <Stack
-                aria-label="Footer icon links"
-                component="ul"
-                direction="row"
-                sx={footerIconLinkListSx}
-              >
+            <NavGroup>
+              <NavItem>© {currentYear} Dylan Gattey</NavItem>
+              {version ? (
+                <>
+                  <NavItem sx={navItemNoPaddingSx}>•</NavItem>
+                  <NavItem>
+                    {releaseUrl ? (
+                      <Link
+                        aria-label={`GitHub release ${version}`}
+                        color="inherit"
+                        href={releaseUrl}
+                        isExternal
+                        title={`GitHub release ${version}`}
+                        variant="caption"
+                      >
+                        {version}
+                      </Link>
+                    ) : (
+                      version
+                    )}
+                  </NavItem>
+                </>
+              ) : null}
+              <Suspense fallback={null}>
+                <RedesignBadge />
+              </Suspense>
+              {process.env.NODE_ENV !== 'production' ? (
+                <>
+                  <NavItem sx={navItemNoPaddingSx}>•</NavItem>
+                  <NavItem>
+                    <Link
+                      aria-label="Developer tools"
+                      color="inherit"
+                      forcePageNavigation
+                      href={devConsoleRoute}
+                      title="Developer tools"
+                      variant="caption"
+                    >
+                      Dev console
+                    </Link>
+                  </NavItem>
+                </>
+              ) : null}
+            </NavGroup>
+            <NavGroup component="div" sx={footerNavGroupSx}>
+              <Stack component="ul" direction="row" sx={footerLinkListSx}>
+                {nonIconFooterLinks?.map((link) => (
+                  <FooterLink key={link.url} link={link} />
+                ))}
+              </Stack>
+              <Stack component="ul" direction="row" sx={footerIconLinkListSx}>
                 {iconFooterLinks?.map((link) =>
                   isFavoriteAlbumsFooterUrl(link.url) ? (
                     <MusicFooterMenu icon={link.icon} key={link.url} />
@@ -173,58 +204,6 @@ export async function Footer() {
                   ),
                 )}
               </Stack>
-              {nonIconFooterLinks.length > 0 ? (
-                <Stack
-                  aria-label="Footer text links"
-                  component="ul"
-                  direction="row"
-                  sx={footerLinkListSx}
-                >
-                  {nonIconFooterLinks.map((link) => (
-                    <FooterLink key={link.url} link={link} />
-                  ))}
-                </Stack>
-              ) : null}
-            </NavGroup>
-            <NavGroup aria-label="Site information" sx={footerMetaSx}>
-              <NavItem sx={footerMetaItemSx}>© {currentYear} Dylan Gattey</NavItem>
-              {version ? (
-                <NavItem sx={footerMetaItemSx}>
-                  •{' '}
-                  {releaseUrl ? (
-                    <Link
-                      aria-label={`GitHub release ${version}`}
-                      color="inherit"
-                      href={releaseUrl}
-                      isExternal
-                      title={`GitHub release ${version}`}
-                      variant="caption"
-                    >
-                      {version}
-                    </Link>
-                  ) : (
-                    version
-                  )}
-                </NavItem>
-              ) : null}
-              <Suspense fallback={null}>
-                <RedesignBadge />
-              </Suspense>
-              {process.env.NODE_ENV !== 'production' ? (
-                <NavItem sx={footerMetaItemSx}>
-                  •{' '}
-                  <Link
-                    aria-label="Developer tools"
-                    color="inherit"
-                    forcePageNavigation
-                    href={devConsoleRoute}
-                    title="Developer tools"
-                    variant="caption"
-                  >
-                    Dev console
-                  </Link>
-                </NavItem>
-              ) : null}
             </NavGroup>
           </Nav>
         </Box>

--- a/apps/web/src/app/layouts/MusicFooterMenu.tsx
+++ b/apps/web/src/app/layouts/MusicFooterMenu.tsx
@@ -12,11 +12,7 @@ import { Disc3, DiscAlbum, History } from 'lucide-react';
 import { usePathname } from 'next/navigation';
 import type { MouseEvent } from 'react';
 import { useId, useLayoutEffect, useRef, useState } from 'react';
-import {
-  FOOTER_ICON_BASE_PX,
-  FOOTER_ICON_DESKTOP_FONT_SIZE,
-  FOOTER_ICON_FONT_SIZE,
-} from './footerIconSize';
+import { FOOTER_ICON_BASE_PX, FOOTER_ICON_FONT_SIZE } from './footerIconSize';
 import { isMusicDestinationPath, MUSIC_DESTINATIONS } from './musicFooterDestinations';
 
 const MUSIC_LABEL = 'Music';
@@ -30,7 +26,7 @@ const triggerSx: SxObject = {
   alignItems: 'center',
   color: 'secondary.main',
   display: 'flex',
-  fontSize: { sm: FOOTER_ICON_DESKTOP_FONT_SIZE, xs: FOOTER_ICON_FONT_SIZE },
+  fontSize: FOOTER_ICON_FONT_SIZE,
   justifyContent: 'center',
   minHeight: { sm: 40, xs: 36 },
   minWidth: { sm: 40, xs: 36 },

--- a/apps/web/src/app/layouts/MusicFooterMenu.tsx
+++ b/apps/web/src/app/layouts/MusicFooterMenu.tsx
@@ -12,7 +12,11 @@ import { Disc3, DiscAlbum, History } from 'lucide-react';
 import { usePathname } from 'next/navigation';
 import type { MouseEvent } from 'react';
 import { useId, useLayoutEffect, useRef, useState } from 'react';
-import { FOOTER_ICON_BASE_PX, FOOTER_ICON_FONT_SIZE } from './footerIconSize';
+import {
+  FOOTER_ICON_BASE_PX,
+  FOOTER_ICON_DESKTOP_FONT_SIZE,
+  FOOTER_ICON_FONT_SIZE,
+} from './footerIconSize';
 import { isMusicDestinationPath, MUSIC_DESTINATIONS } from './musicFooterDestinations';
 
 const MUSIC_LABEL = 'Music';
@@ -26,7 +30,7 @@ const triggerSx: SxObject = {
   alignItems: 'center',
   color: 'secondary.main',
   display: 'flex',
-  fontSize: FOOTER_ICON_FONT_SIZE,
+  fontSize: { sm: FOOTER_ICON_DESKTOP_FONT_SIZE, xs: FOOTER_ICON_FONT_SIZE },
   justifyContent: 'center',
   minHeight: { sm: 40, xs: 36 },
   minWidth: { sm: 40, xs: 36 },

--- a/apps/web/src/app/layouts/MusicFooterMenu.tsx
+++ b/apps/web/src/app/layouts/MusicFooterMenu.tsx
@@ -28,8 +28,8 @@ const triggerSx: SxObject = {
   display: 'flex',
   fontSize: FOOTER_ICON_FONT_SIZE,
   justifyContent: 'center',
-  minHeight: 40,
-  minWidth: 40,
+  minHeight: { sm: 40, xs: 36 },
+  minWidth: { sm: 40, xs: 36 },
   padding: 0,
 };
 

--- a/apps/web/src/app/layouts/__tests__/Footer.test.tsx
+++ b/apps/web/src/app/layouts/__tests__/Footer.test.tsx
@@ -83,24 +83,13 @@ describe('Footer redesign badge', () => {
       { icon: 'albums', title: 'Favorite albums', url: favoriteAlbumsRoute },
       { icon: 'cursor', title: 'Cursor', url: 'https://cursor.com' },
       { icon: 'github', title: 'GitHub', url: 'https://github.com/dgattey' },
-      { title: 'Privacy', url: '/privacy' },
     ]);
     render(await Footer());
 
-    const iconLinks = screen.getByRole('list', { name: 'Footer icon links' });
-    const textLinks = screen.getByRole('list', { name: 'Footer text links' });
-    const siteInformation = screen.getByRole('list', { name: 'Site information' });
     const cursor = screen.getByRole('link', { name: 'Cursor' });
     const github = screen.getByRole('link', { name: 'GitHub' });
     expect(cursor).toHaveAttribute('href', 'https://cursor.com');
     expect(github).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Privacy' })).toHaveAttribute('href', '/privacy');
-    expect(
-      iconLinks.compareDocumentPosition(textLinks) & Node.DOCUMENT_POSITION_FOLLOWING,
-    ).toBeTruthy();
-    expect(
-      textLinks.compareDocumentPosition(siteInformation) & Node.DOCUMENT_POSITION_FOLLOWING,
-    ).toBeTruthy();
     // Cursor sits immediately left of GitHub in the icon row.
     expect(cursor.compareDocumentPosition(github) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
 

--- a/apps/web/src/app/layouts/__tests__/Footer.test.tsx
+++ b/apps/web/src/app/layouts/__tests__/Footer.test.tsx
@@ -81,11 +81,17 @@ describe('Footer redesign badge', () => {
     mockInteractiveRedesign.mockResolvedValue(false);
     mockGetFooterLinks.mockResolvedValue([
       { icon: 'albums', title: 'Favorite albums', url: favoriteAlbumsRoute },
+      { icon: 'cursor', title: 'Cursor', url: 'https://cursor.com' },
       { icon: 'github', title: 'GitHub', url: 'https://github.com/dgattey' },
     ]);
     render(await Footer());
 
-    expect(screen.getByRole('link', { name: 'GitHub' })).toBeInTheDocument();
+    const cursor = screen.getByRole('link', { name: 'Cursor' });
+    const github = screen.getByRole('link', { name: 'GitHub' });
+    expect(cursor).toHaveAttribute('href', 'https://cursor.com');
+    expect(github).toBeInTheDocument();
+    // Cursor sits immediately left of GitHub in the icon row.
+    expect(cursor.compareDocumentPosition(github) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
 
     await user.click(screen.getByRole('button', { name: 'Music' }));
     expect(screen.getByRole('link', { name: 'Favorite albums' })).toHaveAttribute(

--- a/apps/web/src/app/layouts/__tests__/Footer.test.tsx
+++ b/apps/web/src/app/layouts/__tests__/Footer.test.tsx
@@ -83,13 +83,24 @@ describe('Footer redesign badge', () => {
       { icon: 'albums', title: 'Favorite albums', url: favoriteAlbumsRoute },
       { icon: 'cursor', title: 'Cursor', url: 'https://cursor.com' },
       { icon: 'github', title: 'GitHub', url: 'https://github.com/dgattey' },
+      { title: 'Privacy', url: '/privacy' },
     ]);
     render(await Footer());
 
+    const iconLinks = screen.getByRole('list', { name: 'Footer icon links' });
+    const textLinks = screen.getByRole('list', { name: 'Footer text links' });
+    const siteInformation = screen.getByRole('list', { name: 'Site information' });
     const cursor = screen.getByRole('link', { name: 'Cursor' });
     const github = screen.getByRole('link', { name: 'GitHub' });
     expect(cursor).toHaveAttribute('href', 'https://cursor.com');
     expect(github).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Privacy' })).toHaveAttribute('href', '/privacy');
+    expect(
+      iconLinks.compareDocumentPosition(textLinks) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      textLinks.compareDocumentPosition(siteInformation) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
     // Cursor sits immediately left of GitHub in the icon row.
     expect(cursor.compareDocumentPosition(github) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
 

--- a/apps/web/src/app/layouts/footerIconSize.ts
+++ b/apps/web/src/app/layouts/footerIconSize.ts
@@ -4,5 +4,8 @@
  */
 export const FOOTER_ICON_FONT_SIZE = '1.25em';
 
+/** Slightly larger footer icon size from the small breakpoint upward. */
+export const FOOTER_ICON_DESKTOP_FONT_SIZE = '1.4em';
+
 /** Caption size in px — the font-size under footer icon links / menu labels. */
 export const FOOTER_ICON_BASE_PX = 14;

--- a/apps/web/src/app/layouts/footerIconSize.ts
+++ b/apps/web/src/app/layouts/footerIconSize.ts
@@ -4,8 +4,5 @@
  */
 export const FOOTER_ICON_FONT_SIZE = '1.25em';
 
-/** Slightly larger footer icon size from the small breakpoint upward. */
-export const FOOTER_ICON_DESKTOP_FONT_SIZE = '1.4em';
-
 /** Caption size in px — the font-size under footer icon links / menu labels. */
 export const FOOTER_ICON_BASE_PX = 14;

--- a/apps/web/src/app/layouts/footerIconSize.ts
+++ b/apps/web/src/app/layouts/footerIconSize.ts
@@ -1,8 +1,11 @@
+/** Caption size in px — the font-size under footer icon links / menu labels. */
+export const FOOTER_ICON_BASE_PX = 14;
+
 /**
  * Footer icon links set this font-size; lucide icons use `1em` so they resolve
  * against it. Equals caption (14px) × 1.25.
  */
 export const FOOTER_ICON_FONT_SIZE = '1.25em';
 
-/** Caption size in px — the font-size under footer icon links / menu labels. */
-export const FOOTER_ICON_BASE_PX = 14;
+/** Exact 18px footer icon size from the small breakpoint upward. */
+export const FOOTER_ICON_DESKTOP_FONT_SIZE = `${18 / FOOTER_ICON_BASE_PX}em`;

--- a/package.json
+++ b/package.json
@@ -27,5 +27,5 @@
     "clean": "rm -f .env .env.tmp",
     "preinstall": "npx only-allow pnpm"
   },
-  "version": "2.63.11"
+  "version": "2.64.0"
 }

--- a/packages/ui/dependent/Link.tsx
+++ b/packages/ui/dependent/Link.tsx
@@ -91,11 +91,36 @@ type LinkProps = BaseLinkProps &
   ({ isButton: true; buttonProps?: ButtonProps<'a'> } | { isButton?: false; buttonProps?: never });
 
 /**
+ * Official Cursor cube mark (simple-icons / cursor brand), sized like FaIcon
+ * peers so footer icons share caption color via currentColor.
+ */
+function CursorIcon({ size = '1em' }: { size?: string }) {
+  return (
+    <span
+      aria-hidden
+      style={{
+        display: 'inline-flex',
+        height: size,
+        width: size,
+      }}
+    >
+      {/* Decorative: parent Link provides aria-label / tooltip title */}
+      {/* biome-ignore lint/a11y/noSvgWithoutTitle: decorative peer to FaIcon */}
+      <svg fill="currentColor" height={size} viewBox="0 0 24 24" width={size}>
+        <path d="M11.503.131 1.891 5.678a.84.84 0 0 0-.42.726v11.188c0 .3.162.575.42.724l9.609 5.55a1 1 0 0 0 .998 0l9.61-5.55a.84.84 0 0 0 .42-.724V6.404a.84.84 0 0 0-.42-.726L12.497.131a1.01 1.01 0 0 0-.996 0M2.657 6.338h18.55c.263 0 .43.287.297.515L12.23 22.918c-.062.107-.229.064-.229-.06V12.335a.59.59 0 0 0-.295-.51l-9.11-5.257c-.109-.063-.064-.23.061-.23" />
+      </svg>
+    </span>
+  );
+}
+
+/**
  * All built in mappings for icon name to element. Brand marks come from Font
  * Awesome since lucide-react v1 dropped brand icons for trademark reasons.
+ * Cursor is not in FA; map the Contentful `icon: "cursor"` string the same way.
  */
 const BUILT_IN_ICONS: Record<string, React.ReactNode> = {
   albums: <Disc3 size="1em" />,
+  cursor: <CursorIcon />,
   email: <Send size="1em" />,
   github: <FaIcon icon={faGithub} />,
   instagram: <FaIcon icon={faInstagram} />,


### PR DESCRIPTION
## Summary
- Adds a Contentful-driven Cursor footer icon immediately left of GitHub (`icon: "cursor"` → `BUILT_IN_ICONS`), using the official cube mark with `currentColor` so it matches peer brand icons.
- Links Cursor to Dylan's public profile at https://cursor.com/@dyl (verified HTTP 200 and published in Contentful entry `3OplR5LChrkZ7tvGUCg3zn`).
- Keeps the established desktop footer layout: site metadata on the left and icon links on the right.
- Sets icons to exactly 18px at `sm+`; mobile remains 17.5px with the tightened 36px targets/margins.

## Test plan
- [x] `turbo check` / `check:types` / `test` for `@dg/web` + `@dg/ui`
- [x] Browser computed size: 18px at 1280, 17.5px at 390
- [x] Browser href: `https://cursor.com/@dyl`
- [x] Cursor remains immediately left of Github

# Release info

- [ ] Major
- [x] Minor
- [ ] Patch