### PR TITLE
Refresh favorite albums in the Spotify cron

### DIFF
--- a/.github/workflows/spotify-sync.yml
+++ b/.github/workflows/spotify-sync.yml
@@ -1,4 +1,4 @@
-# Sync Spotify listening history every 30 minutes
+# Sync Spotify listening history and favorite albums every 30 minutes
 name: Spotify sync
 
 on:

--- a/apps/web/src/app/api/spotify/sync/__tests__/route.test.ts
+++ b/apps/web/src/app/api/spotify/sync/__tests__/route.test.ts
@@ -7,10 +7,15 @@ jest.mock('@dg/services/spotify/spotifyClient', () => ({
   getSpotifyClient: jest.fn(),
 }));
 
+jest.mock('@dg/services/spotify/refreshFavoriteAlbumsSnapshot', () => ({
+  refreshFavoriteAlbumsSnapshotWithLogging: jest.fn(),
+}));
+
 jest.mock('next/cache', () => ({
   revalidateTag: jest.fn(),
 }));
 
+import { refreshFavoriteAlbumsSnapshotWithLogging } from '@dg/services/spotify/refreshFavoriteAlbumsSnapshot';
 // Get typed references to the mocked functions
 import * as spotifyClient from '@dg/services/spotify/spotifyClient';
 import { revalidateTag } from 'next/cache';
@@ -18,6 +23,7 @@ import { handleSpotifySync } from '../route';
 
 const mockSpotifyGet = jest.fn();
 const mockGetSpotifyClient = jest.mocked(spotifyClient.getSpotifyClient);
+const mockRefreshFavoriteAlbums = jest.mocked(refreshFavoriteAlbumsSnapshotWithLogging);
 const mockRevalidateTag = jest.mocked(revalidateTag);
 
 // Use unique prefix for this test file to avoid conflicts with parallel tests
@@ -71,6 +77,7 @@ beforeAll(() => {
 
 beforeEach(async () => {
   jest.clearAllMocks();
+  mockRefreshFavoriteAlbums.mockResolvedValue({ count: 3 });
   mockGetSpotifyClient.mockReturnValue({ get: mockSpotifyGet } as ReturnType<
     typeof spotifyClient.getSpotifyClient
   >);
@@ -135,6 +142,8 @@ describe('Spotify sync route', () => {
 
     expect(response.status).toBe(200);
     expect(response.body).toEqual({
+      favoriteAlbums: 3,
+      favoriteAlbumsRefreshed: true,
       gapDetected: false,
       inserted: 1,
       success: true,
@@ -144,6 +153,7 @@ describe('Spotify sync route', () => {
       expect.stringMatching(/^me\/player\/recently-played\?limit=50$/),
     );
     expect(mockRevalidateTag).toHaveBeenCalledWith('music-history', 'max');
+    expect(mockRevalidateTag).toHaveBeenCalledWith('favorite-albums', 'max');
   });
 
   it('syncs when history already exists', async () => {
@@ -176,6 +186,8 @@ describe('Spotify sync route', () => {
     expect(response.body.total).toBe(1);
     expect(response.body.gapDetected).toBe(false);
     expect(response.body.success).toBe(true);
+    expect(response.body.favoriteAlbums).toBe(3);
+    expect(response.body.favoriteAlbumsRefreshed).toBe(true);
     // Count only rows with our test prefix to avoid conflicts with parallel tests
     const rowCount = await db.SpotifyPlay.count({
       where: { trackId: { [Op.like]: `${PREFIX}-%` } },
@@ -184,5 +196,6 @@ describe('Spotify sync route', () => {
 
     // Verify revalidateTag was called when tracks were inserted
     expect(mockRevalidateTag).toHaveBeenCalledWith('music-history', 'max');
+    expect(mockRevalidateTag).toHaveBeenCalledWith('favorite-albums', 'max');
   });
 });

--- a/apps/web/src/app/api/spotify/sync/route.ts
+++ b/apps/web/src/app/api/spotify/sync/route.ts
@@ -1,3 +1,4 @@
+import { refreshFavoriteAlbumsSnapshotWithLogging } from '@dg/services/spotify/refreshFavoriteAlbumsSnapshot';
 import { syncSpotifyHistoryWithLogging } from '@dg/services/spotify/syncSpotifyHistory';
 import { log } from '@dg/shared-core/logging/log';
 import { revalidateTag } from 'next/cache';
@@ -12,6 +13,8 @@ type SyncResponse = {
   status: number;
   body: {
     error?: string;
+    favoriteAlbums?: number;
+    favoriteAlbumsRefreshed?: boolean;
     gapDetected?: boolean;
     inserted?: number;
     success?: boolean;
@@ -31,9 +34,21 @@ export async function handleSpotifySync(request: NextRequest): Promise<SyncRespo
     context: 'cron',
     failureLogLevel: 'error',
   });
+  const favoriteAlbums = await refreshFavoriteAlbumsSnapshotWithLogging();
+
+  if (favoriteAlbums) {
+    revalidateTag('favorite-albums', 'max');
+  }
 
   if (!result) {
-    return { body: { error: 'Sync failed' }, status: 500 };
+    return {
+      body: {
+        error: 'History sync failed',
+        favoriteAlbums: favoriteAlbums?.count,
+        favoriteAlbumsRefreshed: favoriteAlbums !== null,
+      },
+      status: 500,
+    };
   }
 
   if (result.inserted > 0) {
@@ -42,6 +57,8 @@ export async function handleSpotifySync(request: NextRequest): Promise<SyncRespo
 
   return {
     body: {
+      favoriteAlbums: favoriteAlbums?.count,
+      favoriteAlbumsRefreshed: favoriteAlbums !== null,
       gapDetected: result.gapDetected,
       inserted: result.inserted,
       success: true,

--- a/apps/web/src/app/music/albums/layout.tsx
+++ b/apps/web/src/app/music/albums/layout.tsx
@@ -22,8 +22,15 @@ export const metadata: Metadata = {
 async function AlbumsGrid({ children }: { children: ReactNode }) {
   const albums = await getFavoriteAlbums();
 
-  if (!albums?.length) {
-    return <Typography color="text.secondary">No albums right now. Check back soon.</Typography>;
+  if (albums === null) {
+    return (
+      <Typography color="text.secondary">
+        Favorite albums are temporarily unavailable. Please try again soon.
+      </Typography>
+    );
+  }
+  if (albums.length === 0) {
+    return <Typography color="text.secondary">No favorite albums yet.</Typography>;
   }
 
   return <FavoriteAlbumsGrid albums={albums}>{children}</FavoriteAlbumsGrid>;

--- a/apps/web/src/services/albums.ts
+++ b/apps/web/src/services/albums.ts
@@ -1,66 +1,21 @@
 import 'server-only';
 
-import type { PlaylistAlbum } from '@dg/content-models/spotify/PlaylistAlbums';
-import { fetchPlaylistAlbums } from '@dg/services/spotify/fetchPlaylistAlbums';
-import { isMissingTokenError } from '@dg/shared-core/errors/MissingTokenError';
-import { log } from '@dg/shared-core/logging/log';
+import { readFavoriteAlbumsSnapshot } from '@dg/services/spotify/favoriteAlbumsSnapshot';
 import { cacheLife, cacheTag } from 'next/cache';
-import { connection } from 'next/server';
 
 const FAVORITE_ALBUMS_TAG = 'favorite-albums';
 
-/** Playlist holding one or more tracks from each favorite album. */
-const FAVORITE_ALBUMS_PLAYLIST_ID = '1bbwGrz6rSq5APjRfZp63U';
-
 /**
- * Cached playlist read, returning a result rather than throwing so that an
- * unavailable Spotify is cached too.
+ * Favorite albums are read only from the database snapshot. The half-hourly
+ * Spotify sync owns refreshing it, so neither page renders nor builds ever
+ * touch the rate-limited playlist endpoint.
  *
- * Two properties here are load-bearing rather than optimizations:
- *
- * `remote`, because this runs outside the static shell (see
- * `getFavoriteAlbums`) and a plain `use cache` is in-memory per instance.
- * Serverless instances each missed and re-fetched, turning one rate-limited
- * endpoint into a per-visitor Spotify call — the documented case for a remote
- * handler.
- *
- * Caching the failure, because Spotify answers a blown quota with a
- * `Retry-After` measured in hours. Letting the failure escape uncached meant
- * every single request tried again, which is how the quota got blown in the
- * first place. Now Spotify sees roughly one attempt per revalidation window,
- * and recovery still happens on its own once the quota resets.
- */
-async function getFavoriteAlbumsCached(): Promise<
-  { albums: Array<PlaylistAlbum> } | { albums: null }
-> {
-  'use cache: remote';
-  cacheLife('hours');
-  cacheTag(FAVORITE_ALBUMS_TAG);
-  try {
-    return { albums: await fetchPlaylistAlbums(FAVORITE_ALBUMS_PLAYLIST_ID) };
-  } catch (error) {
-    if (!isMissingTokenError(error)) {
-      log.warn('Favorite albums unavailable; degrading to empty state', { error });
-    }
-    return { albums: null };
-  }
-}
-
-/**
- * Favorite albums from the curated playlist, deduped and newest-added first,
- * or null when Spotify is unavailable and nothing has ever been stored, so
- * prerendering degrades instead of failing the build.
- *
- * Do not schedule `after()` work here: this path can re-execute during ISR
- * revalidation and PPR resume where `waitUntil` can be unavailable, and the
- * resulting throw kills the whole RSC stream.
+ * A regular cache is sufficient here because the database is already the
+ * shared durable cache; a miss costs one fast query, not a Spotify call.
  */
 export async function getFavoriteAlbums() {
-  // Keep the live refresh out of prerendering so a rate limit can't fail the
-  // build; callers already place this behind Suspense. `fetchPlaylistAlbums`
-  // falls back to the stored snapshot, so a rate limit costs a stale list
-  // rather than an empty page.
-  await connection();
-  const { albums } = await getFavoriteAlbumsCached();
-  return albums;
+  'use cache';
+  cacheLife('hours');
+  cacheTag(FAVORITE_ALBUMS_TAG);
+  return await readFavoriteAlbumsSnapshot();
 }

--- a/package.json
+++ b/package.json
@@ -27,5 +27,5 @@
     "clean": "rm -f .env .env.tmp",
     "preinstall": "npx only-allow pnpm"
   },
-  "version": "2.68.0"
+  "version": "2.68.1"
 }

--- a/packages/db/client.ts
+++ b/packages/db/client.ts
@@ -3,6 +3,7 @@ import { Op } from 'sequelize';
 import { Sequelize } from 'sequelize-typescript';
 import { getDatabaseUrl, sequelizeOptions } from './dbConfig';
 import { FavoriteAlbum } from './models/FavoriteAlbum';
+import { FavoriteAlbumSnapshot } from './models/FavoriteAlbumSnapshot';
 import { MusicAlbum } from './models/MusicAlbum';
 import { MusicAlbumArtist } from './models/MusicAlbumArtist';
 import { MusicArtist } from './models/MusicArtist';
@@ -16,6 +17,7 @@ import { Token } from './models/Token';
 // Models
 export const db = {
   FavoriteAlbum,
+  FavoriteAlbumSnapshot,
   MusicAlbum,
   MusicAlbumArtist,
   MusicArtist,

--- a/packages/db/migrations/20260807070000-add-favorite-album-snapshot.js
+++ b/packages/db/migrations/20260807070000-add-favorite-album-snapshot.js
@@ -1,0 +1,20 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('FavoriteAlbumSnapshot', {
+      refreshedAt: { allowNull: false, type: Sequelize.DATE },
+      singleton: {
+        allowNull: false,
+        defaultValue: true,
+        primaryKey: true,
+        type: Sequelize.BOOLEAN,
+      },
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('FavoriteAlbumSnapshot');
+  },
+};

--- a/packages/db/models/FavoriteAlbumSnapshot.ts
+++ b/packages/db/models/FavoriteAlbumSnapshot.ts
@@ -1,0 +1,16 @@
+import { Column, DataType, Model, PrimaryKey, Table } from 'sequelize-typescript';
+
+/**
+ * Marks that the favorite-albums snapshot has completed at least once.
+ * The row is separate from FavoriteAlbum so an intentionally empty playlist
+ * can be distinguished from a snapshot that has never been populated.
+ */
+@Table({ modelName: 'FavoriteAlbumSnapshot', timestamps: false })
+export class FavoriteAlbumSnapshot extends Model {
+  @PrimaryKey
+  @Column(DataType.BOOLEAN)
+  declare singleton: boolean;
+
+  @Column(DataType.DATE)
+  declare refreshedAt: Date;
+}

--- a/packages/services/README.md
+++ b/packages/services/README.md
@@ -89,6 +89,7 @@ Spotify API integration for currently playing, history, and albums.
 | `fetchRecentlyPlayed()`      | Recently played or currently playing track            |
 | `fetchMusicHistoryPage()`    | Paginated listening history from the DB               |
 | `fetchPlaylistAlbums()`      | Favorite albums from a playlist                       |
+| `refreshFavoriteAlbumsSnapshot()` | Refresh the DB snapshot from the playlist         |
 | `syncSpotifyHistory()`       | Incremental history sync (seeds empty DB from recent plays) |
 | `spotifyClient`              | Configured REST client with token refresh             |
 | `CurrentlyPlaying`           | Type in `@dg/content-models/spotify/CurrentlyPlaying` |

--- a/packages/services/spotify/__tests__/favoriteAlbumsSnapshot.test.ts
+++ b/packages/services/spotify/__tests__/favoriteAlbumsSnapshot.test.ts
@@ -30,4 +30,10 @@ describe('favorite albums snapshot', () => {
     await writeFavoriteAlbumsSnapshot([album]);
     await expect(readFavoriteAlbumsSnapshot()).resolves.toEqual([album]);
   });
+
+  it('reads populated rows without requiring the newer marker table state', async () => {
+    await db.FavoriteAlbum.create(album);
+
+    await expect(readFavoriteAlbumsSnapshot()).resolves.toEqual([album]);
+  });
 });

--- a/packages/services/spotify/__tests__/favoriteAlbumsSnapshot.test.ts
+++ b/packages/services/spotify/__tests__/favoriteAlbumsSnapshot.test.ts
@@ -1,0 +1,33 @@
+import type { PlaylistAlbum } from '@dg/content-models/spotify/PlaylistAlbums';
+import { setupTestDatabase } from '@dg/db/testing/databaseSetup';
+import { readFavoriteAlbumsSnapshot, writeFavoriteAlbumsSnapshot } from '../favoriteAlbumsSnapshot';
+
+const db = setupTestDatabase();
+
+const album: PlaylistAlbum = {
+  addedAt: '2024-01-01T00:00:00Z',
+  artistNames: 'Artist',
+  id: '1234567890123456789012',
+  imageUrl: 'https://image.test/cover.jpg',
+  name: 'Album',
+  primaryArtist: 'Artist',
+  releaseDate: '2024-01-01',
+  url: 'https://open.spotify.com/album/1234567890123456789012',
+};
+
+describe('favorite albums snapshot', () => {
+  beforeEach(async () => {
+    await db.FavoriteAlbum.destroy({ where: {} });
+    await db.FavoriteAlbumSnapshot.destroy({ where: {} });
+  });
+
+  it('distinguishes never refreshed, empty, and populated snapshots', async () => {
+    await expect(readFavoriteAlbumsSnapshot()).resolves.toBeNull();
+
+    await writeFavoriteAlbumsSnapshot([]);
+    await expect(readFavoriteAlbumsSnapshot()).resolves.toEqual([]);
+
+    await writeFavoriteAlbumsSnapshot([album]);
+    await expect(readFavoriteAlbumsSnapshot()).resolves.toEqual([album]);
+  });
+});

--- a/packages/services/spotify/__tests__/fetchPlaylistAlbums.test.ts
+++ b/packages/services/spotify/__tests__/fetchPlaylistAlbums.test.ts
@@ -1,14 +1,7 @@
 const mockGet = jest.fn();
-const mockReadSnapshot = jest.fn();
-const mockWriteSnapshot = jest.fn();
 
 jest.mock('../spotifyClient', () => ({
   getSpotifyClient: () => ({ get: mockGet }),
-}));
-
-jest.mock('../favoriteAlbumsSnapshot', () => ({
-  readFavoriteAlbumsSnapshot: () => mockReadSnapshot(),
-  writeFavoriteAlbumsSnapshot: (albums: unknown) => mockWriteSnapshot(albums),
 }));
 
 import { fetchPlaylistAlbums } from '../fetchPlaylistAlbums';
@@ -48,8 +41,6 @@ const buildPage = (albumIds: Array<string>, next: string | null) => ({
 describe('fetchPlaylistAlbums', () => {
   beforeEach(() => {
     mockGet.mockReset();
-    mockReadSnapshot.mockReset().mockResolvedValue(null);
-    mockWriteSnapshot.mockReset().mockResolvedValue(undefined);
   });
 
   it('pages through the playlist and dedupes albums across pages', async () => {
@@ -65,23 +56,12 @@ describe('fetchPlaylistAlbums', () => {
     expect(albums.map((album) => album.id).sort()).toEqual(['a', 'b', 'c']);
   });
 
-  it('stores each successful read so a later failure has something to serve', async () => {
-    mockGet.mockResolvedValueOnce(buildPage(['a'], null));
-
-    await fetchPlaylistAlbums('playlist-id');
-
-    expect(mockWriteSnapshot).toHaveBeenCalledWith([expect.objectContaining({ id: 'a' })]);
-  });
-
-  it('serves the stored list when Spotify rate limits, without waiting', async () => {
-    const stored = [{ id: 'stored-album', name: 'Stored' }];
+  it('fails immediately on a rate limit so the cron can try next run', async () => {
     mockGet.mockResolvedValue({ response: { json: async () => ({}) }, status: 429 });
-    mockReadSnapshot.mockResolvedValue(stored);
 
     const started = Date.now();
-    const albums = await fetchPlaylistAlbums('playlist-id');
+    await expect(fetchPlaylistAlbums('playlist-id')).rejects.toThrow('status 429');
 
-    expect(albums).toEqual(stored);
     expect(mockGet).toHaveBeenCalledTimes(1);
     expect(Date.now() - started).toBeLessThan(1000);
   });

--- a/packages/services/spotify/__tests__/refreshFavoriteAlbumsSnapshot.test.ts
+++ b/packages/services/spotify/__tests__/refreshFavoriteAlbumsSnapshot.test.ts
@@ -1,0 +1,37 @@
+const mockFetchPlaylistAlbums = jest.fn();
+const mockWriteSnapshot = jest.fn();
+
+jest.mock('../fetchPlaylistAlbums', () => ({
+  fetchPlaylistAlbums: () => mockFetchPlaylistAlbums(),
+}));
+
+jest.mock('../favoriteAlbumsSnapshot', () => ({
+  writeFavoriteAlbumsSnapshot: (albums: unknown) => mockWriteSnapshot(albums),
+}));
+
+import {
+  refreshFavoriteAlbumsSnapshot,
+  refreshFavoriteAlbumsSnapshotWithLogging,
+} from '../refreshFavoriteAlbumsSnapshot';
+
+describe('refreshFavoriteAlbumsSnapshot', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('stores a successful playlist read, including an intentionally empty one', async () => {
+    mockFetchPlaylistAlbums.mockResolvedValue([]);
+    mockWriteSnapshot.mockResolvedValue(undefined);
+
+    await expect(refreshFavoriteAlbumsSnapshot()).resolves.toEqual({ count: 0 });
+    expect(mockWriteSnapshot).toHaveBeenCalledWith([]);
+  });
+
+  it('keeps the existing snapshot and returns without retrying when Spotify fails', async () => {
+    mockFetchPlaylistAlbums.mockRejectedValue(new Error('status 429'));
+
+    await expect(refreshFavoriteAlbumsSnapshotWithLogging()).resolves.toBeNull();
+    expect(mockFetchPlaylistAlbums).toHaveBeenCalledTimes(1);
+    expect(mockWriteSnapshot).not.toHaveBeenCalled();
+  });
+});

--- a/packages/services/spotify/favoriteAlbumsSnapshot.ts
+++ b/packages/services/spotify/favoriteAlbumsSnapshot.ts
@@ -25,15 +25,20 @@ const SNAPSHOT_FIELDS = [
  */
 export async function readFavoriteAlbumsSnapshot(): Promise<Array<PlaylistAlbum> | null> {
   try {
-    const [snapshot, rows] = await Promise.all([
-      db.FavoriteAlbumSnapshot.findOne({ where: { singleton: true } }),
-      db.FavoriteAlbum.findAll({
-        attributes: [...SNAPSHOT_FIELDS],
-        order: [['addedAt', 'DESC']],
-        raw: true,
-      }),
-    ]);
-    return snapshot ? (rows as unknown as Array<PlaylistAlbum>) : null;
+    const rows = (await db.FavoriteAlbum.findAll({
+      attributes: [...SNAPSHOT_FIELDS],
+      order: [['addedAt', 'DESC']],
+      raw: true,
+    })) as unknown as Array<PlaylistAlbum>;
+    if (rows.length > 0) {
+      return rows;
+    }
+
+    // Preview builds skip migrations. Only the marker needs the new table, and
+    // only an empty snapshot needs the marker, so populated snapshots remain
+    // readable in previews immediately after the FavoriteAlbum migration.
+    const snapshot = await db.FavoriteAlbumSnapshot.findOne({ where: { singleton: true } });
+    return snapshot ? [] : null;
   } catch (error) {
     log.warn('Could not read stored favorite albums', { error });
     return null;

--- a/packages/services/spotify/favoriteAlbumsSnapshot.ts
+++ b/packages/services/spotify/favoriteAlbumsSnapshot.ts
@@ -16,19 +16,24 @@ const SNAPSHOT_FIELDS = [
 ] as const;
 
 /**
- * Last stored favorites list, newest playlist addition first, or null when
- * nothing has been stored yet. Never throws: a missing table (a preview
- * deployment reading a database that hasn't migrated) has to degrade rather
- * than take the page down.
+ * Last stored favorites list, newest playlist addition first, or null when no
+ * refresh has ever completed. An empty array means Spotify was reached and the
+ * playlist was genuinely empty.
+ *
+ * Never throws: a missing table (a preview deployment reading a database that
+ * hasn't migrated) has to degrade rather than take the page down.
  */
 export async function readFavoriteAlbumsSnapshot(): Promise<Array<PlaylistAlbum> | null> {
   try {
-    const rows = await db.FavoriteAlbum.findAll({
-      attributes: [...SNAPSHOT_FIELDS],
-      order: [['addedAt', 'DESC']],
-      raw: true,
-    });
-    return rows.length > 0 ? (rows as unknown as Array<PlaylistAlbum>) : null;
+    const [snapshot, rows] = await Promise.all([
+      db.FavoriteAlbumSnapshot.findOne({ where: { singleton: true } }),
+      db.FavoriteAlbum.findAll({
+        attributes: [...SNAPSHOT_FIELDS],
+        order: [['addedAt', 'DESC']],
+        raw: true,
+      }),
+    ]);
+    return snapshot ? (rows as unknown as Array<PlaylistAlbum>) : null;
   } catch (error) {
     log.warn('Could not read stored favorite albums', { error });
     return null;
@@ -39,16 +44,20 @@ export async function readFavoriteAlbumsSnapshot(): Promise<Array<PlaylistAlbum>
  * Replaces the stored favorites list with a fresh one. The playlist is the
  * source of truth, so removals have to disappear here too — hence replace
  * rather than upsert. Never throws; failing to store is not worth failing a
- * request that already has its data.
+ * request that already has its data. The marker row records a successful empty
+ * playlist too, so the UI can tell empty from temporarily unavailable.
  */
 export async function writeFavoriteAlbumsSnapshot(albums: Array<PlaylistAlbum>): Promise<void> {
-  if (albums.length === 0) {
-    return;
-  }
   try {
     await dbClient.transaction(async (transaction) => {
       await db.FavoriteAlbum.destroy({ transaction, where: {} });
-      await db.FavoriteAlbum.bulkCreate([...albums], { transaction });
+      if (albums.length > 0) {
+        await db.FavoriteAlbum.bulkCreate([...albums], { transaction });
+      }
+      await db.FavoriteAlbumSnapshot.upsert(
+        { refreshedAt: new Date(), singleton: true },
+        { transaction },
+      );
     });
   } catch (error) {
     log.warn('Could not store favorite albums', { error });

--- a/packages/services/spotify/fetchPlaylistAlbums.ts
+++ b/packages/services/spotify/fetchPlaylistAlbums.ts
@@ -6,7 +6,6 @@ import {
   playlistItemsPageApiSchema,
 } from '@dg/content-models/spotify/PlaylistAlbums';
 import { log } from '@dg/shared-core/logging/log';
-import { readFavoriteAlbumsSnapshot, writeFavoriteAlbumsSnapshot } from './favoriteAlbumsSnapshot';
 import { spotifyGet } from './trackMetadataShared';
 
 const PAGE_SIZE = 50;
@@ -21,11 +20,9 @@ const MAX_PAGES = 100;
  * Fetches every item of a playlist and collapses them into unique albums,
  * newest playlist addition first.
  *
- * This runs on a user's request path, so it never waits out a rate limit. A
- * live read that fails falls back to the stored snapshot from the last
- * successful read, and only throws when there is nothing stored either — so
- * callers can still tell "no data at all" from "showing slightly stale data".
- * A successful read refreshes the snapshot for the next failure.
+ * This is called by the background sync, never by a page render. It still does
+ * not retry: a rate limit is honored by leaving the last snapshot untouched
+ * and trying again on the next scheduled run.
  */
 export async function fetchPlaylistAlbums(playlistId: string): Promise<Array<PlaylistAlbum>> {
   const items: Array<unknown> = [];
@@ -34,14 +31,6 @@ export async function fetchPlaylistAlbums(playlistId: string): Promise<Array<Pla
     const resource = `playlists/${playlistId}/tracks?limit=${PAGE_SIZE}&offset=${page * PAGE_SIZE}`;
     const result = await spotifyGet(resource, playlistItemsPageApiSchema, 'playlist page');
     if (!result.success) {
-      const stored = await readFavoriteAlbumsSnapshot();
-      if (stored) {
-        log.warn('Serving stored favorite albums; live playlist read failed', {
-          playlistId,
-          status: result.status,
-        });
-        return stored;
-      }
       throw new Error(`Spotify playlist ${playlistId} fetch failed with status ${result.status}`);
     }
     items.push(...result.data.items);
@@ -53,7 +42,5 @@ export async function fetchPlaylistAlbums(playlistId: string): Promise<Array<Pla
       playlistId,
     });
   }
-  const albums = mapPlaylistAlbumsFromApi(items);
-  await writeFavoriteAlbumsSnapshot(albums);
-  return albums;
+  return mapPlaylistAlbumsFromApi(items);
 }

--- a/packages/services/spotify/refreshFavoriteAlbumsSnapshot.ts
+++ b/packages/services/spotify/refreshFavoriteAlbumsSnapshot.ts
@@ -1,0 +1,35 @@
+import 'server-only';
+
+import { log } from '@dg/shared-core/logging/log';
+import { serializeError } from '@dg/shared-core/logging/maskSecrets';
+import { writeFavoriteAlbumsSnapshot } from './favoriteAlbumsSnapshot';
+import { fetchPlaylistAlbums } from './fetchPlaylistAlbums';
+
+/** Playlist holding one or more tracks from each favorite album. */
+const FAVORITE_ALBUMS_PLAYLIST_ID = '1bbwGrz6rSq5APjRfZp63U';
+
+/**
+ * Refreshes the favorite-albums snapshot from Spotify once.
+ *
+ * There is deliberately no retry here. If Spotify returns a rate limit, the
+ * stored snapshot remains valid and the scheduled sync tries again in 30
+ * minutes, after the supplied Retry-After has had time to elapse.
+ */
+export async function refreshFavoriteAlbumsSnapshot(): Promise<{ count: number }> {
+  const albums = await fetchPlaylistAlbums(FAVORITE_ALBUMS_PLAYLIST_ID);
+  await writeFavoriteAlbumsSnapshot(albums);
+  log.info('Favorite albums snapshot refreshed', { count: albums.length });
+  return { count: albums.length };
+}
+
+/** Runs a snapshot refresh without allowing it to fail the history sync. */
+export async function refreshFavoriteAlbumsSnapshotWithLogging() {
+  try {
+    return await refreshFavoriteAlbumsSnapshot();
+  } catch (error) {
+    log.warn('Favorite albums snapshot refresh failed; keeping stored snapshot', {
+      error: serializeError(error as Error),
+    });
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- Make `/music/albums` read only from its database snapshot; page renders and builds never call Spotify
- Refresh that snapshot alongside listening history in the existing half-hourly Spotify cron, with one attempt per run and no retry ladder
- Preserve the last successful snapshot through rate limits and revalidate the albums cache after a successful refresh
- Distinguish a snapshot that has never populated from a genuinely empty playlist, with honest empty-state copy

## Production state
The quota cleared at 00:30 local: both playlist endpoints now return `200`. I deliberately fetched all 1,622 playlist items and populated the production snapshot with **102 unique albums**. After the existing one-hour cache revalidated, production renders **102 album links**, including USB, with no empty-state copy.

Before clearing, Spotify's evidence was `429 QUOTA_EXCEEDED` with `Retry-After: 1858`, then `1593` seconds. Album and profile endpoints stayed healthy throughout. The scheduled workflow runs every 30 minutes, so after this lands future quota blocks keep serving the last snapshot and recover on the first healthy cron run without needing a visitor.

## Verification
- [x] `turbo check` / `turbo check:types` for db, services, and web
- [x] `turbo test --filter=@dg/services` — 18 suites / 108 tests
- [x] `turbo test --filter=@dg/web` — 45 suites / 179 tests
- [x] Forced production build: zero Spotify playlist or album-detail calls
- [x] `/music/albums` remains partially prerendered
- [x] Production: 102 album links, USB present, empty state absent
- [x] CI and Vercel preview green

## Version
- [ ] Major
- [ ] Minor
- [x] Patch