### PR TITLE
Keep the sticky heading scrim out of the row below it

### DIFF
--- a/apps/web/src/app/music/MusicInfiniteScroll.tsx
+++ b/apps/web/src/app/music/MusicInfiniteScroll.tsx
@@ -22,8 +22,9 @@ const loadingContainerSx: SxObject = {
   py: 2,
 };
 
+/** Trailing space comes from the bar's fade ramp, so only lead the label. */
 const sectionHeaderSx: SxObject = {
-  paddingBlock: 2,
+  paddingBlockStart: 2,
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -27,5 +27,5 @@
     "clean": "rm -f .env .env.tmp",
     "preinstall": "npx only-allow pnpm"
   },
-  "version": "2.67.1"
+  "version": "2.67.2"
 }

--- a/packages/ui/core/StickyFadeBar.tsx
+++ b/packages/ui/core/StickyFadeBar.tsx
@@ -53,35 +53,43 @@ const topMaskSx: SxObject = {
   ...stickyDecorSx,
 };
 
+/** Long enough that the ramp reads as a dissolve rather than an edge. */
+const FADE_HEIGHT = '3rem';
+
 /**
- * Opaque under the content so scrolling cards don't show through the label,
- * and out to the window edges so they don't show up beside it either.
+ * Opaque under the label so scrolling cards don't show through it, and out to
+ * the window edges so they don't show up beside it either. Stops where the
+ * ramp starts, overlapping it by a pixel so no seam shows between the two.
  */
 const barSurfaceSx: SxObject = {
   ...fullBleed,
   ...stickyDecorSx,
   backgroundColor: BACKGROUND,
-  bottom: 0,
+  bottom: `calc(${FADE_HEIGHT} - 1px)`,
   pointerEvents: 'none',
   position: 'absolute',
   top: 0,
   zIndex: 0,
 };
 
-/** Long enough that the ramp reads as a dissolve rather than an edge. */
-const FADE_HEIGHT = '3rem';
-
 /**
- * Trails below the bar so content dissolves as it scrolls under. Alpha follows
- * a smoothstep curve rather than a straight line, so neither end forms a knee:
- * a short or linear ramp reads as a band because perceived luminance doesn't
- * fall off linearly with alpha.
+ * The bar's soft bottom edge, so content dissolves as it scrolls under rather
+ * than meeting the opaque fill at a line. Alpha follows a smoothstep curve
+ * rather than a straight line, so neither end forms a knee: a short or linear
+ * ramp reads as a band because perceived luminance doesn't fall off linearly
+ * with alpha.
+ *
+ * Inside the bar's own band, not trailing below it. A ramp that hangs past the
+ * bar washes whatever is parked under it — the row a heading introduces sits
+ * there at rest, so it lost the top third of its album art to a scrim nothing
+ * was scrolling through. Content still crosses the whole ramp on its way up;
+ * it just finishes dissolving before it reaches the label instead of after.
  */
 const fadeOverlaySx: SxObject = {
   ...fullBleed,
   ...stickyDecorSx,
   background: `linear-gradient(to bottom, ${BACKGROUND} 0%, ${scrim(94)} 15%, ${scrim(78)} 30%, ${scrim(57)} 45%, ${scrim(35)} 60%, ${scrim(16)} 75%, ${scrim(4)} 88%, transparent 100%)`,
-  bottom: `calc(-1 * ${FADE_HEIGHT})`,
+  bottom: 0,
   height: FADE_HEIGHT,
   pointerEvents: 'none',
   position: 'absolute',
@@ -89,6 +97,8 @@ const fadeOverlaySx: SxObject = {
 };
 
 const stickyBarSx: SxObject = {
+  /* Room for the ramp, which lives in the band instead of hanging past it. */
+  paddingBlockEnd: FADE_HEIGHT,
   position: 'sticky',
   /* Sit just under the glass header, which the mask above covers. */
   top: HEADER_HEIGHT,
@@ -106,10 +116,13 @@ type StickyFadeBarProps = Omit<BoxProps, 'sx' | 'children'> & {
 };
 
 /**
- * Sticky bar with a soft fade beneath it, so content dissolves as it scrolls
+ * Sticky bar whose band ends in a soft fade, so content dissolves as it scrolls
  * under rather than colliding with the bar. Theme-aware via the background CSS
  * variable, so it works in both light and dark schemes. The strip above the
  * pinned bar is covered by `StickyBarTopMask`, which the app shell renders.
+ *
+ * The band reserves `FADE_HEIGHT` below its children for the ramp, so children
+ * only need their own leading padding.
  */
 export function StickyFadeBar({ children, sx, ...props }: StickyFadeBarProps) {
   const mergedSx = sx ? { ...stickyBarSx, ...sx } : stickyBarSx;


### PR DESCRIPTION
# What changed?

The fade under a `StickyFadeBar` hung entirely below the bar's box
(`bottom: calc(-1 * 3rem)`), where its first stop is fully opaque page
background. The only space between a bar and the row it introduces is the
section `Stack`'s `spacing={1}` — **8px** — so the rest of the ramp landed on
album art.

Measured on the running app (Chrome 151, `deviceScaleFactor: 2`), fade rect vs.
the first tile's rect:

| Viewport | root font | fade height | gap bar→tile | fade over tile | share of tile |
| --- | --- | --- | --- | --- | --- |
| 1280×800 | 19px | 57px | 8px | **49px** | **32.2%** |
| 390×844 | 16px | 48px | 8px | **40px** | **26.7%** |

Tint was measured, not inferred: screenshot the heading and first row with the
fade painted, again with it hidden, and difference per pixel row. Mean per-row
channel delta (0–255) by depth into the tile, 1280 dark:

```
0px:20.4  5px:68.5  10px:78.3  15px:75.0  20px:59.6  25px:43.0
30px:31.7  35px:18.3  40px:8.3  45px:2.6   (last tinted row 47.5px)
```

Peak wash ~31% of full background coverage about 10px into the artwork, decaying
to nothing at 47.5px — exactly the geometry. It happened **pinned and unpinned
alike**, so gating the fade on "is the bar stuck" would not have fixed it: an
unpinned heading veiled its own row at rest with nothing scrolling through, and a
stuck one veiled whatever row was parked under it.

## Ruled out by measurement

- **Alpha floor:** no. Final stop is `transparent`; the last tinted row measures mean delta 1.1/255 (~0.4%).
- **Fade height fixed while heading height varies:** no. Overlap is constant (49px / 40px) regardless of heading height, because `bottom` is a fixed negative offset.
- **`z-index` inversion:** no. The fade is `z-index: 0` inside the bar's `z-index: 5` sticky context, so it composites above the grid — which is what makes content dissolve as it scrolls under. Moving it beneath would restore the hard edge #573 removed.
- **Dark-mode only:** no. Light peaks at mean delta 74.7 vs. 79.9 dark at 1280.
- **`AlbumStack` shadow/filter:** no. It has only `box-shadow`, no `filter`, and plain `AlbumThumbnail` tiles in the same row wash identically, uniformly across the row width.

## Fix

The ramp moves inside the bar's own band:

- `stickyBarSx` gains `paddingBlockEnd: FADE_HEIGHT`, reserving the ramp's space inside the bar's box.
- `fadeOverlaySx`: `bottom: calc(-1 * FADE_HEIGHT)` → `bottom: 0`, so the transparent end of the ramp coincides with the bar's bottom edge.
- `barSurfaceSx`: `bottom: 0` → `bottom: calc(FADE_HEIGHT - 1px)`, so the opaque fill stops where the ramp starts and overlaps it by a pixel.
- `MusicInfiniteScroll`'s `sectionHeaderSx` drops its trailing padding, since the ramp now provides the space under the label.

The gradient string, its eased stops, and `FADE_HEIGHT` are untouched — same ramp,
same softness, it just finishes dissolving before the label instead of after.
Content scrolling up still crosses the whole ramp on its way behind the opaque
fill.

Deliberately kept: the `3rem` eased ramp (#575), full-bleed via
`insetInlineStart: 50%` / `marginInlineStart: -50vw` / `width: 100vw`, and
`stickyDecorSx`'s transition suppression.

## Verification

Chrome 151 headless, dark and light, 1280×800 and 390×844, at scroll 0 plus three
pinned offsets each.

| Metric | Before | After |
| --- | --- | --- |
| fade bottom − bar bottom | +57px / +48px | **0px** everywhere |
| fade over next visible row | 49px (32.2%) / 40px (26.7%) | **0px** |
| worst tint on next visible row (mean / max) | 79.9 / 216 | **0 / 0** |
| bar band height, 1280 | 74.4px | 115.4px |
| bar band height, 390 | 62.5px | 94.5px |

- **Dissolve still soft:** with a heading pinned, the tint profile inside the band decays monotonically 102 → 4 over ~50px, the same shape as before relocation.
- **No side peek:** fade width = `innerWidth` = `document.scrollWidth` (1280/1280/1280, 390/390/390) in every state, so `overflow-x: clip` still absorbs the full-bleed layers with no horizontal scroll.
- **Several headings:** the live feed currently has one date group, so three extra sections were cloned into the DOM for four sticky bars. At scroll 900/1600/2400/3200 every bar reports `fadeBottom − barBottom = 0` and full-bleed width, and hand-off between stuck bars behaves.
- **Albums sorter** (same component): band 110.6px, `fadeBottom − barBottom = 0`, full-bleed 1280.
- **Page transition** `/music → /music/albums`: the window-top mask computes `opacity: 0` throughout the flight, the bar's surface and fade are absent from the DOM mid-flight, and captured frames show no washed band sliding over the rows.

`turbo check`, `turbo check:types`, `turbo test` pass (59 suites, 266 tests).

Not verified: Firefox and Safari (the change adds no new CSS features — only
`padding-block-end` and a changed `bottom` offset — but it was measured in Chrome
only), and real multi-date-group data.

# Release info

- [ ] Major
- [ ] Minor
- [x] Patch

Made with [Cursor](https://cursor.com)