### PR TITLE
Make the color scheme picker a vertical collapsible glass control

### DIFF
--- a/apps/web/src/app/home/__tests__/Homepage.test.tsx
+++ b/apps/web/src/app/home/__tests__/Homepage.test.tsx
@@ -69,19 +69,14 @@ describe('Homepage basics', () => {
 
     expect(screen.getByText('About me')).toBeInTheDocument();
 
+    // The picker is collapsed until its trigger is pressed
+    await user.click(screen.getByRole('button', { name: 'Color scheme: system' }));
+
     const themePicker = screen.getByRole('radiogroup', {
       name: 'Choose color scheme',
     });
-    const radios = within(themePicker).getAllByRole('radio', { hidden: true });
-    const darkRadio = radios.find(
-      (radio) => radio instanceof HTMLInputElement && radio.value === 'dark',
-    );
+    await user.click(within(themePicker).getByRole('radio', { name: 'Dark' }));
 
-    if (!darkRadio) {
-      throw new Error('Dark color option not found');
-    }
-
-    await user.click(darkRadio);
     expect(mockSetPreference).toHaveBeenCalledWith('dark');
   });
 });

--- a/package.json
+++ b/package.json
@@ -27,5 +27,5 @@
     "clean": "rm -f .env .env.tmp",
     "preinstall": "npx only-allow pnpm"
   },
-  "version": "2.64.0"
+  "version": "2.65.0"
 }

--- a/packages/ui/core/ColorSchemeToggleClient.tsx
+++ b/packages/ui/core/ColorSchemeToggleClient.tsx
@@ -1,39 +1,338 @@
 'use client';
 
-import { Monitor, Moon, Sun } from 'lucide-react';
+import { Box, Typography } from '@mui/material';
+import { ChevronUp, Monitor, Moon, Sun } from 'lucide-react';
+import type { ChangeEvent, FocusEvent, KeyboardEvent, ReactNode } from 'react';
+import { useEffect, useId, useRef, useState } from 'react';
+import { createBouncyTransition } from '../helpers/bouncyTransition';
+import { createTransition, TIMING_MEDIUM, TIMING_SLOW } from '../helpers/timing';
+import type { SxObject } from '../theme';
 import { type ColorSchemePreference, parseColorSchemePreference } from '../theme/colorScheme';
 import { useColorScheme } from '../theme/useColorScheme';
-import { GlassSwitcher } from './GlassSwitcher';
+import { MouseAwareGlassContainer } from './MouseAwareGlassContainer';
 
-const ICON_SIZE = 18;
+const ICON_SIZE = 22;
 
-const ICONS: Record<ColorSchemePreference, React.ReactNode> = {
-  dark: <Moon size={ICON_SIZE} />,
-  light: <Sun size={ICON_SIZE} />,
-  system: <Monitor size={ICON_SIZE} />,
-} as const;
+/**
+ * Row geometry in px. Collapsed, the control is one padded row — a glass
+ * circle. Expanded, it keeps that row as the disclosure toggle and grows down
+ * and to the left to fit one row per scheme.
+ */
+const ROW_HEIGHT = 48;
+const ROW_GAP = 4;
+const PANEL_PADDING = 8;
+const COLLAPSED_SIZE = ROW_HEIGHT + PANEL_PADDING * 2;
+const EXPANDED_WIDTH = 176;
 
-const LABELS: Record<ColorSchemePreference, string> = {
-  dark: 'Use dark color mode',
-  light: 'Use light color mode',
-  system: 'Use system color mode',
-} as const;
+interface SchemeOption {
+  icon: ReactNode;
+  label: string;
+  value: ColorSchemePreference;
+}
 
-const STATIC_OPTIONS = [
-  { icon: ICONS.light, label: LABELS.light, value: 'light' },
-  { icon: ICONS.dark, label: LABELS.dark, value: 'dark' },
-  { icon: ICONS.system, label: LABELS.system, value: 'system' },
-];
+const OPTIONS = [
+  { icon: <Sun size={ICON_SIZE} />, label: 'Light', value: 'light' },
+  { icon: <Moon size={ICON_SIZE} />, label: 'Dark', value: 'dark' },
+  { icon: <Monitor size={ICON_SIZE} />, label: 'System', value: 'system' },
+] as const satisfies ReadonlyArray<SchemeOption>;
 
+const EXPANDED_HEIGHT =
+  PANEL_PADDING * 2 + ROW_HEIGHT * (OPTIONS.length + 1) + ROW_GAP * OPTIONS.length;
+
+/** Arrow keys move through the group in either axis, matching native radios. */
+const ARROW_STEPS: Record<string, number | undefined> = {
+  ArrowDown: 1,
+  ArrowLeft: -1,
+  ArrowRight: 1,
+  ArrowUp: -1,
+};
+
+const REDUCED_MOTION = '@media (prefers-reduced-motion: reduce)';
+
+/** Reserves the collapsed footprint so expanding never reflows the header. */
+const anchorSx: SxObject = {
+  display: 'block',
+  height: COLLAPSED_SIZE,
+  position: 'relative',
+  width: COLLAPSED_SIZE,
+};
+
+/**
+ * The glass surface itself. Absolutely positioned out of the header's flow so
+ * the expanded panel hangs below the sticky bar instead of stretching it, and
+ * anchored to the right edge so it grows inward, away from the viewport edge.
+ */
+function createPanelSx(isOpen: boolean): SxObject {
+  return {
+    [REDUCED_MOTION]: { transition: 'none' },
+    height: isOpen ? EXPANDED_HEIGHT : COLLAPSED_SIZE,
+    overflow: 'hidden',
+    position: 'absolute',
+    right: 0,
+    top: 0,
+    width: isOpen ? EXPANDED_WIDTH : COLLAPSED_SIZE,
+    zIndex: 1,
+    ...createBouncyTransition(
+      ['background-color', 'border-color', 'box-shadow', 'height', 'width'],
+      TIMING_SLOW,
+    ),
+  };
+}
+
+const triggerSx: SxObject = {
+  '& svg': {
+    ...createBouncyTransition('scale'),
+    display: 'block',
+  },
+  '&:hover': {
+    color: 'var(--mui-palette-primary-light)',
+  },
+  '&:hover svg': {
+    scale: 1.2,
+  },
+  alignItems: 'center',
+  appearance: 'none',
+  background: 'none',
+  border: 'none',
+  borderRadius: '999px',
+  color: 'var(--mui-palette-primary-main)',
+  cursor: 'pointer',
+  display: 'flex',
+  height: ROW_HEIGHT,
+  justifyContent: 'center',
+  left: PANEL_PADDING,
+  padding: 0,
+  position: 'absolute',
+  right: PANEL_PADDING,
+  top: PANEL_PADDING,
+};
+
+/**
+ * Collapsed, the list is invisible rather than unmounted so both directions
+ * animate. `visibility` also takes it out of the accessibility tree and out of
+ * the tab order, and `inert` keeps pointer and focus events off it.
+ */
+function createListSx(isOpen: boolean): SxObject {
+  return {
+    [REDUCED_MOTION]: { transition: 'none' },
+    display: 'grid',
+    left: PANEL_PADDING,
+    opacity: isOpen ? 1 : 0,
+    position: 'absolute',
+    right: PANEL_PADDING,
+    rowGap: `${ROW_GAP}px`,
+    top: PANEL_PADDING + ROW_HEIGHT + ROW_GAP,
+    transform: isOpen ? 'none' : `translateY(-${ROW_HEIGHT / 4}px)`,
+    transition: `${createTransition(['opacity', 'transform'], TIMING_MEDIUM)}, visibility 0s linear ${isOpen ? 0 : TIMING_MEDIUM}ms`,
+    visibility: isOpen ? 'visible' : 'hidden',
+  };
+}
+
+/** Sliding highlight behind the selected row, echoing the albums sorter thumb. */
+function createThumbSx(selectedIndex: number): SxObject {
+  return {
+    [REDUCED_MOTION]: { transition: 'none' },
+    backgroundColor: 'var(--mui-palette-action-selected)',
+    border: '1px solid color-mix(in srgb, var(--mui-palette-primary-main) 30%, transparent)',
+    borderRadius: '999px',
+    height: ROW_HEIGHT,
+    left: 0,
+    position: 'absolute',
+    right: 0,
+    top: 0,
+    transform: `translateY(${selectedIndex * (ROW_HEIGHT + ROW_GAP)}px)`,
+    transition: createTransition(['background-color', 'transform'], TIMING_MEDIUM),
+    zIndex: 0,
+  };
+}
+
+const optionSx: SxObject = {
+  '& svg': {
+    ...createBouncyTransition('scale'),
+    display: 'block',
+  },
+  '&:has(input:focus-visible)': {
+    outline: '-webkit-focus-ring-color auto 1px',
+  },
+  '&:hover': {
+    color: 'var(--mui-palette-primary-light)',
+  },
+  '&:hover svg': {
+    scale: 1.2,
+  },
+  alignItems: 'center',
+  borderRadius: '999px',
+  color: 'var(--mui-palette-primary-main)',
+  cursor: 'pointer',
+  display: 'grid',
+  gridTemplateColumns: `${ROW_HEIGHT}px 1fr`,
+  height: ROW_HEIGHT,
+  position: 'relative',
+  zIndex: 1,
+};
+
+/**
+ * Stretched over its row so the whole row is the tap target, and kept at zero
+ * opacity rather than `display: none` so it stays focusable and announced.
+ */
+const inputSx: SxObject = {
+  appearance: 'none',
+  cursor: 'pointer',
+  inset: 0,
+  margin: 0,
+  opacity: 0,
+  position: 'absolute',
+};
+
+const iconCellSx: SxObject = {
+  display: 'grid',
+  placeItems: 'center',
+};
+
+const optionLabelSx: SxObject = {
+  lineHeight: 1.2,
+  paddingInlineEnd: 1.5,
+  whiteSpace: 'nowrap',
+};
+
+/**
+ * Color scheme picker: a glass circle showing the active scheme that expands
+ * into a vertical radio group of light, dark, and system.
+ *
+ * Click or tap the circle to open; picking a scheme, clicking away, tabbing
+ * out, or pressing Escape closes it again. Hover deliberately does not open it,
+ * since the rows would land under the cursor and invite an accidental change.
+ */
 export function ColorSchemeToggleClient() {
   const { preference, setPreference } = useColorScheme();
+  const [isOpen, setIsOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const listId = useId();
+  // Unique radio name so a second picker on the page can't join this group
+  const radioGroupName = useId();
+
+  const matchedIndex = OPTIONS.findIndex((option) => option.value === preference);
+  const selectedIndex = matchedIndex === -1 ? 0 : matchedIndex;
+  const selectedOption = OPTIONS[selectedIndex] ?? OPTIONS[0];
+
+  // Focus lands on the selected row when the list opens, wherever it opened from
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    listRef.current?.querySelector<HTMLInputElement>('input:checked')?.focus();
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    const closeOnOutsidePress = (event: PointerEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener('pointerdown', closeOnOutsidePress);
+    return () => {
+      document.removeEventListener('pointerdown', closeOnOutsidePress);
+    };
+  }, [isOpen]);
+
+  const collapse = () => {
+    setIsOpen(false);
+    triggerRef.current?.focus();
+  };
+
+  const handleRootKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (isOpen && event.key === 'Escape') {
+      event.preventDefault();
+      collapse();
+    }
+  };
+
+  /**
+   * Arrows and Home/End change the scheme in place so the page previews it
+   * without the list snapping shut; Enter commits and closes.
+   */
+  const handleListKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      collapse();
+      return;
+    }
+    const step = ARROW_STEPS[event.key];
+    const nextIndex =
+      event.key === 'Home'
+        ? 0
+        : event.key === 'End'
+          ? OPTIONS.length - 1
+          : step === undefined
+            ? -1
+            : (selectedIndex + step + OPTIONS.length) % OPTIONS.length;
+    const nextOption = nextIndex === -1 ? undefined : OPTIONS[nextIndex];
+    if (!nextOption) {
+      return;
+    }
+    event.preventDefault();
+    setPreference(nextOption.value);
+    listRef.current?.querySelectorAll<HTMLInputElement>('input[type="radio"]')[nextIndex]?.focus();
+  };
+
+  const handleFocusOut = (event: FocusEvent<HTMLDivElement>) => {
+    if (isOpen && !event.currentTarget.contains(event.relatedTarget)) {
+      setIsOpen(false);
+    }
+  };
 
   return (
-    <GlassSwitcher
-      aria-label="Choose color scheme"
-      onChange={(value) => setPreference(parseColorSchemePreference(value))}
-      options={STATIC_OPTIONS}
-      value={preference}
-    />
+    <Box onBlur={handleFocusOut} onKeyDown={handleRootKeyDown} ref={rootRef} sx={anchorSx}>
+      <MouseAwareGlassContainer gravity={{ maxTilt: 1.5, radius: 180 }} sx={createPanelSx(isOpen)}>
+        <Box
+          aria-controls={listId}
+          aria-expanded={isOpen}
+          aria-label={`Color scheme: ${selectedOption.label.toLowerCase()}`}
+          component="button"
+          onClick={() => (isOpen ? collapse() : setIsOpen(true))}
+          ref={triggerRef}
+          sx={triggerSx}
+          type="button"
+        >
+          {isOpen ? <ChevronUp size={ICON_SIZE} /> : selectedOption.icon}
+        </Box>
+        <Box
+          aria-label="Choose color scheme"
+          id={listId}
+          inert={!isOpen}
+          onKeyDown={handleListKeyDown}
+          ref={listRef}
+          role="radiogroup"
+          sx={createListSx(isOpen)}
+        >
+          <Box sx={createThumbSx(selectedIndex)} />
+          {OPTIONS.map((option) => (
+            <Box component="label" key={option.value} sx={optionSx}>
+              <Box
+                checked={option.value === preference}
+                component="input"
+                name={radioGroupName}
+                onChange={(event: ChangeEvent<HTMLInputElement>) => {
+                  setPreference(parseColorSchemePreference(event.target.value));
+                  collapse();
+                }}
+                sx={inputSx}
+                type="radio"
+                value={option.value}
+              />
+              <Box sx={iconCellSx}>{option.icon}</Box>
+              <Typography component="span" sx={optionLabelSx} variant="caption">
+                {option.label}
+              </Typography>
+            </Box>
+          ))}
+        </Box>
+      </MouseAwareGlassContainer>
+    </Box>
   );
 }

--- a/packages/ui/core/__tests__/ColorSchemeToggleClient.test.tsx
+++ b/packages/ui/core/__tests__/ColorSchemeToggleClient.test.tsx
@@ -1,18 +1,19 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { COLOR_SCHEME_ATTRIBUTE, COLOR_SCHEME_STORAGE_KEY } from '../../theme/colorScheme';
 import { ColorSchemeToggleClient } from '../ColorSchemeToggleClient';
 
-const findRadioByValue = (value: string) => {
-  const radios = screen.getAllByRole('radio', { hidden: true });
-  const match = radios.find(
-    (radio): radio is HTMLInputElement =>
-      radio instanceof HTMLInputElement && radio.value === value,
-  );
-  if (!match) {
-    throw new Error(`Radio option "${value}" not found`);
-  }
-  return match;
+const getTrigger = () => screen.getByRole('button', { name: /^color scheme:/i });
+
+const getGroup = () => screen.getByRole('radiogroup', { name: 'Choose color scheme' });
+
+const getOption = (name: string) => within(getGroup()).getByRole('radio', { name });
+
+const openPicker = async (user: ReturnType<typeof userEvent.setup>) => {
+  await user.click(getTrigger());
+  await waitFor(() => {
+    expect(getTrigger()).toHaveAttribute('aria-expanded', 'true');
+  });
 };
 
 describe('ColorSchemeToggleClient', () => {
@@ -26,28 +27,48 @@ describe('ColorSchemeToggleClient', () => {
     jest.restoreAllMocks();
   });
 
-  it('reads an explicit preference from the root attribute', async () => {
+  it('collapses to a single button that announces the current scheme', () => {
     document.documentElement.setAttribute(COLOR_SCHEME_ATTRIBUTE, 'dark');
 
     render(<ColorSchemeToggleClient />);
 
-    await waitFor(() => {
-      expect(findRadioByValue('dark')).toBeChecked();
-    });
+    expect(getTrigger()).toHaveAccessibleName('Color scheme: dark');
+    expect(getTrigger()).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByRole('radiogroup')).not.toBeInTheDocument();
+    expect(screen.getByRole('radiogroup', { hidden: true })).toHaveAttribute('inert');
   });
 
-  it('persists and applies an explicit preference', async () => {
+  it('expands to the full scheme list and marks the current one', async () => {
+    const user = userEvent.setup();
+    document.documentElement.setAttribute(COLOR_SCHEME_ATTRIBUTE, 'dark');
+
+    render(<ColorSchemeToggleClient />);
+    await openPicker(user);
+
+    const group = getGroup();
+    expect(group).not.toHaveAttribute('inert');
+    expect(within(group).getAllByRole('radio')).toHaveLength(3);
+    await waitFor(() => {
+      expect(getOption('Dark')).toBeChecked();
+    });
+    expect(getOption('Dark')).toHaveFocus();
+  });
+
+  it('persists and applies an explicit preference, then collapses', async () => {
     const user = userEvent.setup();
 
     render(<ColorSchemeToggleClient />);
+    await openPicker(user);
+    await user.click(getOption('Dark'));
 
-    await user.click(findRadioByValue('dark'));
     await waitFor(() => {
       expect(document.documentElement).toHaveAttribute(COLOR_SCHEME_ATTRIBUTE, 'dark');
       expect(document.documentElement.style.colorScheme).toBe('dark');
       expect(localStorage.getItem(COLOR_SCHEME_STORAGE_KEY)).toBe('dark');
-      expect(findRadioByValue('dark')).toBeChecked();
     });
+    expect(getTrigger()).toHaveAttribute('aria-expanded', 'false');
+    expect(getTrigger()).toHaveFocus();
+    expect(getTrigger()).toHaveAccessibleName('Color scheme: dark');
   });
 
   it('removes the stored override for system preference', async () => {
@@ -56,13 +77,13 @@ describe('ColorSchemeToggleClient', () => {
     document.documentElement.setAttribute(COLOR_SCHEME_ATTRIBUTE, 'dark');
 
     render(<ColorSchemeToggleClient />);
+    await openPicker(user);
+    await user.click(getOption('System'));
 
-    await user.click(findRadioByValue('system'));
     await waitFor(() => {
       expect(document.documentElement).not.toHaveAttribute(COLOR_SCHEME_ATTRIBUTE);
       expect(document.documentElement.style.colorScheme).toBe('light dark');
       expect(localStorage.getItem(COLOR_SCHEME_STORAGE_KEY)).toBeNull();
-      expect(findRadioByValue('system')).toBeChecked();
     });
   });
 
@@ -73,11 +94,11 @@ describe('ColorSchemeToggleClient', () => {
     });
 
     render(<ColorSchemeToggleClient />);
+    await openPicker(user);
+    await user.click(getOption('Light'));
 
-    await user.click(findRadioByValue('light'));
     await waitFor(() => {
       expect(document.documentElement).toHaveAttribute(COLOR_SCHEME_ATTRIBUTE, 'light');
-      expect(findRadioByValue('light')).toBeChecked();
     });
   });
 
@@ -93,7 +114,72 @@ describe('ColorSchemeToggleClient', () => {
 
     await waitFor(() => {
       expect(document.documentElement).toHaveAttribute(COLOR_SCHEME_ATTRIBUTE, 'dark');
-      expect(findRadioByValue('dark')).toBeChecked();
+      expect(getTrigger()).toHaveAccessibleName('Color scheme: dark');
+    });
+  });
+
+  it('moves through the group with arrow keys without collapsing', async () => {
+    const user = userEvent.setup();
+    document.documentElement.setAttribute(COLOR_SCHEME_ATTRIBUTE, 'light');
+
+    render(<ColorSchemeToggleClient />);
+    await openPicker(user);
+    await user.keyboard('{ArrowDown}');
+
+    await waitFor(() => {
+      expect(document.documentElement).toHaveAttribute(COLOR_SCHEME_ATTRIBUTE, 'dark');
+      expect(getOption('Dark')).toHaveFocus();
+    });
+    expect(getTrigger()).toHaveAttribute('aria-expanded', 'true');
+
+    await user.keyboard('{End}');
+    await waitFor(() => {
+      expect(getOption('System')).toHaveFocus();
+    });
+    expect(document.documentElement).not.toHaveAttribute(COLOR_SCHEME_ATTRIBUTE);
+  });
+
+  it('commits with Enter and returns focus to the trigger', async () => {
+    const user = userEvent.setup();
+
+    render(<ColorSchemeToggleClient />);
+    await openPicker(user);
+    await user.keyboard('{ArrowUp}{Enter}');
+
+    await waitFor(() => {
+      expect(getTrigger()).toHaveAttribute('aria-expanded', 'false');
+    });
+    expect(getTrigger()).toHaveFocus();
+    expect(document.documentElement).toHaveAttribute(COLOR_SCHEME_ATTRIBUTE, 'dark');
+  });
+
+  it('closes on Escape and returns focus to the trigger', async () => {
+    const user = userEvent.setup();
+
+    render(<ColorSchemeToggleClient />);
+    await openPicker(user);
+    await user.keyboard('{Escape}');
+
+    await waitFor(() => {
+      expect(getTrigger()).toHaveAttribute('aria-expanded', 'false');
+    });
+    expect(getTrigger()).toHaveFocus();
+  });
+
+  it('closes when pressing outside the picker', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <>
+        <ColorSchemeToggleClient />
+        <button type="button">Elsewhere</button>
+      </>,
+    );
+    await openPicker(user);
+    await user.click(screen.getByRole('button', { name: 'Elsewhere' }));
+
+    await waitFor(() => {
+      expect(getTrigger()).toHaveAttribute('aria-expanded', 'false');
     });
   });
 });


### PR DESCRIPTION
# What changed?

The header's color scheme control was an always-expanded horizontal pill of
three segments on desktop, plus a separate icon-button-and-`Menu` treatment on
mobile. It is now one control on every breakpoint: a glass circle showing the
active scheme that expands downward into a vertical radio group of light, dark,
and system.

## Interaction model

- **Collapsed by default** on every breakpoint — a 64px glass circle showing the
  active scheme's icon, so it reads as a single glass button.
- **Click or tap the circle to open.** The circle stays put as the top row of the
  expanded panel and swaps its icon for a chevron, so the same target that opened
  the panel also closes it.
- **Hover does not open it.** On a fine pointer, opening under the cursor would
  put an option row where the cursor already is and invite an accidental theme
  change on the next click. Hover keeps the existing affordances only: mouse
  gravity on the glass and the icon scale-up.
- Picking a scheme with the mouse closes the panel. Clicking outside, tabbing
  out, or pressing <kbd>Escape</kbd> also closes it.
- Arrow keys and <kbd>Home</kbd>/<kbd>End</kbd> change the scheme in place so the
  page previews it without the list snapping shut; <kbd>Enter</kbd> commits and
  closes.

## Motion

One glass surface animates `height` and `width` with the site's bouncy easing
(`createBouncyTransition`) while the option rows fade and lift in, and the
selected-row thumb slides the same way the albums sorter's does. Everything is
disabled under `prefers-reduced-motion: reduce`.

The panel is absolutely positioned out of the header's flow and anchored to the
right edge, so expanding never reflows the sticky bar and the panel grows inward
away from the viewport edge. Nothing new claims a `view-transition-name` or adds
a containing block around the header, so `pinnedChromeSx` and the header's
`backdrop-filter` glass are untouched — verified visually at both breakpoints,
scrolled and unscrolled, over the homepage and a music page.

## `GlassSwitcher` decision

**Built separately; `GlassSwitcher` is byte-for-byte unchanged.** The two
controls now want opposite things: the sorter is a horizontal segmented control
with text labels and a mobile menu fallback, and the picker is a vertical
disclosure with its own open/close state, focus management, and roving keyboard
handling. Threading orientation *and* collapsibility through the shared
component would have meant two layout modes plus a disclosure state machine in a
component the sorter also renders, for no shared behavior. Keeping them apart
means zero risk to the sorter — its tests and `FavoriteAlbumsGrid`'s tests are
also unchanged, and it renders identically in the browser.

One consequence worth flagging: `GlassSwitcher`'s per-option `icon` + `Tooltip`
path now has no production consumer (the sorter passes text-only options). It is
still exercised by `GlassSwitcher.test.tsx`; removing it would be a reasonable
follow-up.

## Accessibility

- The collapsed trigger is a real `<button>` named `Color scheme: system` (or
  light/dark), so it announces the current scheme, with `aria-expanded` and
  `aria-controls` pointing at the panel.
- The panel keeps the previous `role="radiogroup"` labeled `Choose color scheme`.
- Options are native `<input type="radio">` elements stretched over their row.
  Previously they were `display: none`, which kept them out of the accessibility
  tree entirely; now they are opacity-0 and therefore focusable and announced,
  each with a visible text label ("Light", "Dark", "System") as its name.
- Focus moves to the checked option when the panel opens and returns to the
  trigger when it closes via selection, <kbd>Enter</kbd>, or <kbd>Escape</kbd>.
  Closing by clicking outside leaves focus alone.
- While collapsed the panel is `inert` and `visibility: hidden`, so it is neither
  tabbable nor announced.
- Rows are 48px tall and full-width hit areas; the collapsed circle is 64px.

## Screenshots

Verified in a real browser at 1280×800 and 390×844, in light and dark, on the
homepage and on `/music` (sticky header plus fade context), scrolled and
unscrolled. Captures of the collapsed and expanded states at both widths and a
clip of expand → select → collapse were produced during that pass and handed
back with the change; they are not committed to the repo.

# Release info

- [ ] Major
- [x] Minor
- [ ] Patch
