### PR TITLE
Nest side project rows concentrically and pop their icons on hover

### DIFF
--- a/apps/web/src/app/home/GatteySitesCard.tsx
+++ b/apps/web/src/app/home/GatteySitesCard.tsx
@@ -2,6 +2,7 @@ import type { RenderableSideProject } from '@dg/content-models/contentful/render
 import { ContentCard } from '@dg/ui/dependent/ContentCard';
 import { Image } from '@dg/ui/dependent/Image';
 import { Link } from '@dg/ui/dependent/Link';
+import { createBouncyTransition } from '@dg/ui/helpers/bouncyTransition';
 import { truncated } from '@dg/ui/helpers/truncated';
 import type { SxObject } from '@dg/ui/theme';
 import { Box, Stack, Typography } from '@mui/material';
@@ -11,11 +12,22 @@ type GatteySitesCardProps = {
   projects: ReadonlyArray<RenderableSideProject>;
 };
 
+const MARK_ROLE = 'side-project-mark';
+
+/**
+ * Rows sit 13px inside the card: 20px of card padding plus its 1px border, less
+ * the 8px each row bleeds back out. Keeping their corners concentric with the
+ * card's 32px radius means subtracting that gap.
+ */
+const ROW_BORDER_RADIUS = '19px';
+
 const markSx: SxObject = {
   flexShrink: 0,
   height: 40,
   overflow: 'hidden',
+  transform: 'scale(1)',
   width: 40,
+  ...createBouncyTransition('transform'),
 };
 
 const cardSx: SxObject = {
@@ -45,6 +57,9 @@ const projectListSx: SxObject = {
 };
 
 const projectLinkSx: SxObject = {
+  [`&:hover [data-role="${MARK_ROLE}"], &:focus-visible [data-role="${MARK_ROLE}"]`]: {
+    transform: 'scale(1.1)',
+  },
   '&:focus-visible': {
     outline: '2px solid var(--mui-palette-primary-main)',
     outlineOffset: 2,
@@ -54,13 +69,13 @@ const projectLinkSx: SxObject = {
     textDecoration: 'none',
   },
   alignItems: 'center',
-  borderRadius: 1,
+  borderRadius: ROW_BORDER_RADIUS,
   display: 'flex',
   gap: 1.5,
   marginInline: -1,
   padding: 1,
   textDecoration: 'none',
-  transition: 'background-color 160ms ease',
+  ...createBouncyTransition('background-color'),
 };
 
 const projectTextSx: SxObject = {
@@ -99,7 +114,7 @@ export function GatteySitesCard({ projects }: GatteySitesCardProps) {
           {projects.map(({ description, mark, title, url }) => (
             <Box component="li" key={url}>
               <Link href={url} isExternal={true} sx={projectLinkSx} title={title} underline="none">
-                <Box aria-hidden="true" sx={markSx}>
+                <Box aria-hidden="true" data-role={MARK_ROLE} sx={markSx}>
                   <Image
                     alt=""
                     cover={true}

--- a/apps/web/src/app/home/__tests__/GatteySitesCard.test.tsx
+++ b/apps/web/src/app/home/__tests__/GatteySitesCard.test.tsx
@@ -47,6 +47,13 @@ describe('GatteySitesCard', () => {
     expect(screen.getAllByRole('link')).toHaveLength(2);
   });
 
+  it('marks each project icon so row hover can scale it', () => {
+    const { container } = render(<GatteySitesCard projects={projects} />);
+
+    // The hover/focus pop is wired to this attribute from the row's sx.
+    expect(container.querySelectorAll('[data-role="side-project-mark"]')).toHaveLength(2);
+  });
+
   it('renders nothing when there are no projects', () => {
     const { container } = render(<GatteySitesCard projects={[]} />);
     expect(container).toBeEmptyDOMElement();

--- a/package.json
+++ b/package.json
@@ -27,5 +27,5 @@
     "clean": "rm -f .env .env.tmp",
     "preinstall": "npx only-allow pnpm"
   },
-  "version": "2.68.1"
+  "version": "2.68.2"
 }


### PR DESCRIPTION
# What changed?

Two bits of polish on the homepage "Side projects" card.

**Rounding.** Each row's hover/focus highlight had a `4px` radius (`borderRadius: 1`
is 4px, not 8px) while sitting `13px` inside the card's `32px` corners — 20px of
card padding plus its 1px border, less the 8px each row bleeds back out. That read
as a hard rectangle inside a soft card. Rows now use the concentric `32 - 13 = 19px`
radius, so the highlight and the focus ring nest inside the card's curve.

**Icon pop.** The 40×40 mark now scales to `1.1` when its row is hovered or focused,
driven by the shared `createBouncyTransition` the content cards already use, so it
overshoots and settles the same way. The row's background fade moved onto that same
transition so hover reads as one gesture rather than two timings. There is no scale
compounding to worry about here: this card is passed no `link`, so `ContentCard`
never applies its own `scale(1.05)` — verified the card's computed transform stays
identity while a row is hovered. Reduced motion is handled by the existing global
`prefers-reduced-motion` rule in the theme, which zeroes transition durations.

The divider-hiding on hover, the focus-visible outline, and the two-line description
truncation all still work.

# Release info

- [ ] Major
- [ ] Minor
- [x] Patch
