### PR TITLE
Stop making visitors wait out a Spotify rate limit on /music/albums

### DIFF
--- a/apps/web/src/services/albumDetail.ts
+++ b/apps/web/src/services/albumDetail.ts
@@ -10,6 +10,11 @@ const ALBUM_DETAIL_TAG = 'album-detail';
 /**
  * Cached album-detail read. Isolated so Spotify failures do not poison the
  * hours-long cache with a null entry.
+ *
+ * Local rather than `remote` on purpose: `fetchAlbumDetail` already reads the
+ * database first and writes through, so a miss here costs a fast query rather
+ * than a Spotify call. The favorites playlist needs `remote` because it has no
+ * such store in front of it.
  */
 async function getAlbumDetailCached(albumId: string) {
   'use cache';

--- a/apps/web/src/services/albums.ts
+++ b/apps/web/src/services/albums.ts
@@ -1,5 +1,6 @@
 import 'server-only';
 
+import type { PlaylistAlbum } from '@dg/content-models/spotify/PlaylistAlbums';
 import { fetchPlaylistAlbums } from '@dg/services/spotify/fetchPlaylistAlbums';
 import { isMissingTokenError } from '@dg/shared-core/errors/MissingTokenError';
 import { log } from '@dg/shared-core/logging/log';
@@ -12,39 +13,54 @@ const FAVORITE_ALBUMS_TAG = 'favorite-albums';
 const FAVORITE_ALBUMS_PLAYLIST_ID = '1bbwGrz6rSq5APjRfZp63U';
 
 /**
- * Cached playlist read. Lives in its own scope so a thrown Spotify failure
- * does not write an empty entry into the hours-long cache — the outer
- * wrapper catches and degrades instead.
+ * Cached playlist read, returning a result rather than throwing so that an
+ * unavailable Spotify is cached too.
+ *
+ * Two properties here are load-bearing rather than optimizations:
+ *
+ * `remote`, because this runs outside the static shell (see
+ * `getFavoriteAlbums`) and a plain `use cache` is in-memory per instance.
+ * Serverless instances each missed and re-fetched, turning one rate-limited
+ * endpoint into a per-visitor Spotify call — the documented case for a remote
+ * handler.
+ *
+ * Caching the failure, because Spotify answers a blown quota with a
+ * `Retry-After` measured in hours. Letting the failure escape uncached meant
+ * every single request tried again, which is how the quota got blown in the
+ * first place. Now Spotify sees roughly one attempt per revalidation window,
+ * and recovery still happens on its own once the quota resets.
  */
-async function getFavoriteAlbumsCached() {
-  'use cache';
+async function getFavoriteAlbumsCached(): Promise<
+  { albums: Array<PlaylistAlbum> } | { albums: null }
+> {
+  'use cache: remote';
   cacheLife('hours');
   cacheTag(FAVORITE_ALBUMS_TAG);
-  return await fetchPlaylistAlbums(FAVORITE_ALBUMS_PLAYLIST_ID);
+  try {
+    return { albums: await fetchPlaylistAlbums(FAVORITE_ALBUMS_PLAYLIST_ID) };
+  } catch (error) {
+    if (!isMissingTokenError(error)) {
+      log.warn('Favorite albums unavailable; degrading to empty state', { error });
+    }
+    return { albums: null };
+  }
 }
 
 /**
  * Favorite albums from the curated playlist, deduped and newest-added first,
- * or null when Spotify is unavailable (missing token, rate limit, or other
- * fetch failure) so prerendering degrades instead of failing the build.
- * Successful reads stay hours-cached; failures are not cached.
+ * or null when Spotify is unavailable and nothing has ever been stored, so
+ * prerendering degrades instead of failing the build.
  *
  * Do not schedule `after()` work here: this path can re-execute during ISR
  * revalidation and PPR resume where `waitUntil` can be unavailable, and the
  * resulting throw kills the whole RSC stream.
  */
 export async function getFavoriteAlbums() {
-  // This playlist has no faithful DB representation (membership and addedAt
-  // live only at Spotify). Keep the live refresh out of prerendering; callers
-  // already place it behind Suspense, and successful runtime reads stay cached.
+  // Keep the live refresh out of prerendering so a rate limit can't fail the
+  // build; callers already place this behind Suspense. `fetchPlaylistAlbums`
+  // falls back to the stored snapshot, so a rate limit costs a stale list
+  // rather than an empty page.
   await connection();
-  try {
-    return await getFavoriteAlbumsCached();
-  } catch (error) {
-    if (isMissingTokenError(error)) {
-      return null;
-    }
-    log.warn('Favorite albums unavailable; degrading to empty state', { error });
-    return null;
-  }
+  const { albums } = await getFavoriteAlbumsCached();
+  return albums;
 }

--- a/package.json
+++ b/package.json
@@ -27,5 +27,5 @@
     "clean": "rm -f .env .env.tmp",
     "preinstall": "npx only-allow pnpm"
   },
-  "version": "2.67.2"
+  "version": "2.68.0"
 }

--- a/packages/db/client.ts
+++ b/packages/db/client.ts
@@ -2,6 +2,7 @@ import { log } from '@dg/shared-core/logging/log';
 import { Op } from 'sequelize';
 import { Sequelize } from 'sequelize-typescript';
 import { getDatabaseUrl, sequelizeOptions } from './dbConfig';
+import { FavoriteAlbum } from './models/FavoriteAlbum';
 import { MusicAlbum } from './models/MusicAlbum';
 import { MusicAlbumArtist } from './models/MusicAlbumArtist';
 import { MusicArtist } from './models/MusicArtist';
@@ -14,6 +15,7 @@ import { Token } from './models/Token';
 
 // Models
 export const db = {
+  FavoriteAlbum,
   MusicAlbum,
   MusicAlbumArtist,
   MusicArtist,

--- a/packages/db/migrations/20260807020000-add-favorite-album.js
+++ b/packages/db/migrations/20260807020000-add-favorite-album.js
@@ -1,0 +1,38 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      await queryInterface.createTable(
+        'FavoriteAlbum',
+        {
+          addedAt: { allowNull: false, type: Sequelize.STRING },
+          artistNames: { allowNull: false, type: Sequelize.STRING },
+          id: { allowNull: false, primaryKey: true, type: Sequelize.STRING(22) },
+          imageUrl: { allowNull: false, type: Sequelize.STRING },
+          name: { allowNull: false, type: Sequelize.STRING },
+          primaryArtist: { allowNull: false, type: Sequelize.STRING },
+          releaseDate: { allowNull: false, type: Sequelize.STRING },
+          url: { allowNull: false, type: Sequelize.STRING },
+        },
+        { transaction },
+      );
+
+      await queryInterface.addIndex('FavoriteAlbum', ['addedAt'], {
+        name: 'idx_favorite_album_added_at',
+        transaction,
+      });
+
+      await transaction.commit();
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
+    }
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('FavoriteAlbum');
+  },
+};

--- a/packages/db/models/FavoriteAlbum.ts
+++ b/packages/db/models/FavoriteAlbum.ts
@@ -1,0 +1,40 @@
+import { Column, DataType, Model, PrimaryKey, Table } from 'sequelize-typescript';
+
+// Spotify IDs are 22 characters (base62)
+const ID_LENGTH = 22;
+
+/**
+ * Last known good snapshot of the curated favorites playlist. Playlist
+ * membership and add order live only at Spotify, so without this a rate-limited
+ * or failed playlist fetch leaves the albums page with nothing to show.
+ * Stored flat, exactly as the grid consumes it.
+ */
+@Table({ modelName: 'FavoriteAlbum', timestamps: false })
+export class FavoriteAlbum extends Model {
+  @PrimaryKey
+  @Column(DataType.STRING(ID_LENGTH))
+  declare id: string;
+
+  @Column(DataType.STRING)
+  declare name: string;
+
+  @Column(DataType.STRING)
+  declare artistNames: string;
+
+  @Column(DataType.STRING)
+  declare primaryArtist: string;
+
+  @Column(DataType.STRING)
+  declare imageUrl: string;
+
+  @Column(DataType.STRING)
+  declare url: string;
+
+  /** ISO timestamp the album first entered the playlist; sorts newest first. */
+  @Column(DataType.STRING)
+  declare addedAt: string;
+
+  /** Release date as Spotify reports it: YYYY, YYYY-MM, or YYYY-MM-DD. */
+  @Column(DataType.STRING)
+  declare releaseDate: string;
+}

--- a/packages/services/clients/authenticatedRestClient.ts
+++ b/packages/services/clients/authenticatedRestClient.ts
@@ -28,6 +28,13 @@ export type ClientProps = {
  * Creates a REST client that can be used to fetch resources from a base API, with auto-refreshing
  * access tokens built into the fetch function.
  */
+/**
+ * Ceiling for a single upstream request. Without this a slow third party can
+ * hold a server render open indefinitely, which the user experiences as a page
+ * that never finishes loading.
+ */
+const REQUEST_TIMEOUT_MS = 8_000;
+
 export function createClient({ endpoint, accessKey, refreshTokenConfig }: ClientProps) {
   assertHttpsEndpoint(endpoint);
   const api = wretch(endpoint).content('application/json');
@@ -46,8 +53,18 @@ export function createClient({ endpoint, accessKey, refreshTokenConfig }: Client
   /**
    * Spotify (and similar APIs) send `Retry-After` as seconds or an HTTP date.
    * Returns undefined when the header is missing or unparseable.
+   *
+   * Non-2xx responses arrive as a thrown wretch error rather than a `Response`,
+   * so unwrap that too — otherwise the header is invisible for exactly the
+   * statuses (429, 503) that send it.
    */
-  function readRetryAfterSeconds(resp: unknown): number | undefined {
+  function readRetryAfterSeconds(input: unknown): number | undefined {
+    const resp =
+      input instanceof Response
+        ? input
+        : typeof input === 'object' && input !== null && 'response' in input
+          ? (input as { response: unknown }).response
+          : undefined;
     if (!(resp instanceof Response)) {
       return undefined;
     }
@@ -71,7 +88,9 @@ export function createClient({ endpoint, accessKey, refreshTokenConfig }: Client
    * Wretch chain that can be used to further process the response based on status code.
    */
   async function getWithAuth(resource: string) {
-    const authedApi = await addAuth(api, false);
+    const authedApi = (await addAuth(api, false)).options({
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
     const response = authedApi.get(resource).unauthorized(async (_error, req) => {
       // Renew credentials once and try to fetch again but fail if we hit another unauthorized
       log.info('Unauthorized request, refreshing access token', { resource });

--- a/packages/services/spotify/__tests__/fetchAlbumDetail.test.ts
+++ b/packages/services/spotify/__tests__/fetchAlbumDetail.test.ts
@@ -28,7 +28,7 @@ const mockSpotifyGetWithRetry = jest.fn();
 
 jest.mock('../trackMetadataShared', () => ({
   ...jest.requireActual('../trackMetadataShared'),
-  spotifyGetWithRetry: (...args: Array<unknown>) => mockSpotifyGetWithRetry(...args),
+  spotifyGet: (...args: Array<unknown>) => mockSpotifyGetWithRetry(...args),
 }));
 
 const PREFIX = 'ad';

--- a/packages/services/spotify/__tests__/fetchMusicHistoryPage.test.ts
+++ b/packages/services/spotify/__tests__/fetchMusicHistoryPage.test.ts
@@ -34,7 +34,7 @@ const mockSpotifyGetWithRetry = jest.fn();
 
 jest.mock('../trackMetadataShared', () => ({
   ...jest.requireActual('../trackMetadataShared'),
-  spotifyGetWithRetry: (...args: Array<unknown>) => mockSpotifyGetWithRetry(...args),
+  spotifyGet: (...args: Array<unknown>) => mockSpotifyGetWithRetry(...args),
 }));
 
 // Use unique prefix for this test file to avoid conflicts with parallel tests

--- a/packages/services/spotify/__tests__/fetchPlaylistAlbums.test.ts
+++ b/packages/services/spotify/__tests__/fetchPlaylistAlbums.test.ts
@@ -1,7 +1,14 @@
 const mockGet = jest.fn();
+const mockReadSnapshot = jest.fn();
+const mockWriteSnapshot = jest.fn();
 
 jest.mock('../spotifyClient', () => ({
   getSpotifyClient: () => ({ get: mockGet }),
+}));
+
+jest.mock('../favoriteAlbumsSnapshot', () => ({
+  readFavoriteAlbumsSnapshot: () => mockReadSnapshot(),
+  writeFavoriteAlbumsSnapshot: (albums: unknown) => mockWriteSnapshot(albums),
 }));
 
 import { fetchPlaylistAlbums } from '../fetchPlaylistAlbums';
@@ -41,6 +48,8 @@ const buildPage = (albumIds: Array<string>, next: string | null) => ({
 describe('fetchPlaylistAlbums', () => {
   beforeEach(() => {
     mockGet.mockReset();
+    mockReadSnapshot.mockReset().mockResolvedValue(null);
+    mockWriteSnapshot.mockReset().mockResolvedValue(undefined);
   });
 
   it('pages through the playlist and dedupes albums across pages', async () => {
@@ -56,7 +65,28 @@ describe('fetchPlaylistAlbums', () => {
     expect(albums.map((album) => album.id).sort()).toEqual(['a', 'b', 'c']);
   });
 
-  it('throws on a non-200 status instead of returning an empty list', async () => {
+  it('stores each successful read so a later failure has something to serve', async () => {
+    mockGet.mockResolvedValueOnce(buildPage(['a'], null));
+
+    await fetchPlaylistAlbums('playlist-id');
+
+    expect(mockWriteSnapshot).toHaveBeenCalledWith([expect.objectContaining({ id: 'a' })]);
+  });
+
+  it('serves the stored list when Spotify rate limits, without waiting', async () => {
+    const stored = [{ id: 'stored-album', name: 'Stored' }];
+    mockGet.mockResolvedValue({ response: { json: async () => ({}) }, status: 429 });
+    mockReadSnapshot.mockResolvedValue(stored);
+
+    const started = Date.now();
+    const albums = await fetchPlaylistAlbums('playlist-id');
+
+    expect(albums).toEqual(stored);
+    expect(mockGet).toHaveBeenCalledTimes(1);
+    expect(Date.now() - started).toBeLessThan(1000);
+  });
+
+  it('throws when the live read fails and nothing is stored', async () => {
     mockGet.mockResolvedValueOnce({ response: { json: async () => ({}) }, status: 403 });
 
     await expect(fetchPlaylistAlbums('playlist-id')).rejects.toThrow('status 403');

--- a/packages/services/spotify/__tests__/trackMetadataShared.test.ts
+++ b/packages/services/spotify/__tests__/trackMetadataShared.test.ts
@@ -5,9 +5,8 @@ import {
   extractMetadataFromTrack,
   extractTrackId,
   getExistingTrackMetadata,
-  RETRY_CONFIG,
   sleep,
-  spotifyGetWithRetry,
+  spotifyGet,
   trackSchema,
 } from '../trackMetadataShared';
 
@@ -214,7 +213,7 @@ describe('extractMetadataFromTrack', () => {
   });
 });
 
-describe('spotifyGetWithRetry', () => {
+describe('spotifyGet', () => {
   const testSchema = v.looseObject({
     data: v.string(),
   });
@@ -229,7 +228,7 @@ describe('spotifyGetWithRetry', () => {
       status: 200,
     });
 
-    const result = await spotifyGetWithRetry('test-resource', testSchema, 'test');
+    const result = await spotifyGet('test-resource', testSchema, 'test');
 
     expect(result).toEqual({
       data: { data: 'test-value' },
@@ -245,7 +244,7 @@ describe('spotifyGetWithRetry', () => {
       status: 500,
     });
 
-    const result = await spotifyGetWithRetry('test-resource', testSchema, 'test');
+    const result = await spotifyGet('test-resource', testSchema, 'test');
 
     expect(result).toEqual({
       error: 'HTTP 500',
@@ -260,7 +259,7 @@ describe('spotifyGetWithRetry', () => {
       status: 404,
     });
 
-    const result = await spotifyGetWithRetry('test-resource', testSchema, 'test');
+    const result = await spotifyGet('test-resource', testSchema, 'test');
 
     expect(result).toEqual({
       error: 'HTTP 404',
@@ -269,62 +268,24 @@ describe('spotifyGetWithRetry', () => {
     });
   });
 
-  it('does not retry before a Retry-After beyond the bounded retry budget', async () => {
+  it('gives up immediately on a rate limit instead of making the caller wait', async () => {
     mockSpotifyGet.mockResolvedValue({
       response: { json: async () => ({}) },
-      retryAfterSeconds: RETRY_CONFIG.maxBackoffSeconds + 1,
+      retryAfterSeconds: 30,
       status: 429,
     });
 
-    const result = await spotifyGetWithRetry('test-resource', testSchema, 'test');
+    const started = Date.now();
+    const result = await spotifyGet('test-resource', testSchema, 'test');
 
     expect(mockSpotifyGet).toHaveBeenCalledTimes(1);
+    expect(Date.now() - started).toBeLessThan(1000);
     expect(result).toEqual({
-      error: `Retry after ${RETRY_CONFIG.maxBackoffSeconds + 1}s`,
+      error: 'HTTP 429',
       status: 429,
       success: false,
     });
   });
-
-  it('retries on 429 rate limit then succeeds', async () => {
-    let callCount = 0;
-    mockSpotifyGet.mockImplementation(() => {
-      callCount++;
-      if (callCount === 1) {
-        return Promise.resolve({ response: { json: async () => ({}) }, status: 429 });
-      }
-      return Promise.resolve({
-        response: { json: async () => ({ data: 'retry-success' }) },
-        status: 200,
-      });
-    });
-
-    const result = await spotifyGetWithRetry('test-resource', testSchema, 'test');
-
-    expect(callCount).toBe(2);
-    expect(result).toEqual({
-      data: { data: 'retry-success' },
-      status: 200,
-      success: true,
-    });
-  }, 15000);
-
-  it('fails after max retries on persistent 429', async () => {
-    mockSpotifyGet.mockResolvedValue({
-      response: { json: async () => ({}) },
-      status: 429,
-    });
-
-    const result = await spotifyGetWithRetry('test-resource', testSchema, 'test');
-
-    // 4 calls: initial + 3 retries
-    expect(mockSpotifyGet).toHaveBeenCalledTimes(4);
-    expect(result).toEqual({
-      error: 'Max retries exceeded',
-      status: 429,
-      success: false,
-    });
-  }, 60000);
 });
 
 describe('trackSchema', () => {

--- a/packages/services/spotify/favoriteAlbumsSnapshot.ts
+++ b/packages/services/spotify/favoriteAlbumsSnapshot.ts
@@ -1,0 +1,56 @@
+import 'server-only';
+
+import type { PlaylistAlbum } from '@dg/content-models/spotify/PlaylistAlbums';
+import { db, dbClient } from '@dg/db';
+import { log } from '@dg/shared-core/logging/log';
+
+const SNAPSHOT_FIELDS = [
+  'addedAt',
+  'artistNames',
+  'id',
+  'imageUrl',
+  'name',
+  'primaryArtist',
+  'releaseDate',
+  'url',
+] as const;
+
+/**
+ * Last stored favorites list, newest playlist addition first, or null when
+ * nothing has been stored yet. Never throws: a missing table (a preview
+ * deployment reading a database that hasn't migrated) has to degrade rather
+ * than take the page down.
+ */
+export async function readFavoriteAlbumsSnapshot(): Promise<Array<PlaylistAlbum> | null> {
+  try {
+    const rows = await db.FavoriteAlbum.findAll({
+      attributes: [...SNAPSHOT_FIELDS],
+      order: [['addedAt', 'DESC']],
+      raw: true,
+    });
+    return rows.length > 0 ? (rows as unknown as Array<PlaylistAlbum>) : null;
+  } catch (error) {
+    log.warn('Could not read stored favorite albums', { error });
+    return null;
+  }
+}
+
+/**
+ * Replaces the stored favorites list with a fresh one. The playlist is the
+ * source of truth, so removals have to disappear here too — hence replace
+ * rather than upsert. Never throws; failing to store is not worth failing a
+ * request that already has its data.
+ */
+export async function writeFavoriteAlbumsSnapshot(albums: Array<PlaylistAlbum>): Promise<void> {
+  if (albums.length === 0) {
+    return;
+  }
+  try {
+    await dbClient.transaction(async (transaction) => {
+      await db.FavoriteAlbum.destroy({ transaction, where: {} });
+      await db.FavoriteAlbum.bulkCreate([...albums], { transaction });
+    });
+  } catch (error) {
+    log.warn('Could not store favorite albums', { error });
+  }
+}

--- a/packages/services/spotify/fetchAlbumDetail.ts
+++ b/packages/services/spotify/fetchAlbumDetail.ts
@@ -7,7 +7,7 @@ import { MusicTrack } from '@dg/db/models/MusicTrack';
 import { MusicTrackArtist } from '@dg/db/models/MusicTrackArtist';
 import * as v from 'valibot';
 import type { AlbumDetail, AlbumDetailArtist, AlbumDetailTrack } from './albumDetailTypes';
-import { spotifyGetWithRetry } from './trackMetadataShared';
+import { spotifyGet } from './trackMetadataShared';
 
 export type { AlbumDetail, AlbumDetailArtist, AlbumDetailTrack } from './albumDetailTypes';
 
@@ -185,7 +185,7 @@ async function fetchAllAlbumTracks(
   let offset = items.length;
 
   while (next) {
-    const page = await spotifyGetWithRetry(
+    const page = await spotifyGet(
       `albums/${albumId}/tracks?limit=50&offset=${offset}`,
       albumTracksPageSchema,
       'album tracks page',
@@ -202,7 +202,7 @@ async function fetchAllAlbumTracks(
 }
 
 async function fetchAlbumFromSpotify(albumId: string): Promise<AlbumDetail | null> {
-  const result = await spotifyGetWithRetry(`albums/${albumId}`, albumDetailSchema, 'album detail');
+  const result = await spotifyGet(`albums/${albumId}`, albumDetailSchema, 'album detail');
   if (!result.success) {
     if (result.status === 404) {
       return null;

--- a/packages/services/spotify/fetchPlaylistAlbums.ts
+++ b/packages/services/spotify/fetchPlaylistAlbums.ts
@@ -6,7 +6,8 @@ import {
   playlistItemsPageApiSchema,
 } from '@dg/content-models/spotify/PlaylistAlbums';
 import { log } from '@dg/shared-core/logging/log';
-import { spotifyGetWithRetry } from './trackMetadataShared';
+import { readFavoriteAlbumsSnapshot, writeFavoriteAlbumsSnapshot } from './favoriteAlbumsSnapshot';
+import { spotifyGet } from './trackMetadataShared';
 
 const PAGE_SIZE = 50;
 
@@ -18,17 +19,29 @@ const MAX_PAGES = 100;
 
 /**
  * Fetches every item of a playlist and collapses them into unique albums,
- * newest playlist addition first. Throws on non-200 so callers never cache
- * a silently empty list. Rate limits are retried (Retry-After aware) inside
- * spotifyGetWithRetry before this throws.
+ * newest playlist addition first.
+ *
+ * This runs on a user's request path, so it never waits out a rate limit. A
+ * live read that fails falls back to the stored snapshot from the last
+ * successful read, and only throws when there is nothing stored either — so
+ * callers can still tell "no data at all" from "showing slightly stale data".
+ * A successful read refreshes the snapshot for the next failure.
  */
 export async function fetchPlaylistAlbums(playlistId: string): Promise<Array<PlaylistAlbum>> {
   const items: Array<unknown> = [];
   let hasMore = true;
   for (let page = 0; hasMore && page < MAX_PAGES; page += 1) {
     const resource = `playlists/${playlistId}/tracks?limit=${PAGE_SIZE}&offset=${page * PAGE_SIZE}`;
-    const result = await spotifyGetWithRetry(resource, playlistItemsPageApiSchema, 'playlist page');
+    const result = await spotifyGet(resource, playlistItemsPageApiSchema, 'playlist page');
     if (!result.success) {
+      const stored = await readFavoriteAlbumsSnapshot();
+      if (stored) {
+        log.warn('Serving stored favorite albums; live playlist read failed', {
+          playlistId,
+          status: result.status,
+        });
+        return stored;
+      }
       throw new Error(`Spotify playlist ${playlistId} fetch failed with status ${result.status}`);
     }
     items.push(...result.data.items);
@@ -40,5 +53,7 @@ export async function fetchPlaylistAlbums(playlistId: string): Promise<Array<Pla
       playlistId,
     });
   }
-  return mapPlaylistAlbumsFromApi(items);
+  const albums = mapPlaylistAlbumsFromApi(items);
+  await writeFavoriteAlbumsSnapshot(albums);
+  return albums;
 }

--- a/packages/services/spotify/trackMetadataShared.ts
+++ b/packages/services/spotify/trackMetadataShared.ts
@@ -73,67 +73,35 @@ export function sleep(ms: number): Promise<void> {
 }
 
 /**
- * Retry configuration for Spotify API calls.
- */
-export const RETRY_CONFIG = {
-  /** Initial wait time in seconds for rate limit backoff */
-  initialBackoffSeconds: 5,
-  /** Maximum wait time in seconds for rate limit backoff */
-  maxBackoffSeconds: 30,
-  /** Maximum number of retries for rate-limited requests */
-  maxRetries: 3,
-} as const;
-
-/**
- * Result of a Spotify API request with rate limit retry.
+ * Result of a Spotify API request.
  */
 export type SpotifyRequestResult<T> =
   | { success: true; data: T; status: 200 }
   | { success: false; status: number; error: string };
 
 /**
- * Makes a GET request to Spotify with automatic rate limit retry.
- * Prefers Spotify's Retry-After when present, otherwise exponential backoff,
- * always capped at maxBackoffSeconds and maxRetries.
+ * Makes a GET request to Spotify and validates the payload.
+ *
+ * Deliberately does not retry. Every caller is on a page render, and sleeping
+ * through a rate limit while a visitor waits is never the right trade — an
+ * earlier backoff ladder here made `/music/albums` hang for 51 seconds before
+ * showing an empty page. Rate limits are absorbed by caching the successful
+ * result and by falling back to stored data, not by waiting.
  */
-export async function spotifyGetWithRetry<T>(
+export async function spotifyGet<T>(
   resource: string,
   schema: v.GenericSchema<unknown, T>,
   context: string,
 ): Promise<SpotifyRequestResult<T>> {
-  let retries = 0;
+  const { response, retryAfterSeconds, status } = await getSpotifyClient().get(resource);
 
-  while (retries <= RETRY_CONFIG.maxRetries) {
-    const { response, retryAfterSeconds, status } = await getSpotifyClient().get(resource);
-
+  if (status !== 200) {
     if (status === 429) {
-      if (retryAfterSeconds && retryAfterSeconds > RETRY_CONFIG.maxBackoffSeconds) {
-        log.warn(`Spotify rate limit exceeds retry budget (${context})`, {
-          resource,
-          retryAfterSeconds,
-        });
-        return { error: `Retry after ${retryAfterSeconds}s`, status, success: false };
-      }
-      const waitSeconds = retryAfterSeconds ?? RETRY_CONFIG.initialBackoffSeconds * (retries + 1);
-      log.warn(`Spotify rate limited (${context}), waiting`, {
-        resource,
-        retries,
-        retryAfterSeconds,
-        waitSeconds,
-      });
-      await sleep(waitSeconds * 1000);
-      retries++;
-      continue;
+      log.warn(`Spotify rate limited (${context})`, { resource, retryAfterSeconds });
     }
-
-    if (status !== 200) {
-      return { error: `HTTP ${status}`, status, success: false };
-    }
-
-    const data = v.parse(schema, await response.json());
-    return { data, status: 200, success: true };
+    return { error: `HTTP ${status}`, status, success: false };
   }
 
-  log.warn(`Spotify request failed after max retries (${context})`, { resource });
-  return { error: 'Max retries exceeded', status: 429, success: false };
+  const data = v.parse(schema, await response.json());
+  return { data, status: 200, success: true };
 }

--- a/packages/services/spotify/trackMetadataSingle.ts
+++ b/packages/services/spotify/trackMetadataSingle.ts
@@ -1,7 +1,7 @@
 import 'server-only';
 
 import * as v from 'valibot';
-import { spotifyGetWithRetry } from './trackMetadataShared';
+import { spotifyGet } from './trackMetadataShared';
 
 /**
  * Extended track schema for fetching display-ready data.
@@ -69,11 +69,7 @@ function bestImage(images: Array<{ height: number; url: string; width: number }>
  * Returns structured data ready for Music* table inserts.
  */
 export async function fetchTrackDisplayData(trackId: string): Promise<TrackDisplayData | null> {
-  const result = await spotifyGetWithRetry(
-    `tracks/${trackId}`,
-    trackDisplaySchema,
-    'track display',
-  );
+  const result = await spotifyGet(`tracks/${trackId}`, trackDisplaySchema, 'track display');
   if (!result.success) {
     return null;
   }


### PR DESCRIPTION
## Summary

`/music/albums` took **51 seconds** to load in production and then rendered an empty state. This is a regression from #582.

The measured cause, in order:

1. **A backoff ladder ran on the page render.** Spotify answers our favorites-playlist reads with `429 QUOTA_EXCEEDED` and `Retry-After: 19572` (~5.4 hours). The retry path slept 5 + 10 + 15 + 20 = **50 seconds** before giving up — that is the 51 seconds, almost exactly. `spotifyGetWithRetry` becomes `spotifyGet` and no longer retries; every caller of it was a page render, and none was ever a background job.
2. **The cached playlist read was in-memory only.** Plain `use cache` stores entries per instance, so once #582 deferred the read to request time with `connection()`, serverless instances each missed and re-fetched — turning one rate-limited endpoint into a per-visitor Spotify call. It is now `use cache: remote`, the documented case for a rate-limited upstream outside the static shell.
3. **An unavailable Spotify was never cached.** The failure escaped the cache scope, so every request tried again, which is how the quota got blown. The cached scope now returns a result instead of throwing, so a blown quota costs about one attempt per revalidation window and still recovers on its own.
4. **The playlist had no database fallback**, unlike album detail (which is already DB-first with write-through). A new `FavoriteAlbum` snapshot records each successful read, so a failed live read serves the last known list rather than an empty page.

Also bounds every outbound request with an 8s `AbortSignal.timeout`, and fixes `Retry-After` parsing — wretch throws on non-2xx, so the header was invisible for exactly the statuses that send it. The real 5.4-hour value now shows up in logs.

## Measured before / after

Production today, and the same build locally against the same quota-blocked Spotify:

| | Before | After |
|---|---|---|
| First request | 51.0s | 1.78s (cold start) |
| Warm request | 51.4s | **0.01s** |
| Spotify calls per request | 1+ every request | 0 once cached |
| Result shown | empty after 51s | empty fast, real albums once the snapshot exists |

For reference, `/music` is 0.46s and `/` is 1.0s, so warm `/music/albums` is now well inside normal.

## Notes

- The build still makes **zero** Spotify calls (verified against a forced production build) and `/music/albums` stays partially prerendered (`◐`).
- The quota block predates this PR and clears on Spotify's schedule. Until the first successful read, the page shows its fast empty state; after that the snapshot keeps it populated through future rate limits.
- `FavoriteAlbum` migrations run on production builds only, so the preview deployment reads a database without that table. `readFavoriteAlbumsSnapshot` swallows that and falls through, so the preview exercises the timing fix but not the snapshot fallback.

## Verification
- [x] `turbo check`
- [x] `turbo check:types`
- [x] `turbo test` — 45 web suites / 179 tests; 16 services suites / 105 tests
- [x] Production build makes no `playlists/` or `albums/` Spotify calls
- [x] Timing measured on the built app, not just dev

## Version
- [ ] Major
- [x] Minor
- [ ] Patch

Made with [Cursor](https://cursor.com)