### PR TITLE
Keep the header music disc visible through album transitions

### DIFF
--- a/apps/web/src/app/layouts/MusicHeaderMenu.tsx
+++ b/apps/web/src/app/layouts/MusicHeaderMenu.tsx
@@ -9,7 +9,7 @@ import {
 } from '@dg/ui/core/GlassDisclosurePanel';
 import { Tooltip } from '@dg/ui/core/Tooltip';
 import { PageTransitionLink } from '@dg/ui/core/transitions/PageTransitionLink';
-import { pageTitleMorphName } from '@dg/ui/core/transitions/pageTransitions';
+import { pageTitleMorphName, pageTransitionTypes } from '@dg/ui/core/transitions/pageTransitions';
 import { createBouncyTransition } from '@dg/ui/helpers/bouncyTransition';
 import type { SxObject } from '@dg/ui/theme';
 import { Box, IconButton } from '@mui/material';
@@ -17,7 +17,7 @@ import type { LucideIcon } from 'lucide-react';
 import { Disc3, DiscAlbum, History } from 'lucide-react';
 import { usePathname } from 'next/navigation';
 import type { FocusEvent, KeyboardEvent } from 'react';
-import { useEffect, useId, useLayoutEffect, useRef } from 'react';
+import { useEffect, useId, useRef } from 'react';
 import { isMusicDestinationPath, MUSIC_DESTINATIONS } from './musicHeaderDestinations';
 
 const MUSIC_LABEL = 'Music';
@@ -68,6 +68,35 @@ const destinationLinkSx: SxObject = {
   width: '100%',
 };
 
+/** Only navigations move a heading, so only they need the trigger named. */
+const PAGE_NAVIGATION_CAPTURE = `html:active-view-transition-type(${[
+  ...pageTransitionTypes('open'),
+  ...pageTransitionTypes('close'),
+].join(', ')}) &`;
+
+/**
+ * Lends the trigger's box to a music page's heading, but only while a
+ * navigation is being photographed.
+ *
+ * Held persistently, the name also lifts the trigger out of every *same-page*
+ * transition on a music route — and `page-title-slot` snapshots are deliberately
+ * blanked, since the slot a heading flew out of is a hole rather than a second
+ * copy of it. That blanked the disc for the whole flight every time an album
+ * well opened or closed on the favorite albums page. Unnamed between
+ * navigations, the trigger stays inside the `site-header` snapshot instead,
+ * which paints once at full opacity and never animates.
+ *
+ * The selector leads with `html` rather than `:root`, which Emotion would read
+ * as a pseudo-class on this element and never match.
+ */
+function pageTitleMorphSx(destinationIsOpen: boolean): SxObject {
+  return {
+    [PAGE_NAVIGATION_CAPTURE]: {
+      viewTransitionName: pageTitleMorphName(destinationIsOpen),
+    },
+  };
+}
+
 type MusicHeaderMenuProps = {
   isOpen: boolean;
   onOpenChange: (isOpen: boolean) => void;
@@ -85,13 +114,6 @@ export function MusicHeaderMenu({ isOpen, onOpenChange }: MusicHeaderMenuProps) 
   const listRef = useRef<HTMLDivElement>(null);
   const pathname = usePathname();
   const destinationIsOpen = isMusicDestinationPath(pathname);
-
-  useLayoutEffect(() => {
-    if (!triggerRef.current) {
-      return;
-    }
-    triggerRef.current.style.viewTransitionName = pageTitleMorphName(destinationIsOpen);
-  }, [destinationIsOpen]);
 
   useEffect(() => {
     if (!isOpen) {
@@ -174,7 +196,7 @@ export function MusicHeaderMenu({ isOpen, onOpenChange }: MusicHeaderMenuProps) 
           aria-label={MUSIC_LABEL}
           onClick={() => onOpenChange(!isOpen)}
           ref={triggerRef}
-          sx={triggerSx}
+          sx={{ ...triggerSx, ...pageTitleMorphSx(destinationIsOpen) }}
         >
           <Disc3 size={DISCLOSURE_ICON_SIZE} />
         </IconButton>

--- a/apps/web/src/app/layouts/__tests__/MusicHeaderMenu.test.tsx
+++ b/apps/web/src/app/layouts/__tests__/MusicHeaderMenu.test.tsx
@@ -24,6 +24,23 @@ import { MusicHeaderMenu } from '../MusicHeaderMenu';
 
 const mockUsePathname = usePathname as jest.MockedFunction<typeof usePathname>;
 
+/**
+ * The trigger's name is scoped to a navigation capture rather than set on the
+ * element, so it is absent at rest and only visible in the emitted rule.
+ */
+function capturedTitleName(element: HTMLElement): string | undefined {
+  const matched = [...document.querySelectorAll('style')]
+    .flatMap((style) => [...(style.sheet?.cssRules ?? [])].map((rule) => rule.cssText))
+    .filter(
+      (rule) =>
+        rule.includes('active-view-transition-type') &&
+        [...element.classList].some((className) => rule.includes(`.${className}`)),
+    )
+    .map((rule) => rule.match(/view-transition-name:\s*([\w-]+)/)?.at(1))
+    .filter((name): name is string => Boolean(name));
+  return [...new Set(matched)].at(0);
+}
+
 function TestMusicHeaderMenu() {
   const [isOpen, setIsOpen] = useState(false);
   return <MusicHeaderMenu isOpen={isOpen} onOpenChange={setIsOpen} />;
@@ -55,25 +72,27 @@ describe('MusicHeaderMenu', () => {
     expect(links.map((link) => link.textContent)).toEqual(['Favorite albums', 'Listening history']);
   });
 
-  it('gives only the trigger the page-title name while the menu is open', async () => {
+  /**
+   * A name held at rest also lifts the trigger out of same-page transitions,
+   * whose `page-title-slot` snapshots are blanked — that made the disc vanish
+   * for the length of every album well open and close.
+   */
+  it('names the trigger only for a navigation capture, never at rest', async () => {
     const user = userEvent.setup();
     mockUsePathname.mockReturnValue('/');
     render(<TestMusicHeaderMenu />);
 
     const trigger = screen.getByRole('button', { name: 'Music' });
-    expect(trigger.style.viewTransitionName).toBe(PAGE_TITLE_VIEW_TRANSITION_NAME);
+    expect(trigger.style.viewTransitionName).toBe('');
+    expect(capturedTitleName(trigger)).toBe(PAGE_TITLE_VIEW_TRANSITION_NAME);
 
     await user.click(trigger);
     const menuLinks = screen.getAllByRole('menuitem');
     expect(menuLinks).toHaveLength(2);
     for (const link of menuLinks) {
       expect(link.style.viewTransitionName).toBe('');
+      expect(capturedTitleName(link)).toBeUndefined();
     }
-
-    const named = [trigger, ...menuLinks].filter(
-      (element) => element.style.viewTransitionName === PAGE_TITLE_VIEW_TRANSITION_NAME,
-    );
-    expect(named).toHaveLength(1);
   });
 
   it('closes on Escape and returns focus to the trigger', async () => {
@@ -92,20 +111,13 @@ describe('MusicHeaderMenu', () => {
   it('switches the trigger to the slot name on either music destination', () => {
     mockUsePathname.mockReturnValue(musicRoute);
     const { rerender } = render(<TestMusicHeaderMenu />);
-    expect(screen.getByRole('button', { name: 'Music' }).style.viewTransitionName).toBe(
-      PAGE_TITLE_SLOT_VIEW_TRANSITION_NAME,
-    );
 
-    mockUsePathname.mockReturnValue(favoriteAlbumsRoute);
-    rerender(<TestMusicHeaderMenu />);
-    expect(screen.getByRole('button', { name: 'Music' }).style.viewTransitionName).toBe(
-      PAGE_TITLE_SLOT_VIEW_TRANSITION_NAME,
-    );
-
-    mockUsePathname.mockReturnValue(`${favoriteAlbumsRoute}/album123`);
-    rerender(<TestMusicHeaderMenu />);
-    expect(screen.getByRole('button', { name: 'Music' }).style.viewTransitionName).toBe(
-      PAGE_TITLE_SLOT_VIEW_TRANSITION_NAME,
-    );
+    for (const path of [musicRoute, favoriteAlbumsRoute, `${favoriteAlbumsRoute}/album123`]) {
+      mockUsePathname.mockReturnValue(path);
+      rerender(<TestMusicHeaderMenu />);
+      const trigger = screen.getByRole('button', { name: 'Music' });
+      expect(trigger.style.viewTransitionName).toBe('');
+      expect(capturedTitleName(trigger)).toBe(PAGE_TITLE_SLOT_VIEW_TRANSITION_NAME);
+    }
   });
 });

--- a/package.json
+++ b/package.json
@@ -27,5 +27,5 @@
     "clean": "rm -f .env .env.tmp",
     "preinstall": "npx only-allow pnpm"
   },
-  "version": "2.67.1"
+  "version": "2.67.2"
 }


### PR DESCRIPTION
## Summary

Opening or closing an album well on `/music/albums` made the header music disc vanish for the whole transition.

The trigger held `page-title-slot` for as long as a music route was open, so *every* view transition on that page — not just navigations — lifted it into `::view-transition-group(page-title-slot)`. Both snapshots of that group are deliberately forced to `opacity: 0` (the slot a heading flew out of is a hole, not a second copy of it), so the disc simply stopped painting for the length of every `album-open` / `album-close`.

The name is now scoped to the two page-navigation transition types, mirroring the `pinnedChromeSx` pattern. Between navigations the trigger is unnamed, which leaves it inside the `site-header` snapshot — painted once, at full opacity, never animated.

- Replace the `useLayoutEffect` that assigned `viewTransitionName` imperatively with an `sx` rule under `html:active-view-transition-type(page-open, page-close)`
- Rework the two tests that asserted the persistent inline name to assert the scoped rule plus an unnamed resting element

The morph is unaffected: the transition type is already active when the old snapshot is photographed, so the `page-title` group still starts at the trigger's exact box.

## Test plan

- [x] `turbo check` / `check:types` / `test` — 27/27 tasks, 162/162 tests
- [x] Frame-sampled an album open and close at 90ms intervals with the transition slowed to 2.4s: the disc paints in **all 10 frames** in every combination (open and close, 1280 and 390, dark and light). Reproducing the old persistent name on this same branch blanks **8 of 10 frames**, confirming causality
- [x] `page-title` morph intact: home → `/music` starts the title group at the trigger's 48×48 box; `/music` → home reclaims `page-title` and starts at the heading's box. No title dip
- [x] Theme trigger still unnamed, capsule glass still `blur(12px) saturate(1.5)` and unnamed, and still fits the capsule exactly — all four viewport/scheme combinations

Follow-up to #580.

Made with [Cursor](https://cursor.com)