### PR TITLE
Share glass disclosure panels for header menus

### DIFF
--- a/apps/web/src/app/layouts/Footer.tsx
+++ b/apps/web/src/app/layouts/Footer.tsx
@@ -25,7 +25,7 @@ const getFooterLinkSx = (hasIcon: boolean): SxObject => ({
   display: 'flex',
   fontSize: hasIcon ? { sm: FOOTER_ICON_DESKTOP_FONT_SIZE, xs: FOOTER_ICON_FONT_SIZE } : undefined,
   justifyContent: 'center',
-  // Slightly tighter on mobile so an extra icon still fits; 36px is below the
+  // Slightly tighter on mobile so the icon row fits; 36px is below the
   // ideal 44px a11y target (desktop stays at 40, already a trade-off).
   minHeight: { sm: 40, xs: 36 },
   minWidth: { sm: 40, xs: 36 },
@@ -65,7 +65,6 @@ const footerIconLinkListSx: SxObject = {
   flex: 1,
   justifyContent: 'space-between',
   margin: 0,
-  // Pull further into container padding on mobile so the extra icon fits.
   marginLeft: { sm: -2.5, xs: -3 },
   marginRight: { sm: -1.5, xs: -2 },
   padding: 0,

--- a/apps/web/src/app/layouts/HeaderControls.tsx
+++ b/apps/web/src/app/layouts/HeaderControls.tsx
@@ -1,11 +1,44 @@
 'use client';
 
 import { ColorSchemeToggleClient } from '@dg/ui/core/ColorSchemeToggleClient';
-import { MouseAwareGlassContainer } from '@dg/ui/core/MouseAwareGlassContainer';
+import { GlassContainer } from '@dg/ui/core/GlassContainer';
+import { GRAVITY_TRANSFORM_PREFIX, useMouseGravity } from '@dg/ui/helpers/useMouseGravity';
+import type { SxObject } from '@dg/ui/theme';
+import { Box } from '@mui/material';
 import { useState } from 'react';
 import { MusicHeaderMenu } from './MusicHeaderMenu';
 
 type OpenControl = 'music' | 'theme' | null;
+
+const CAPSULE_GRAVITY = { maxTilt: 1.5, radius: 180 };
+
+/**
+ * Lays the two triggers out in a row and tilts the whole cluster — glass, both
+ * triggers, and whichever panel is open — toward the cursor as one object.
+ */
+const capsuleSx: SxObject = {
+  alignItems: 'center',
+  display: 'flex',
+  gap: 0.5,
+  p: 1,
+  position: 'relative',
+  transform: GRAVITY_TRANSFORM_PREFIX,
+};
+
+/**
+ * The glass sits *behind* the triggers as a sibling instead of wrapping them.
+ *
+ * `backdrop-filter` makes an element the backdrop root for its entire subtree, so
+ * a panel nested inside the capsule blurs the capsule rather than the page — and
+ * because the panel hangs below the capsule's box there is nothing of the capsule
+ * under it to sample, which paints it fully transparent. Keeping the glass a
+ * sibling leaves the page as each panel's backdrop root while the capsule still
+ * reads as one continuous surface.
+ */
+const capsuleGlassSx: SxObject = {
+  inset: 0,
+  position: 'absolute',
+};
 
 /**
  * Sibling header disclosures on one shared glass capsule. Music sits left and
@@ -14,6 +47,7 @@ type OpenControl = 'music' | 'theme' | null;
  */
 export function HeaderControls() {
   const [openControl, setOpenControl] = useState<OpenControl>(null);
+  const { ref } = useMouseGravity(CAPSULE_GRAVITY);
 
   const handleThemeOpenChange = (isOpen: boolean) => {
     setOpenControl((current) => (isOpen ? 'theme' : current === 'theme' ? null : current));
@@ -24,17 +58,14 @@ export function HeaderControls() {
   };
 
   return (
-    <MouseAwareGlassContainer
-      data-header-controls={true}
-      gravity={{ maxTilt: 1.5, radius: 180 }}
-      sx={{ alignItems: 'center', display: 'flex', gap: 0.5, p: 1 }}
-    >
+    <Box data-header-controls={true} ref={ref} sx={capsuleSx}>
+      <GlassContainer aria-hidden={true} data-capsule-glass={true} sx={capsuleGlassSx} />
       <MusicHeaderMenu isOpen={openControl === 'music'} onOpenChange={handleMusicOpenChange} />
       <ColorSchemeToggleClient
         embedded
         isOpen={openControl === 'theme'}
         onOpenChange={handleThemeOpenChange}
       />
-    </MouseAwareGlassContainer>
+    </Box>
   );
 }

--- a/apps/web/src/app/layouts/MusicHeaderMenu.tsx
+++ b/apps/web/src/app/layouts/MusicHeaderMenu.tsx
@@ -1,33 +1,44 @@
 'use client';
 
 import { favoriteAlbumsRoute, musicRoute } from '@dg/shared-core/routes/app';
+import {
+  DISCLOSURE_ICON_SIZE,
+  DISCLOSURE_ROW_HEIGHT,
+  GlassDisclosurePanel,
+  GlassDisclosureRow,
+} from '@dg/ui/core/GlassDisclosurePanel';
 import { Tooltip } from '@dg/ui/core/Tooltip';
 import { PageTransitionLink } from '@dg/ui/core/transitions/PageTransitionLink';
 import { pageTitleMorphName } from '@dg/ui/core/transitions/pageTransitions';
 import { createBouncyTransition } from '@dg/ui/helpers/bouncyTransition';
 import type { SxObject } from '@dg/ui/theme';
-import { Box, IconButton, Menu, MenuItem } from '@mui/material';
+import { Box, IconButton } from '@mui/material';
 import type { LucideIcon } from 'lucide-react';
 import { Disc3, DiscAlbum, History } from 'lucide-react';
 import { usePathname } from 'next/navigation';
-import { useId, useLayoutEffect, useRef } from 'react';
+import type { FocusEvent, KeyboardEvent } from 'react';
+import { useEffect, useId, useLayoutEffect, useRef } from 'react';
 import { isMusicDestinationPath, MUSIC_DESTINATIONS } from './musicHeaderDestinations';
 
 const MUSIC_LABEL = 'Music';
-const ICON_SIZE = 22;
-const ROW_HEIGHT = 48;
-const EXPANDED_WIDTH = 176;
 
 const DESTINATION_ICONS: Record<string, LucideIcon> = {
   [favoriteAlbumsRoute]: DiscAlbum,
   [musicRoute]: History,
 };
 
+const ARROW_STEPS: Record<string, number | undefined> = {
+  ArrowDown: 1,
+  ArrowLeft: -1,
+  ArrowRight: 1,
+  ArrowUp: -1,
+};
+
 const anchorSx: SxObject = {
   display: 'block',
-  height: ROW_HEIGHT,
+  height: DISCLOSURE_ROW_HEIGHT,
   position: 'relative',
-  width: ROW_HEIGHT,
+  width: DISCLOSURE_ROW_HEIGHT,
 };
 
 const triggerSx: SxObject = {
@@ -44,64 +55,17 @@ const triggerSx: SxObject = {
   alignItems: 'center',
   color: 'var(--mui-palette-primary-main)',
   display: 'flex',
-  height: ROW_HEIGHT,
+  height: DISCLOSURE_ROW_HEIGHT,
   justifyContent: 'center',
   padding: 0,
-  width: ROW_HEIGHT,
+  width: DISCLOSURE_ROW_HEIGHT,
 };
 
-const menuPaperSx: SxObject = {
-  backdropFilter: 'blur(12px) saturate(150%)',
-  backgroundColor: 'color-mix(in srgb, var(--mui-palette-background-default) 70%, transparent)',
-  border: '1px solid color-mix(in srgb, CanvasText 12%, transparent)',
-  borderRadius: 2,
-  boxShadow: `
-    inset 0 1px 0 color-mix(in srgb, var(--mui-palette-common-white) 15%, transparent),
-    0px 1px 5px color-mix(in srgb, var(--mui-palette-common-black) 12%, transparent),
-    0px 6px 16px color-mix(in srgb, var(--mui-palette-common-black) 8%, transparent)`,
-  minWidth: EXPANDED_WIDTH,
-  mt: 0.5,
-  py: 1,
-};
-
-const menuItemSx: SxObject = {
-  '&:hover': {
-    backgroundColor: 'color-mix(in srgb, var(--mui-palette-primary-main) 10%, transparent)',
-  },
-  borderRadius: '999px',
-  minHeight: ROW_HEIGHT,
-  mx: 1,
-  px: 0,
-  py: 0,
-};
-
-const menuLinkSx: SxObject = {
-  alignItems: 'center',
+const destinationLinkSx: SxObject = {
   color: 'inherit',
-  display: 'grid',
-  fontSize: 'inherit',
-  fontWeight: 500,
-  gridTemplateColumns: `${ROW_HEIGHT}px 1fr`,
-  height: ROW_HEIGHT,
+  display: 'block',
   textDecoration: 'none',
   width: '100%',
-};
-
-const menuRowSx: SxObject = {
-  alignItems: 'center',
-  display: 'contents',
-  lineHeight: 1.3,
-  minWidth: 0,
-};
-
-const menuIconSx: SxObject = {
-  '& svg': {
-    height: ICON_SIZE,
-    width: ICON_SIZE,
-  },
-  display: 'grid',
-  flexShrink: 0,
-  placeItems: 'center',
 };
 
 type MusicHeaderMenuProps = {
@@ -110,13 +74,15 @@ type MusicHeaderMenuProps = {
 };
 
 /**
- * Header vinyl control: opens a glass menu of music destinations. The trigger
- * alone owns the page-title view-transition name so menu item links never
- * collide. Scroll lock stays off so sticky header chrome remains pinned.
+ * Header vinyl control: opens a shared glass disclosure of music destinations.
+ * The trigger alone owns the page-title view-transition name so menu item links
+ * never collide.
  */
 export function MusicHeaderMenu({ isOpen, onOpenChange }: MusicHeaderMenuProps) {
   const menuId = useId();
+  const rootRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
   const pathname = usePathname();
   const destinationIsOpen = isMusicDestinationPath(pathname);
 
@@ -127,56 +93,114 @@ export function MusicHeaderMenu({ isOpen, onOpenChange }: MusicHeaderMenuProps) 
     triggerRef.current.style.viewTransitionName = pageTitleMorphName(destinationIsOpen);
   }, [destinationIsOpen]);
 
-  const handleClose = () => {
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    const links = listRef.current?.querySelectorAll<HTMLAnchorElement>('a[href]');
+    links?.[0]?.focus();
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    const closeOnOutsidePress = (event: PointerEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        onOpenChange(false);
+      }
+    };
+    document.addEventListener('pointerdown', closeOnOutsidePress);
+    return () => {
+      document.removeEventListener('pointerdown', closeOnOutsidePress);
+    };
+  }, [isOpen, onOpenChange]);
+
+  const collapse = () => {
     onOpenChange(false);
+    triggerRef.current?.focus();
+  };
+
+  const handleRootKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (isOpen && event.key === 'Escape') {
+      event.preventDefault();
+      collapse();
+    }
+  };
+
+  const handleListKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      collapse();
+      return;
+    }
+    const links = [...(listRef.current?.querySelectorAll<HTMLAnchorElement>('a[href]') ?? [])];
+    if (links.length === 0) {
+      return;
+    }
+    const currentIndex =
+      document.activeElement instanceof HTMLAnchorElement
+        ? links.indexOf(document.activeElement)
+        : -1;
+    const step = ARROW_STEPS[event.key];
+    const nextIndex =
+      event.key === 'Home'
+        ? 0
+        : event.key === 'End'
+          ? links.length - 1
+          : step === undefined || currentIndex === -1
+            ? -1
+            : (currentIndex + step + links.length) % links.length;
+    if (nextIndex === -1) {
+      return;
+    }
+    event.preventDefault();
+    links[nextIndex]?.focus();
+  };
+
+  const handleFocusOut = (event: FocusEvent<HTMLDivElement>) => {
+    if (isOpen && !event.currentTarget.contains(event.relatedTarget)) {
+      onOpenChange(false);
+    }
   };
 
   return (
-    <Box sx={anchorSx}>
+    <Box onBlur={handleFocusOut} onKeyDown={handleRootKeyDown} ref={rootRef} sx={anchorSx}>
       <Tooltip placement="bottom" title={MUSIC_LABEL}>
         <IconButton
           aria-controls={isOpen ? menuId : undefined}
-          aria-expanded={isOpen ? 'true' : undefined}
+          aria-expanded={isOpen}
           aria-haspopup="menu"
           aria-label={MUSIC_LABEL}
           onClick={() => onOpenChange(!isOpen)}
           ref={triggerRef}
           sx={triggerSx}
         >
-          <Disc3 size={ICON_SIZE} />
+          <Disc3 size={DISCLOSURE_ICON_SIZE} />
         </IconButton>
       </Tooltip>
-      <Menu
-        anchorEl={triggerRef.current}
-        anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
-        disableScrollLock
-        id={menuId}
-        onClose={handleClose}
-        open={isOpen}
-        slotProps={{ paper: { sx: menuPaperSx } }}
-        transformOrigin={{ horizontal: 'right', vertical: 'top' }}
-      >
-        {MUSIC_DESTINATIONS.map((destination) => {
-          const Icon = DESTINATION_ICONS[destination.href] ?? Disc3;
-          return (
-            <MenuItem key={destination.href} onClick={handleClose} sx={menuItemSx}>
+      <GlassDisclosurePanel id={menuId} isOpen={isOpen} label={MUSIC_LABEL} role="menu">
+        <Box onKeyDown={handleListKeyDown} ref={listRef} sx={{ display: 'contents' }}>
+          {MUSIC_DESTINATIONS.map((destination) => {
+            const Icon = DESTINATION_ICONS[destination.href] ?? Disc3;
+            return (
               <PageTransitionLink
                 href={destination.href}
-                sx={menuLinkSx}
+                key={destination.href}
+                onClick={collapse}
+                role="menuitem"
+                sx={destinationLinkSx}
                 title={destination.label}
-                variant="caption"
               >
-                <Box component="span" sx={menuRowSx}>
-                  <Box component="span" sx={menuIconSx}>
-                    <Icon aria-hidden size={ICON_SIZE} />
-                  </Box>
-                  <Box component="span">{destination.label}</Box>
-                </Box>
+                <GlassDisclosureRow
+                  icon={<Icon aria-hidden size={DISCLOSURE_ICON_SIZE} />}
+                  label={destination.label}
+                />
               </PageTransitionLink>
-            </MenuItem>
-          );
-        })}
-      </Menu>
+            );
+          })}
+        </Box>
+      </GlassDisclosurePanel>
     </Box>
   );
 }

--- a/apps/web/src/app/layouts/__tests__/Footer.test.tsx
+++ b/apps/web/src/app/layouts/__tests__/Footer.test.tsx
@@ -67,45 +67,33 @@ describe('Footer redesign badge', () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it('renders the footer shell without a listening-history text link', async () => {
+  it('renders the footer shell without music destination links', async () => {
     mockInteractiveRedesign.mockResolvedValue(false);
     mockGetFooterLinks.mockResolvedValue([]);
     render(await Footer());
     expect(screen.getByText(/Dylan Gattey/)).toBeInTheDocument();
     expect(screen.queryByText('Listening history')).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Favorite albums' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Music' })).not.toBeInTheDocument();
   });
 
-  it('keeps the favorite-albums icon as a regular footer link', async () => {
+  it('renders social icon links from Contentful without a music disc', async () => {
     mockInteractiveRedesign.mockResolvedValue(false);
     mockGetFooterLinks.mockResolvedValue([
-      { icon: 'albums', title: 'Favorite albums', url: favoriteAlbumsRoute },
       { icon: 'cursor', title: 'Cursor', url: 'https://cursor.com' },
       { icon: 'github', title: 'GitHub', url: 'https://github.com/dgattey' },
+      { icon: 'spotify', title: 'Spotify', url: 'https://open.spotify.com/user/dylangattey' },
     ]);
     render(await Footer());
 
     const cursor = screen.getByRole('link', { name: 'Cursor' });
     const github = screen.getByRole('link', { name: 'GitHub' });
+    const spotify = screen.getByRole('link', { name: 'Spotify' });
     expect(cursor).toHaveAttribute('href', 'https://cursor.com');
     expect(github).toBeInTheDocument();
-    // Cursor sits immediately left of GitHub in the icon row.
+    expect(spotify).toHaveAttribute('href', 'https://open.spotify.com/user/dylangattey');
     expect(cursor.compareDocumentPosition(github) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-    expect(screen.getByRole('link', { name: 'Favorite albums' })).toHaveAttribute(
-      'href',
-      favoriteAlbumsRoute,
-    );
-    expect(screen.queryByRole('button', { name: 'Music' })).not.toBeInTheDocument();
-  });
-
-  it('normalizes a favorite-albums URL with a trailing slash', async () => {
-    mockInteractiveRedesign.mockResolvedValue(false);
-    mockGetFooterLinks.mockResolvedValue([
-      { icon: 'albums', title: 'Favorite albums', url: `${favoriteAlbumsRoute}/` },
-    ]);
-    render(await Footer());
-    expect(screen.getByRole('link', { name: 'Favorite albums' })).toHaveAttribute(
-      'href',
-      favoriteAlbumsRoute,
-    );
+    expect(screen.queryByRole('link', { name: 'Favorite albums' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: favoriteAlbumsRoute })).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/layouts/__tests__/HeaderControls.test.tsx
+++ b/apps/web/src/app/layouts/__tests__/HeaderControls.test.tsx
@@ -43,4 +43,24 @@ describe('HeaderControls', () => {
       expect(music).toHaveAttribute('aria-expanded', 'true');
     });
   });
+
+  /**
+   * An element with `backdrop-filter` is the backdrop root for its whole subtree,
+   * so a panel nested inside the capsule glass would blur the capsule instead of
+   * the page — and, hanging below the capsule's box, sample nothing at all.
+   */
+  it('keeps the capsule glass a sibling of the disclosure panels, never their ancestor', () => {
+    render(<HeaderControls />);
+
+    const glass = document.querySelector('[data-capsule-glass]');
+    expect(glass).not.toBeNull();
+    expect(glass?.childElementCount).toBe(0);
+
+    for (const panel of [
+      screen.getByRole('menu', { hidden: true }),
+      screen.getByRole('radiogroup', { hidden: true }),
+    ]) {
+      expect(glass?.contains(panel)).toBe(false);
+    }
+  });
 });

--- a/apps/web/src/app/layouts/__tests__/MusicHeaderMenu.test.tsx
+++ b/apps/web/src/app/layouts/__tests__/MusicHeaderMenu.test.tsx
@@ -35,7 +35,7 @@ describe('MusicHeaderMenu', () => {
     mockUsePathname.mockReturnValue('/');
   });
 
-  it('opens a menu with both music destinations in order', async () => {
+  it('opens a shared glass menu with both music destinations in order', async () => {
     const user = userEvent.setup();
     render(<TestMusicHeaderMenu />);
 
@@ -45,8 +45,9 @@ describe('MusicHeaderMenu', () => {
 
     await user.click(trigger);
     expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByRole('menu', { name: 'Music' })).toBeInTheDocument();
 
-    const links = screen.getAllByRole('link');
+    const links = screen.getAllByRole('menuitem');
     expect(links.map((link) => link.getAttribute('href'))).toEqual([
       favoriteAlbumsRoute,
       musicRoute,
@@ -63,7 +64,7 @@ describe('MusicHeaderMenu', () => {
     expect(trigger.style.viewTransitionName).toBe(PAGE_TITLE_VIEW_TRANSITION_NAME);
 
     await user.click(trigger);
-    const menuLinks = screen.getAllByRole('link');
+    const menuLinks = screen.getAllByRole('menuitem');
     expect(menuLinks).toHaveLength(2);
     for (const link of menuLinks) {
       expect(link.style.viewTransitionName).toBe('');
@@ -73,6 +74,19 @@ describe('MusicHeaderMenu', () => {
       (element) => element.style.viewTransitionName === PAGE_TITLE_VIEW_TRANSITION_NAME,
     );
     expect(named).toHaveLength(1);
+  });
+
+  it('closes on Escape and returns focus to the trigger', async () => {
+    const user = userEvent.setup();
+    render(<TestMusicHeaderMenu />);
+
+    const trigger = screen.getByRole('button', { name: 'Music' });
+    await user.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+    await user.keyboard('{Escape}');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(trigger).toHaveFocus();
   });
 
   it('switches the trigger to the slot name on either music destination', () => {

--- a/package.json
+++ b/package.json
@@ -27,5 +27,5 @@
     "clean": "rm -f .env .env.tmp",
     "preinstall": "npx only-allow pnpm"
   },
-  "version": "2.67.0"
+  "version": "2.67.1"
 }

--- a/packages/ui/core/ColorSchemeToggleClient.tsx
+++ b/packages/ui/core/ColorSchemeToggleClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Box, Typography } from '@mui/material';
+import { Box } from '@mui/material';
 import { ChevronUp, Moon, Sun, SunMoon } from 'lucide-react';
 import type { ChangeEvent, FocusEvent, KeyboardEvent, ReactNode } from 'react';
 import { useEffect, useId, useRef, useState } from 'react';
@@ -9,20 +9,23 @@ import { createTransition, TIMING_MEDIUM, TIMING_SLOW } from '../helpers/timing'
 import type { SxObject } from '../theme';
 import { type ColorSchemePreference, parseColorSchemePreference } from '../theme/colorScheme';
 import { useColorScheme } from '../theme/useColorScheme';
+import {
+  DISCLOSURE_ICON_SIZE,
+  DISCLOSURE_PANEL_PADDING,
+  DISCLOSURE_PANEL_WIDTH,
+  DISCLOSURE_ROW_GAP,
+  DISCLOSURE_ROW_HEIGHT,
+  GlassDisclosurePanel,
+  GlassDisclosureRow,
+} from './GlassDisclosurePanel';
 import { MouseAwareGlassContainer } from './MouseAwareGlassContainer';
 
-const ICON_SIZE = 22;
-
 /**
- * Row geometry in px. Collapsed, the control is one padded row — a glass
- * circle. Expanded, it keeps that row as the disclosure toggle and grows down
- * and to the left to fit one row per scheme.
+ * Row geometry in px. Collapsed, the standalone control is one padded row — a
+ * glass circle. Expanded, it keeps that row as the disclosure toggle and grows
+ * down and to the left to fit one row per scheme.
  */
-const ROW_HEIGHT = 48;
-const ROW_GAP = 4;
-const PANEL_PADDING = 8;
-const COLLAPSED_SIZE = ROW_HEIGHT + PANEL_PADDING * 2;
-const EXPANDED_WIDTH = 176;
+const COLLAPSED_SIZE = DISCLOSURE_ROW_HEIGHT + DISCLOSURE_PANEL_PADDING * 2;
 
 interface SchemeOption {
   icon: ReactNode;
@@ -31,15 +34,15 @@ interface SchemeOption {
 }
 
 const OPTIONS = [
-  { icon: <Sun size={ICON_SIZE} />, label: 'Light', value: 'light' },
-  { icon: <Moon size={ICON_SIZE} />, label: 'Dark', value: 'dark' },
-  { icon: <SunMoon size={ICON_SIZE} />, label: 'System', value: 'system' },
+  { icon: <Sun size={DISCLOSURE_ICON_SIZE} />, label: 'Light', value: 'light' },
+  { icon: <Moon size={DISCLOSURE_ICON_SIZE} />, label: 'Dark', value: 'dark' },
+  { icon: <SunMoon size={DISCLOSURE_ICON_SIZE} />, label: 'System', value: 'system' },
 ] as const satisfies ReadonlyArray<SchemeOption>;
 
 const EXPANDED_HEIGHT =
-  PANEL_PADDING * 2 + ROW_HEIGHT * (OPTIONS.length + 1) + ROW_GAP * OPTIONS.length;
-const EMBEDDED_EXPANDED_HEIGHT =
-  PANEL_PADDING * 2 + ROW_HEIGHT * OPTIONS.length + ROW_GAP * (OPTIONS.length - 1);
+  DISCLOSURE_PANEL_PADDING * 2 +
+  DISCLOSURE_ROW_HEIGHT * (OPTIONS.length + 1) +
+  DISCLOSURE_ROW_GAP * OPTIONS.length;
 
 /** Arrow keys move through the group in either axis, matching native radios. */
 const ARROW_STEPS: Record<string, number | undefined> = {
@@ -60,13 +63,13 @@ const anchorSx: SxObject = {
 };
 
 const embeddedAnchorSx: SxObject = {
-  height: ROW_HEIGHT,
+  height: DISCLOSURE_ROW_HEIGHT,
   position: 'relative',
-  width: ROW_HEIGHT,
+  width: DISCLOSURE_ROW_HEIGHT,
 };
 
 /**
- * The glass surface itself. Absolutely positioned out of the header's flow so
+ * Standalone glass surface. Absolutely positioned out of the header's flow so
  * the expanded panel hangs below the sticky bar instead of stretching it, and
  * anchored to the right edge so it grows inward, away from the viewport edge.
  */
@@ -78,29 +81,12 @@ function createPanelSx(isOpen: boolean): SxObject {
     position: 'absolute',
     right: 0,
     top: 0,
-    width: isOpen ? EXPANDED_WIDTH : COLLAPSED_SIZE,
+    width: isOpen ? DISCLOSURE_PANEL_WIDTH : COLLAPSED_SIZE,
     zIndex: 1,
     ...createBouncyTransition(
       ['background-color', 'border-color', 'box-shadow', 'height', 'width'],
       TIMING_SLOW,
     ),
-  };
-}
-
-function createEmbeddedPanelSx(isOpen: boolean): SxObject {
-  return {
-    [REDUCED_MOTION]: { transition: 'none' },
-    height: isOpen ? EMBEDDED_EXPANDED_HEIGHT : 0,
-    opacity: isOpen ? 1 : 0,
-    overflow: 'hidden',
-    pointerEvents: isOpen ? 'auto' : 'none',
-    position: 'absolute',
-    right: 0,
-    top: ROW_HEIGHT + ROW_GAP,
-    transform: isOpen ? 'none' : `translateY(-${ROW_HEIGHT / 4}px)`,
-    width: EXPANDED_WIDTH,
-    zIndex: 2,
-    ...createBouncyTransition(['height', 'opacity', 'transform'], TIMING_SLOW),
   };
 }
 
@@ -123,13 +109,13 @@ const triggerSx: SxObject = {
   color: 'var(--mui-palette-primary-main)',
   cursor: 'pointer',
   display: 'flex',
-  height: ROW_HEIGHT,
+  height: DISCLOSURE_ROW_HEIGHT,
   justifyContent: 'center',
-  left: PANEL_PADDING,
+  left: DISCLOSURE_PANEL_PADDING,
   padding: 0,
   position: 'absolute',
-  right: PANEL_PADDING,
-  top: PANEL_PADDING,
+  right: DISCLOSURE_PANEL_PADDING,
+  top: DISCLOSURE_PANEL_PADDING,
 };
 
 const embeddedTriggerSx: SxObject = {
@@ -140,32 +126,31 @@ const embeddedTriggerSx: SxObject = {
 };
 
 /**
- * Collapsed, the list is invisible rather than unmounted so both directions
- * animate. `visibility` also takes it out of the accessibility tree and out of
- * the tab order, and `inert` keeps pointer and focus events off it.
+ * Collapsed, the standalone list is invisible rather than unmounted so both
+ * directions animate. `visibility` also takes it out of the accessibility tree
+ * and out of the tab order, and `inert` keeps pointer and focus events off it.
  */
-function createListSx(isOpen: boolean): SxObject {
+function createStandaloneListSx(isOpen: boolean): SxObject {
   return {
     [REDUCED_MOTION]: { transition: 'none' },
     display: 'grid',
-    left: PANEL_PADDING,
+    left: DISCLOSURE_PANEL_PADDING,
     opacity: isOpen ? 1 : 0,
     position: 'absolute',
-    right: PANEL_PADDING,
-    rowGap: `${ROW_GAP}px`,
-    top: PANEL_PADDING + ROW_HEIGHT + ROW_GAP,
-    transform: isOpen ? 'none' : `translateY(-${ROW_HEIGHT / 4}px)`,
+    right: DISCLOSURE_PANEL_PADDING,
+    rowGap: `${DISCLOSURE_ROW_GAP}px`,
+    top: DISCLOSURE_PANEL_PADDING + DISCLOSURE_ROW_HEIGHT + DISCLOSURE_ROW_GAP,
+    transform: isOpen ? 'none' : `translateY(-${DISCLOSURE_ROW_HEIGHT / 4}px)`,
     transition: `${createTransition(['opacity', 'transform'], TIMING_MEDIUM)}, visibility 0s linear ${isOpen ? 0 : TIMING_MEDIUM}ms`,
     visibility: isOpen ? 'visible' : 'hidden',
   };
 }
 
-function createEmbeddedListSx(isOpen: boolean): SxObject {
-  return {
-    ...createListSx(isOpen),
-    top: PANEL_PADDING,
-  };
-}
+const embeddedListSx: SxObject = {
+  display: 'grid',
+  position: 'relative',
+  rowGap: `${DISCLOSURE_ROW_GAP}px`,
+};
 
 /** Sliding highlight behind the selected row, echoing the albums sorter thumb. */
 function createThumbSx(selectedIndex: number): SxObject {
@@ -174,40 +159,22 @@ function createThumbSx(selectedIndex: number): SxObject {
     backgroundColor: 'var(--mui-palette-action-selected)',
     border: '1px solid color-mix(in srgb, var(--mui-palette-primary-main) 30%, transparent)',
     borderRadius: '999px',
-    height: ROW_HEIGHT,
+    height: DISCLOSURE_ROW_HEIGHT,
     left: 0,
     position: 'absolute',
     right: 0,
     top: 0,
-    transform: `translateY(${selectedIndex * (ROW_HEIGHT + ROW_GAP)}px)`,
+    transform: `translateY(${selectedIndex * (DISCLOSURE_ROW_HEIGHT + DISCLOSURE_ROW_GAP)}px)`,
     transition: createTransition(['background-color', 'transform'], TIMING_MEDIUM),
     zIndex: 0,
   };
 }
 
-const optionSx: SxObject = {
-  '& svg': {
-    ...createBouncyTransition('scale'),
-    display: 'block',
-  },
+const optionRowSx: SxObject = {
   '&:has(input:focus-visible)': {
     outline: '-webkit-focus-ring-color auto 1px',
   },
-  '&:hover': {
-    color: 'var(--mui-palette-primary-light)',
-  },
-  '&:hover svg': {
-    scale: 1.2,
-  },
-  alignItems: 'center',
-  borderRadius: '999px',
-  color: 'var(--mui-palette-primary-main)',
   cursor: 'pointer',
-  display: 'grid',
-  gridTemplateColumns: `${ROW_HEIGHT}px 1fr`,
-  height: ROW_HEIGHT,
-  position: 'relative',
-  zIndex: 1,
 };
 
 /**
@@ -221,17 +188,6 @@ const inputSx: SxObject = {
   margin: 0,
   opacity: 0,
   position: 'absolute',
-};
-
-const iconCellSx: SxObject = {
-  display: 'grid',
-  placeItems: 'center',
-};
-
-const optionLabelSx: SxObject = {
-  lineHeight: 1.2,
-  paddingInlineEnd: 1.5,
-  whiteSpace: 'nowrap',
 };
 
 /**
@@ -359,9 +315,10 @@ export function ColorSchemeToggleClient({
       sx={embedded ? embeddedTriggerSx : triggerSx}
       type="button"
     >
-      {isOpen ? <ChevronUp size={ICON_SIZE} /> : selectedOption.icon}
+      {isOpen ? <ChevronUp size={DISCLOSURE_ICON_SIZE} /> : selectedOption.icon}
     </Box>
   );
+
   const options = (
     <Box
       aria-label="Choose color scheme"
@@ -370,11 +327,17 @@ export function ColorSchemeToggleClient({
       onKeyDown={handleListKeyDown}
       ref={listRef}
       role="radiogroup"
-      sx={embedded ? createEmbeddedListSx(isOpen) : createListSx(isOpen)}
+      sx={embedded ? embeddedListSx : createStandaloneListSx(isOpen)}
     >
       <Box sx={createThumbSx(selectedIndex)} />
       {OPTIONS.map((option) => (
-        <Box component="label" key={option.value} sx={optionSx}>
+        <GlassDisclosureRow
+          component="label"
+          icon={option.icon}
+          key={option.value}
+          label={option.label}
+          sx={optionRowSx}
+        >
           <Box
             checked={option.value === preference}
             component="input"
@@ -387,14 +350,11 @@ export function ColorSchemeToggleClient({
             type="radio"
             value={option.value}
           />
-          <Box sx={iconCellSx}>{option.icon}</Box>
-          <Typography component="span" sx={optionLabelSx} variant="caption">
-            {option.label}
-          </Typography>
-        </Box>
+        </GlassDisclosureRow>
       ))}
     </Box>
   );
+
   const rootProps = {
     onBlur: handleFocusOut,
     onKeyDown: handleRootKeyDown,
@@ -405,12 +365,9 @@ export function ColorSchemeToggleClient({
     return (
       <Box {...rootProps} sx={embeddedAnchorSx}>
         {trigger}
-        <MouseAwareGlassContainer
-          gravity={{ maxTilt: 1.5, radius: 180 }}
-          sx={createEmbeddedPanelSx(isOpen)}
-        >
+        <GlassDisclosurePanel isOpen={isOpen} label="Choose color scheme">
           {options}
-        </MouseAwareGlassContainer>
+        </GlassDisclosurePanel>
       </Box>
     );
   }

--- a/packages/ui/core/GlassDisclosurePanel.tsx
+++ b/packages/ui/core/GlassDisclosurePanel.tsx
@@ -5,7 +5,7 @@ import type { ReactNode } from 'react';
 import { createBouncyTransition } from '../helpers/bouncyTransition';
 import { createTransition, TIMING_SLOW } from '../helpers/timing';
 import type { SxObject } from '../theme';
-import { MouseAwareGlassContainer } from './MouseAwareGlassContainer';
+import { GlassContainer } from './GlassContainer';
 
 /** Shared geometry for header disclosures that hang under a trigger. */
 export const DISCLOSURE_ICON_SIZE = 22;
@@ -33,8 +33,7 @@ function createPanelMotionSx(isOpen: boolean): SxObject {
     [REDUCED_MOTION]: { transition: 'none' },
     opacity: isOpen ? 1 : 0,
     pointerEvents: isOpen ? 'auto' : 'none',
-    // Only the open/close offset — MouseAwareGlassContainer prefixes gravity.
-    transform: isOpen ? undefined : `translateY(-${DISCLOSURE_ROW_HEIGHT / 4}px)`,
+    transform: isOpen ? 'none' : `translateY(-${DISCLOSURE_ROW_HEIGHT / 4}px)`,
     visibility: isOpen ? 'visible' : 'hidden',
     ...createBouncyTransition(['opacity', 'transform'], TIMING_SLOW),
     transition: `${createTransition(['opacity', 'transform'], TIMING_SLOW)}, visibility 0s linear ${
@@ -95,9 +94,13 @@ type GlassDisclosurePanelProps = {
 };
 
 /**
- * Shared glass disclosure panel for header menus. Uses the same
- * MouseAwareGlassContainer treatment as the logo capsule; open/close motion
- * composes with gravity instead of replacing it.
+ * Shared glass disclosure panel for header menus.
+ *
+ * Deliberately a plain `GlassContainer` rather than a mouse-aware one: the panel
+ * hangs off a trigger inside a capsule that already tilts toward the cursor, so
+ * it inherits that tilt. Its own gravity transform would only double it, and the
+ * transform would make the panel a containing block and stacking context for no
+ * gain.
  */
 export function GlassDisclosurePanel({
   children,
@@ -108,17 +111,16 @@ export function GlassDisclosurePanel({
   sx,
 }: GlassDisclosurePanelProps) {
   return (
-    <MouseAwareGlassContainer
+    <GlassContainer
       aria-hidden={!isOpen}
       aria-label={label}
-      gravity={{ maxTilt: 1.5, radius: 180 }}
       id={id}
       inert={!isOpen}
       role={role}
       sx={{ ...panelBaseSx, ...createPanelMotionSx(isOpen), ...sx }}
     >
       {children}
-    </MouseAwareGlassContainer>
+    </GlassContainer>
   );
 }
 

--- a/packages/ui/core/GlassDisclosurePanel.tsx
+++ b/packages/ui/core/GlassDisclosurePanel.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+import { Box, Typography } from '@mui/material';
+import type { ReactNode } from 'react';
+import { createBouncyTransition } from '../helpers/bouncyTransition';
+import { createTransition, TIMING_SLOW } from '../helpers/timing';
+import type { SxObject } from '../theme';
+import { MouseAwareGlassContainer } from './MouseAwareGlassContainer';
+
+/** Shared geometry for header disclosures that hang under a trigger. */
+export const DISCLOSURE_ICON_SIZE = 22;
+export const DISCLOSURE_ROW_HEIGHT = 48;
+export const DISCLOSURE_ROW_GAP = 4;
+export const DISCLOSURE_PANEL_PADDING = 8;
+export const DISCLOSURE_PANEL_WIDTH = 208;
+
+const REDUCED_MOTION = '@media (prefers-reduced-motion: reduce)';
+
+const panelBaseSx: SxObject = {
+  boxSizing: 'border-box',
+  display: 'grid',
+  padding: `${DISCLOSURE_PANEL_PADDING}px`,
+  position: 'absolute',
+  right: 0,
+  rowGap: `${DISCLOSURE_ROW_GAP}px`,
+  top: DISCLOSURE_ROW_HEIGHT + DISCLOSURE_ROW_GAP,
+  width: DISCLOSURE_PANEL_WIDTH,
+  zIndex: 2,
+};
+
+function createPanelMotionSx(isOpen: boolean): SxObject {
+  return {
+    [REDUCED_MOTION]: { transition: 'none' },
+    opacity: isOpen ? 1 : 0,
+    pointerEvents: isOpen ? 'auto' : 'none',
+    // Only the open/close offset — MouseAwareGlassContainer prefixes gravity.
+    transform: isOpen ? undefined : `translateY(-${DISCLOSURE_ROW_HEIGHT / 4}px)`,
+    visibility: isOpen ? 'visible' : 'hidden',
+    ...createBouncyTransition(['opacity', 'transform'], TIMING_SLOW),
+    transition: `${createTransition(['opacity', 'transform'], TIMING_SLOW)}, visibility 0s linear ${
+      isOpen ? 0 : TIMING_SLOW
+    }ms`,
+  };
+}
+
+const rowBaseSx: SxObject = {
+  '& svg': {
+    ...createBouncyTransition('scale'),
+    display: 'block',
+    height: DISCLOSURE_ICON_SIZE,
+    width: DISCLOSURE_ICON_SIZE,
+  },
+  '&:hover': {
+    color: 'var(--mui-palette-primary-light)',
+  },
+  '&:hover svg': {
+    scale: 1.2,
+  },
+  alignItems: 'center',
+  borderRadius: '999px',
+  boxSizing: 'border-box',
+  color: 'var(--mui-palette-primary-main)',
+  display: 'grid',
+  gridTemplateColumns: `${DISCLOSURE_ROW_HEIGHT}px 1fr`,
+  height: DISCLOSURE_ROW_HEIGHT,
+  minWidth: 0,
+  position: 'relative',
+  textDecoration: 'none',
+  width: '100%',
+  zIndex: 1,
+};
+
+const iconCellSx: SxObject = {
+  display: 'grid',
+  placeItems: 'center',
+};
+
+const labelSx: SxObject = {
+  lineHeight: 1.2,
+  minWidth: 0,
+  overflow: 'hidden',
+  paddingInlineEnd: 1.5,
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+};
+
+type GlassDisclosurePanelProps = {
+  children: ReactNode;
+  isOpen: boolean;
+  /** Accessible name for the disclosure surface. */
+  label: string;
+  id?: string;
+  role?: string;
+  sx?: SxObject;
+};
+
+/**
+ * Shared glass disclosure panel for header menus. Uses the same
+ * MouseAwareGlassContainer treatment as the logo capsule; open/close motion
+ * composes with gravity instead of replacing it.
+ */
+export function GlassDisclosurePanel({
+  children,
+  id,
+  isOpen,
+  label,
+  role,
+  sx,
+}: GlassDisclosurePanelProps) {
+  return (
+    <MouseAwareGlassContainer
+      aria-hidden={!isOpen}
+      aria-label={label}
+      gravity={{ maxTilt: 1.5, radius: 180 }}
+      id={id}
+      inert={!isOpen}
+      role={role}
+      sx={{ ...panelBaseSx, ...createPanelMotionSx(isOpen), ...sx }}
+    >
+      {children}
+    </MouseAwareGlassContainer>
+  );
+}
+
+type GlassDisclosureRowProps = {
+  icon: ReactNode;
+  label: string;
+  children?: ReactNode;
+  component?: React.ElementType;
+  onClick?: () => void;
+  sx?: SxObject;
+};
+
+/**
+ * Shared disclosure row chrome: icon cell + caption label, pill hover treatment.
+ * Wrap with a link, label+radio, or button as the interactive element.
+ */
+export function GlassDisclosureRow({
+  children,
+  component = 'div',
+  icon,
+  label,
+  onClick,
+  sx,
+}: GlassDisclosureRowProps) {
+  return (
+    <Box component={component} onClick={onClick} sx={{ ...rowBaseSx, ...sx }}>
+      {children}
+      <Box aria-hidden component="span" sx={iconCellSx}>
+        {icon}
+      </Box>
+      <Typography component="span" sx={labelSx} variant="caption">
+        {label}
+      </Typography>
+    </Box>
+  );
+}

--- a/packages/ui/core/MouseAwareGlassContainer.tsx
+++ b/packages/ui/core/MouseAwareGlassContainer.tsx
@@ -46,10 +46,8 @@ export function MouseAwareGlassContainer<ContainerOverrideType extends React.Ele
   ...props
 }: MouseAwareGlassContainerProps & ComponentPropsWithoutRef<ContainerOverrideType>) {
   const { ref } = useMouseGravity(gravity);
-  // composeGravitySx already spreads `sx` and prefixes any consumer transform
-  // with the gravity var — don't re-spread `sx` after or gravity is overwritten.
   return (
-    <ContainerOverride ref={ref} sx={composeGravitySx(sx)} {...props}>
+    <ContainerOverride ref={ref} sx={{ ...composeGravitySx(sx), ...sx }} {...props}>
       {children}
     </ContainerOverride>
   );

--- a/packages/ui/core/MouseAwareGlassContainer.tsx
+++ b/packages/ui/core/MouseAwareGlassContainer.tsx
@@ -46,8 +46,10 @@ export function MouseAwareGlassContainer<ContainerOverrideType extends React.Ele
   ...props
 }: MouseAwareGlassContainerProps & ComponentPropsWithoutRef<ContainerOverrideType>) {
   const { ref } = useMouseGravity(gravity);
+  // composeGravitySx already spreads `sx` and prefixes any consumer transform
+  // with the gravity var — don't re-spread `sx` after or gravity is overwritten.
   return (
-    <ContainerOverride ref={ref} sx={{ ...composeGravitySx(sx), ...sx }} {...props}>
+    <ContainerOverride ref={ref} sx={composeGravitySx(sx)} {...props}>
       {children}
     </ContainerOverride>
   );

--- a/packages/ui/core/__tests__/GlassDisclosurePanel.test.tsx
+++ b/packages/ui/core/__tests__/GlassDisclosurePanel.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import { Disc3, Sun } from 'lucide-react';
+import { GlassDisclosurePanel, GlassDisclosureRow } from '../GlassDisclosurePanel';
+
+describe('GlassDisclosurePanel', () => {
+  it('renders a shared glass surface with row chrome', () => {
+    render(
+      <GlassDisclosurePanel isOpen label="Test menu" role="menu">
+        <GlassDisclosureRow icon={<Sun />} label="Light" />
+        <GlassDisclosureRow icon={<Disc3 />} label="Music" />
+      </GlassDisclosurePanel>,
+    );
+
+    expect(screen.getByRole('menu', { name: 'Test menu' })).toBeInTheDocument();
+    expect(screen.getByText('Light')).toBeInTheDocument();
+    expect(screen.getByText('Music')).toBeInTheDocument();
+  });
+
+  it('marks the panel inert while closed', () => {
+    render(
+      <GlassDisclosurePanel isOpen={false} label="Closed menu">
+        <GlassDisclosureRow icon={<Sun />} label="Hidden" />
+      </GlassDisclosurePanel>,
+    );
+
+    expect(screen.getByLabelText('Closed menu')).toHaveAttribute('inert');
+  });
+});

--- a/packages/ui/core/transitions/PageTransitionLink.tsx
+++ b/packages/ui/core/transitions/PageTransitionLink.tsx
@@ -18,6 +18,8 @@ export type PageTransitionLinkProps = {
    * `view-transition-name` abort the transition.
    */
   morphsTitle?: boolean;
+  onClick?: () => void;
+  role?: React.AriaRole;
   sx?: SxProps;
   title: string;
   variant?: 'caption';
@@ -36,6 +38,7 @@ export function PageTransitionLink({
   children,
   href,
   morphsTitle = false,
+  onClick,
   sx,
   title,
   ...rest
@@ -58,6 +61,7 @@ export function PageTransitionLink({
       href={href}
       onClick={() => {
         rememberPageOrigin(pathname);
+        onClick?.();
       }}
       ref={anchor}
       sx={sx}

--- a/packages/ui/dependent/Link.tsx
+++ b/packages/ui/dependent/Link.tsx
@@ -5,7 +5,7 @@ import { faSpotify } from '@fortawesome/free-brands-svg-icons/faSpotify';
 import { faStrava } from '@fortawesome/free-brands-svg-icons/faStrava';
 import type { ButtonProps, LinkProps as MuiLinkProps } from '@mui/material';
 import { Button, Link as MuiLink } from '@mui/material';
-import { Disc3, Send } from 'lucide-react';
+import { Send } from 'lucide-react';
 import NextLink from 'next/link';
 import React from 'react';
 import type { TooltipPlacement } from '../core/Tooltip';
@@ -82,6 +82,11 @@ export type BaseLinkProps = {
    * Only usable from client components.
    */
   onClick?: React.MouseEventHandler<HTMLAnchorElement>;
+
+  /**
+   * Optional ARIA role for the underlying anchor (e.g. menuitem in a disclosure).
+   */
+  role?: React.AriaRole;
 };
 
 /**
@@ -119,7 +124,6 @@ function CursorIcon({ size = '1em' }: { size?: string }) {
  * Cursor is not in FA; map the Contentful `icon: "cursor"` string the same way.
  */
 const BUILT_IN_ICONS: Record<string, React.ReactNode> = {
-  albums: <Disc3 size="1em" />,
   cursor: <CursorIcon />,
   email: <Send size="1em" />,
   github: <FaIcon icon={faGithub} />,
@@ -203,6 +207,7 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(function Link
     tooltipPlacement,
     transitionTypes,
     onClick,
+    role,
   },
   ref,
 ) {
@@ -220,6 +225,7 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(function Link
     'aria-label': title,
     onClick,
     ref,
+    role,
     title: showTooltip ? undefined : title,
   };
   const externalProps = isExternal ? { rel: 'noreferrer' as const, target: '_blank' as const } : {};


### PR DESCRIPTION
## Summary
- Add `GlassDisclosurePanel` / `GlassDisclosureRow` in `@dg/ui` and use it for both music and theme disclosures
- Fix theme glass loss: `MouseAwareGlassContainer` no longer overwrites gravity with consumer transforms; embedded panels animate opacity instead of collapsing height from 0
- Delete MUI `<Menu>` / hand-rolled `menuPaperSx` from the music control
- Remove the Contentful footer Favorite albums link (archived) while keeping Spotify; drop the unused `albums` icon mapping

## Test plan
- [x] `turbo check` / `check:types` / `test` for `@dg/ui` and `@dg/web`
- [x] Visual check at 390/768/1024/1280 light+dark with each panel open
- [x] Confirm centers still match, no sticky reflow/scroll lock/overflow
- [x] Footer icon row starts at Cursor (no music disc); Spotify remains

Resolves follow-up to #577


Made with [Cursor](https://cursor.com)