### PR TITLE
Add route map to Strava activity card

### DIFF
--- a/apps/web/src/app/home/StravaCard.tsx
+++ b/apps/web/src/app/home/StravaCard.tsx
@@ -8,6 +8,19 @@ import { ActivityName } from '../strava/ActivityName';
 import { ActivityStats } from '../strava/ActivityStats';
 import { ActivityTypeWithIcon } from '../strava/ActivityTypeWithIcon';
 
+const paperMix = (percent: number) =>
+  `color-mix(in srgb, var(--mui-palette-background-paper) ${percent}%, transparent)`;
+
+/**
+ * Both schemes pull the map toward their own reading surface, but they cannot use
+ * the same color to do it. Light mode's paper is near-white, so mixing toward it
+ * keeps the route orange. Dark mode's paper is a saturated teal — orange's near
+ * complement — and mixing toward that turns the route to mud, so dark mode
+ * darkens with black instead, which holds the hue while deepening it.
+ */
+const scrimMix = (light: number, dark: number) =>
+  `light-dark(${paperMix(light)}, rgb(0 0 0 / ${dark / 100}))`;
+
 const cardSx: SxObject = {
   padding: 0,
 };
@@ -18,10 +31,37 @@ const layoutStackSx: SxObject = {
   justifyContent: 'space-between',
   padding: 2.5,
   position: 'relative',
-  // Tight enough to carry the text over map labels without fogging the tiles.
-  textShadow:
-    '0 1px 2px var(--mui-palette-background-paper), 0 0 7px var(--mui-palette-background-paper)',
+  // Per-glyph insurance on top of the backing layer, for the map's own labels.
+  textShadow: `0 1px 2px ${paperMix(100)}, 0 0 8px ${paperMix(100)}`,
   zIndex: 3,
+};
+
+const BLEED = 2.5;
+const FADE = 30;
+
+/**
+ * Each text group carries its own backing, so the route runs behind the copy
+ * rather than through it. Anchoring the gradients to the groups instead of the
+ * card keeps them aligned when the card changes shape or the description runs
+ * long, and the fade distances are absolute so they always land on the first
+ * line rather than drifting with the card's aspect ratio.
+ */
+const statsBackingSx: SxObject = {
+  background: `linear-gradient(180deg, ${scrimMix(50, 34)} 0, ${scrimMix(44, 28)} ${FADE}px, transparent 100%)`,
+  marginTop: -BLEED,
+  marginX: -BLEED,
+  paddingBottom: 2,
+  paddingTop: BLEED,
+  paddingX: BLEED,
+};
+
+const copyBackingSx: SxObject = {
+  background: `linear-gradient(180deg, transparent 0, ${scrimMix(58, 38)} ${FADE}px, ${scrimMix(70, 48)} 55%, ${scrimMix(80, 58)} 100%)`,
+  marginBottom: -BLEED,
+  marginX: -BLEED,
+  paddingBottom: BLEED,
+  paddingTop: `${FADE}px`,
+  paddingX: BLEED,
 };
 
 const activityNameSx: SxObject = {
@@ -52,8 +92,10 @@ export function StravaCard({ activity }: { activity: StravaActivity | null }) {
         </Box>
       ) : null}
       <Stack sx={layoutStackSx}>
-        <ActivityStats activity={activity} />
-        <Stack>
+        <Box sx={statsBackingSx}>
+          <ActivityStats activity={activity} />
+        </Box>
+        <Stack sx={copyBackingSx}>
           <ActivityTypeWithIcon activity={activity} />
           <ActivityName activity={activity} sx={activityNameSx} />
           <ActivityDescription activity={activity} />

--- a/apps/web/src/app/home/StravaCard.tsx
+++ b/apps/web/src/app/home/StravaCard.tsx
@@ -18,8 +18,9 @@ const layoutStackSx: SxObject = {
   justifyContent: 'space-between',
   padding: 2.5,
   position: 'relative',
+  // Tight enough to carry the text over map labels without fogging the tiles.
   textShadow:
-    '0 0 4px var(--mui-palette-background-paper), 0 0 10px var(--mui-palette-background-paper), 0 0 16px var(--mui-palette-background-paper)',
+    '0 1px 2px var(--mui-palette-background-paper), 0 0 7px var(--mui-palette-background-paper)',
   zIndex: 3,
 };
 
@@ -31,15 +32,6 @@ const mapSx: SxObject = {
   inset: 0,
   position: 'absolute',
   zIndex: 0,
-};
-
-const scrimSx: SxObject = {
-  background:
-    'linear-gradient(180deg, color-mix(in srgb, var(--mui-palette-background-paper) 22%, transparent), color-mix(in srgb, var(--mui-palette-background-paper) 48%, transparent))',
-  inset: 0,
-  pointerEvents: 'none',
-  position: 'absolute',
-  zIndex: 1,
 };
 
 /**
@@ -55,12 +47,9 @@ export function StravaCard({ activity }: { activity: StravaActivity | null }) {
   return (
     <ContentCard sx={cardSx}>
       {encodedPolyline ? (
-        <>
-          <Box sx={mapSx}>
-            <StravaRouteMap encodedPolyline={encodedPolyline} />
-          </Box>
-          <Box aria-hidden="true" sx={scrimSx} />
-        </>
+        <Box sx={mapSx}>
+          <StravaRouteMap encodedPolyline={encodedPolyline} />
+        </Box>
       ) : null}
       <Stack sx={layoutStackSx}>
         <ActivityStats activity={activity} />

--- a/apps/web/src/app/home/StravaCard.tsx
+++ b/apps/web/src/app/home/StravaCard.tsx
@@ -1,24 +1,44 @@
 import type { StravaActivity } from '@dg/content-models/strava/StravaActivity';
+import { StravaRouteMap } from '@dg/maps/StravaRouteMap';
 import { ContentCard } from '@dg/ui/dependent/ContentCard';
 import type { SxObject } from '@dg/ui/theme';
-import { Stack } from '@mui/material';
+import { Box, Stack } from '@mui/material';
 import { ActivityDescription } from '../strava/ActivityDescription';
 import { ActivityName } from '../strava/ActivityName';
 import { ActivityStats } from '../strava/ActivityStats';
 import { ActivityTypeWithIcon } from '../strava/ActivityTypeWithIcon';
 
 const cardSx: SxObject = {
-  padding: 2.5,
+  padding: 0,
 };
 
 const layoutStackSx: SxObject = {
   gap: 2,
   height: '100%',
   justifyContent: 'space-between',
+  padding: 2.5,
+  position: 'relative',
+  textShadow:
+    '0 0 3px var(--mui-palette-background-paper), 0 0 7px var(--mui-palette-background-paper)',
+  zIndex: 3,
 };
 
 const activityNameSx: SxObject = {
   marginBottom: 1,
+};
+
+const mapSx: SxObject = {
+  inset: 0,
+  position: 'absolute',
+};
+
+const scrimSx: SxObject = {
+  background:
+    'linear-gradient(180deg, color-mix(in srgb, var(--mui-palette-background-paper) 68%, transparent), color-mix(in srgb, var(--mui-palette-background-paper) 86%, transparent))',
+  inset: 0,
+  pointerEvents: 'none',
+  position: 'absolute',
+  zIndex: 1,
 };
 
 /**
@@ -29,8 +49,18 @@ export function StravaCard({ activity }: { activity: StravaActivity | null }) {
     return null;
   }
 
+  const encodedPolyline = activity.map?.summaryPolyline ?? activity.map?.polyline;
+
   return (
     <ContentCard sx={cardSx}>
+      {encodedPolyline ? (
+        <>
+          <Box sx={mapSx}>
+            <StravaRouteMap encodedPolyline={encodedPolyline} />
+          </Box>
+          <Box aria-hidden="true" sx={scrimSx} />
+        </>
+      ) : null}
       <Stack sx={layoutStackSx}>
         <ActivityStats activity={activity} />
         <Stack>

--- a/apps/web/src/app/home/StravaCard.tsx
+++ b/apps/web/src/app/home/StravaCard.tsx
@@ -19,7 +19,7 @@ const layoutStackSx: SxObject = {
   padding: 2.5,
   position: 'relative',
   textShadow:
-    '0 0 3px var(--mui-palette-background-paper), 0 0 7px var(--mui-palette-background-paper)',
+    '0 0 4px var(--mui-palette-background-paper), 0 0 10px var(--mui-palette-background-paper), 0 0 16px var(--mui-palette-background-paper)',
   zIndex: 3,
 };
 
@@ -30,11 +30,12 @@ const activityNameSx: SxObject = {
 const mapSx: SxObject = {
   inset: 0,
   position: 'absolute',
+  zIndex: 0,
 };
 
 const scrimSx: SxObject = {
   background:
-    'linear-gradient(180deg, color-mix(in srgb, var(--mui-palette-background-paper) 68%, transparent), color-mix(in srgb, var(--mui-palette-background-paper) 86%, transparent))',
+    'linear-gradient(180deg, color-mix(in srgb, var(--mui-palette-background-paper) 22%, transparent), color-mix(in srgb, var(--mui-palette-background-paper) 48%, transparent))',
   inset: 0,
   pointerEvents: 'none',
   position: 'absolute',

--- a/apps/web/src/app/home/__tests__/StravaCard.test.tsx
+++ b/apps/web/src/app/home/__tests__/StravaCard.test.tsx
@@ -1,0 +1,38 @@
+import type { StravaActivity } from '@dg/content-models/strava/StravaActivity';
+import { render, screen } from '@testing-library/react';
+import { StravaCard } from '../StravaCard';
+
+jest.mock('@dg/maps/StravaRouteMap', () => ({
+  StravaRouteMap: ({ encodedPolyline }: { encodedPolyline: string }) => (
+    <div data-polyline={encodedPolyline} data-testid="route-map" />
+  ),
+}));
+
+const activity: StravaActivity = {
+  id: 123,
+  name: 'Morning run',
+  type: 'Run',
+  url: 'https://www.strava.com/activities/123',
+};
+
+describe('StravaCard', () => {
+  it('keeps the standard card treatment when the activity has no route', () => {
+    render(<StravaCard activity={{ ...activity, map: null }} />);
+
+    expect(screen.getByRole('link', { name: 'Morning run' })).toBeInTheDocument();
+    expect(screen.queryByTestId('route-map')).not.toBeInTheDocument();
+  });
+
+  it('prefers the summary polyline for the background route', () => {
+    render(
+      <StravaCard
+        activity={{
+          ...activity,
+          map: { polyline: 'full-route', summaryPolyline: 'summary-route' },
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId('route-map')).toHaveAttribute('data-polyline', 'summary-route');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -27,5 +27,5 @@
     "clean": "rm -f .env .env.tmp",
     "preinstall": "npx only-allow pnpm"
   },
-  "version": "2.68.5"
+  "version": "2.68.6"
 }

--- a/packages/maps/StravaRouteMap.tsx
+++ b/packages/maps/StravaRouteMap.tsx
@@ -1,0 +1,21 @@
+import 'server-only';
+
+import type { Point } from 'pigeon-maps';
+import { RouteMap } from './src/RouteMap';
+import { decodePolyline } from './src/routeGeometry';
+
+/** Server wrapper that keeps the Stadia key out of the calling component. */
+export function StravaRouteMap({ encodedPolyline }: { encodedPolyline: string }) {
+  let points: Array<Point>;
+  try {
+    points = decodePolyline(encodedPolyline);
+  } catch {
+    return null;
+  }
+
+  if (points.length < 2) {
+    return null;
+  }
+
+  return <RouteMap points={points} stadiaApiKey={process.env.STADIA_API_KEY ?? ''} />;
+}

--- a/packages/maps/jest.config.ts
+++ b/packages/maps/jest.config.ts
@@ -1,0 +1,4 @@
+/** @jest-config-loader esbuild-register */
+import { baseConfig } from '@dg/testing/jest.config.base';
+
+export default { ...baseConfig, testEnvironment: 'node' };

--- a/packages/maps/package.json
+++ b/packages/maps/package.json
@@ -7,15 +7,19 @@
     "lucide-react": "catalog:",
     "pigeon-maps": "0.22.1",
     "react": "catalog:",
-    "react-dom": "19.2.7"
+    "react-dom": "19.2.7",
+    "server-only": "catalog:"
   },
   "devDependencies": {
+    "@dg/testing": "workspace:*",
     "@dg/tsconfig": "workspace:*",
+    "@types/jest": "catalog:",
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "19.2.3",
     "@typescript/native": "catalog:",
     "dotenv-mono": "catalog:",
+    "jest": "catalog:",
     "typescript": "catalog:"
   },
   "name": "@dg/maps",
@@ -24,6 +28,7 @@
     "check": "biome check --write .",
     "check:ci": "biome ci .",
     "check:types": "tsc",
-    "clean": "rm -rf .turbo *.tsbuildinfo"
+    "clean": "rm -rf .turbo *.tsbuildinfo",
+    "test": "jest"
   }
 }

--- a/packages/maps/src/RouteMap.tsx
+++ b/packages/maps/src/RouteMap.tsx
@@ -1,0 +1,230 @@
+'use client';
+
+import type { SxObject } from '@dg/ui/theme';
+import { useColorScheme } from '@dg/ui/theme/useColorScheme';
+import { Box } from '@mui/material';
+import type { PigeonProps, Point } from 'pigeon-maps';
+import { Map as PigeonMapCore } from 'pigeon-maps';
+import { useEffect, useRef, useState, useSyncExternalStore } from 'react';
+import { fitRouteViewport } from './routeGeometry';
+import { SmoothTile } from './SmoothTile';
+
+const ROUTE_PADDING = 42;
+const DEFAULT_SIZE = 320;
+
+const containerSx: SxObject = {
+  '& .pigeon-attribution': {
+    background:
+      'color-mix(in srgb, var(--mui-palette-background-paper) 82%, transparent) !important',
+    color: 'var(--mui-palette-text-secondary) !important',
+    opacity: 0.76,
+  },
+  '& .pigeon-attribution a': {
+    color: 'inherit !important',
+    textDecoration: 'none',
+  },
+  '& .pigeon-attribution, & .pigeon-overlays': {
+    zIndex: 2,
+  },
+  '& > div': {
+    backgroundColor: 'transparent !important',
+  },
+  backgroundColor: 'var(--mui-palette-background-paper)',
+  height: '100%',
+  overflow: 'hidden',
+  pointerEvents: 'none',
+  position: 'relative',
+  width: '100%',
+};
+
+const underlaySx: SxObject = {
+  filter: 'blur(8px)',
+  height: '110%',
+  inset: '-5%',
+  objectFit: 'cover',
+  opacity: 0.7,
+  position: 'absolute',
+  transform: 'scale(1.05)',
+  width: '110%',
+};
+
+const routeSvgSx: SxObject = {
+  height: '100%',
+  left: 0,
+  overflow: 'visible',
+  position: 'absolute',
+  top: 0,
+  width: '100%',
+};
+
+type RouteOverlayProps = PigeonProps & {
+  points: Array<Point>;
+};
+
+function RouteOverlay({ latLngToPixel, mapState, points }: RouteOverlayProps) {
+  if (!latLngToPixel || !mapState || mapState.width <= 0 || mapState.height <= 0) {
+    return null;
+  }
+
+  const path = points
+    .map((point, index) => {
+      const [x, y] = latLngToPixel(point);
+      return `${index === 0 ? 'M' : 'L'}${x.toFixed(2)} ${y.toFixed(2)}`;
+    })
+    .join(' ');
+
+  return (
+    <Box
+      aria-hidden="true"
+      component="svg"
+      sx={routeSvgSx}
+      viewBox={`0 0 ${mapState.width} ${mapState.height}`}
+    >
+      <Box
+        component="path"
+        d={path}
+        fill="none"
+        stroke="color-mix(in srgb, var(--mui-palette-background-default) 85%, transparent)"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={8}
+        vectorEffect="non-scaling-stroke"
+      />
+      <Box
+        component="path"
+        d={path}
+        fill="none"
+        opacity={0.75}
+        stroke="#fc4c02"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={4}
+        vectorEffect="non-scaling-stroke"
+      />
+    </Box>
+  );
+}
+
+const subscribeToSystemDark = (onStoreChange: () => void) => {
+  const media = window.matchMedia('(prefers-color-scheme: dark)');
+  media.addEventListener('change', onStoreChange);
+  return () => media.removeEventListener('change', onStoreChange);
+};
+
+const getSystemDarkSnapshot = () => window.matchMedia('(prefers-color-scheme: dark)').matches;
+const getServerSystemDarkSnapshot = () => false;
+
+function tileCoordinates([latitude, longitude]: Point, zoom: number) {
+  const tileZoom = Math.round(zoom);
+  const scale = 2 ** tileZoom;
+  const latitudeRadians = (latitude * Math.PI) / 180;
+  return {
+    x: Math.floor(((longitude + 180) / 360) * scale),
+    y: Math.floor(
+      ((1 - Math.log(Math.tan(latitudeRadians) + 1 / Math.cos(latitudeRadians)) / Math.PI) / 2) *
+        scale,
+    ),
+    zoom: tileZoom,
+  };
+}
+
+function tileUrl({
+  dark,
+  stadiaApiKey,
+  x,
+  y,
+  zoom,
+}: {
+  dark: boolean;
+  stadiaApiKey: string;
+  x: number;
+  y: number;
+  zoom: number;
+}) {
+  const style = dark ? 'alidade_smooth_dark' : 'alidade_smooth';
+  return `https://tiles.stadiamaps.com/tiles/${style}/${zoom}/${x}/${y}.png?api_key=${stadiaApiKey}`;
+}
+
+export type RouteMapProps = {
+  points: Array<Point>;
+  stadiaApiKey: string;
+};
+
+/** A non-interactive, theme-aware route map intended for card backgrounds. */
+export function RouteMap({ points, stadiaApiKey }: RouteMapProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [size, setSize] = useState({ height: DEFAULT_SIZE, width: DEFAULT_SIZE });
+  const { preference } = useColorScheme();
+  const systemDark = useSyncExternalStore(
+    subscribeToSystemDark,
+    getSystemDarkSnapshot,
+    getServerSystemDarkSnapshot,
+  );
+  const dark = preference === 'dark' || (preference === 'system' && systemDark);
+  const viewport = fitRouteViewport({
+    height: size.height,
+    padding: ROUTE_PADDING,
+    points,
+    width: size.width,
+  });
+  const underlayTile = tileCoordinates(viewport.center, viewport.zoom);
+  const provider = (x: number, y: number, zoom: number) =>
+    tileUrl({ dark, stadiaApiKey, x, y, zoom });
+
+  useEffect(() => {
+    const element = containerRef.current;
+    if (!element) {
+      return;
+    }
+
+    const updateSize = () => {
+      const { height, width } = element.getBoundingClientRect();
+      if (height > 0 && width > 0) {
+        setSize({ height, width });
+      }
+    };
+    updateSize();
+    const observer = new ResizeObserver(updateSize);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <Box aria-hidden="true" ref={containerRef} sx={containerSx}>
+      <Box
+        alt=""
+        component="img"
+        src={tileUrl({
+          dark,
+          stadiaApiKey,
+          x: underlayTile.x,
+          y: underlayTile.y,
+          zoom: underlayTile.zoom,
+        })}
+        sx={underlaySx}
+      />
+      <PigeonMapCore
+        animate={false}
+        attribution={
+          <span style={{ fontSize: 8 }}>
+            © <a href="https://stadiamaps.com/">Stadia</a> ·{' '}
+            <a href="https://openmaptiles.org/">OpenMapTiles</a> ·{' '}
+            <a href="https://www.openstreetmap.org/copyright">OSM</a>
+          </span>
+        }
+        attributionPrefix={false}
+        center={viewport.center}
+        dprs={[1, 2]}
+        key={`${Math.round(size.width)}x${Math.round(size.height)}`}
+        mouseEvents={false}
+        provider={provider}
+        tileComponent={SmoothTile}
+        touchEvents={false}
+        zoom={viewport.zoom}
+        zoomSnap={false}
+      >
+        <RouteOverlay points={points} />
+      </PigeonMapCore>
+    </Box>
+  );
+}

--- a/packages/maps/src/RouteMap.tsx
+++ b/packages/maps/src/RouteMap.tsx
@@ -13,24 +13,18 @@ const ROUTE_PADDING = 42;
 const DEFAULT_SIZE = 320;
 
 const containerSx: SxObject = {
-  '& .pigeon-attribution': {
-    background:
-      'color-mix(in srgb, var(--mui-palette-background-paper) 82%, transparent) !important',
-    color: 'var(--mui-palette-text-secondary) !important',
-    opacity: 0.76,
-  },
-  '& .pigeon-attribution a': {
-    color: 'inherit !important',
-    textDecoration: 'none',
-  },
-  '& .pigeon-attribution, & .pigeon-overlays': {
-    zIndex: 2,
-  },
+  // Pigeon's root is the tile layer's own stacking level; keep it above the
+  // placeholder underlay instead of relying on DOM order.
   '& > div': {
     backgroundColor: 'transparent !important',
+    position: 'relative',
+    zIndex: 1,
   },
   backgroundColor: 'var(--mui-palette-background-paper)',
   height: '100%',
+  // Groups the underlay, tiles and route into one layer so none of them can
+  // paint above whatever the host renders over the map.
+  isolation: 'isolate',
   overflow: 'hidden',
   pointerEvents: 'none',
   position: 'relative',
@@ -46,6 +40,7 @@ const underlaySx: SxObject = {
   position: 'absolute',
   transform: 'scale(1.05)',
   width: '110%',
+  zIndex: 0,
 };
 
 const routeSvgSx: SxObject = {
@@ -94,7 +89,6 @@ function RouteOverlay({ latLngToPixel, mapState, points }: RouteOverlayProps) {
         component="path"
         d={path}
         fill="none"
-        opacity={0.75}
         stroke="#fc4c02"
         strokeLinecap="round"
         strokeLinejoin="round"
@@ -130,19 +124,22 @@ function tileCoordinates([latitude, longitude]: Point, zoom: number) {
 
 function tileUrl({
   dark,
+  dpr,
   stadiaApiKey,
   x,
   y,
   zoom,
 }: {
   dark: boolean;
+  dpr?: number;
   stadiaApiKey: string;
   x: number;
   y: number;
   zoom: number;
 }) {
   const style = dark ? 'alidade_smooth_dark' : 'alidade_smooth';
-  return `https://tiles.stadiamaps.com/tiles/${style}/${zoom}/${x}/${y}.png?api_key=${stadiaApiKey}`;
+  const density = dpr && dpr > 1 ? '@2x' : '';
+  return `https://tiles.stadiamaps.com/tiles/${style}/${zoom}/${x}/${y}${density}.png?api_key=${stadiaApiKey}`;
 }
 
 export type RouteMapProps = {
@@ -168,8 +165,8 @@ export function RouteMap({ points, stadiaApiKey }: RouteMapProps) {
     width: size.width,
   });
   const underlayTile = tileCoordinates(viewport.center, viewport.zoom);
-  const provider = (x: number, y: number, zoom: number) =>
-    tileUrl({ dark, stadiaApiKey, x, y, zoom });
+  const provider = (x: number, y: number, zoom: number, dpr?: number) =>
+    tileUrl({ dark, dpr, stadiaApiKey, x, y, zoom });
 
   useEffect(() => {
     const element = containerRef.current;
@@ -205,21 +202,17 @@ export function RouteMap({ points, stadiaApiKey }: RouteMapProps) {
       />
       <PigeonMapCore
         animate={false}
-        attribution={
-          <span style={{ fontSize: 8 }}>
-            © <a href="https://stadiamaps.com/">Stadia</a> ·{' '}
-            <a href="https://openmaptiles.org/">OpenMapTiles</a> ·{' '}
-            <a href="https://www.openstreetmap.org/copyright">OSM</a>
-          </span>
-        }
-        attributionPrefix={false}
+        attribution={false}
         center={viewport.center}
         dprs={[1, 2]}
+        height={size.height}
+        // Pigeon only reads width/height in its constructor, so remount on resize.
         key={`${Math.round(size.width)}x${Math.round(size.height)}`}
         mouseEvents={false}
         provider={provider}
         tileComponent={SmoothTile}
         touchEvents={false}
+        width={size.width}
         zoom={viewport.zoom}
         zoomSnap={false}
       >

--- a/packages/maps/src/RouteMap.tsx
+++ b/packages/maps/src/RouteMap.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { SxObject } from '@dg/ui/theme';
+import { BRAND } from '@dg/ui/theme/color';
 import { useColorScheme } from '@dg/ui/theme/useColorScheme';
 import { Box } from '@mui/material';
 import type { Point } from 'pigeon-maps';
@@ -11,7 +12,6 @@ import { SmoothTile } from './SmoothTile';
 
 const ROUTE_PADDING = 42;
 const DEFAULT_SIZE = 320;
-const STRAVA_ORANGE = '#fc4c02';
 
 const paperMix = (percent: number) =>
   `color-mix(in srgb, var(--mui-palette-background-paper) ${percent}%, transparent)`;
@@ -216,20 +216,20 @@ export function RouteMap({ points, stadiaApiKey }: RouteMapProps) {
           component="path"
           d={routePath}
           fill="none"
-          stroke={dark ? 'rgb(0 0 0 / 0.5)' : paperMix(92)}
+          stroke={dark ? 'rgb(0 0 0 / 0.42)' : paperMix(86)}
           strokeLinecap="round"
           strokeLinejoin="round"
-          strokeWidth={7}
+          strokeWidth={6}
           vectorEffect="non-scaling-stroke"
         />
         <Box
           component="path"
           d={routePath}
           fill="none"
-          stroke={STRAVA_ORANGE}
+          stroke={BRAND.routeLine}
           strokeLinecap="round"
           strokeLinejoin="round"
-          strokeWidth={3}
+          strokeWidth={2.5}
           vectorEffect="non-scaling-stroke"
         />
       </Box>

--- a/packages/maps/src/RouteMap.tsx
+++ b/packages/maps/src/RouteMap.tsx
@@ -3,27 +3,21 @@
 import type { SxObject } from '@dg/ui/theme';
 import { useColorScheme } from '@dg/ui/theme/useColorScheme';
 import { Box } from '@mui/material';
-import type { PigeonProps, Point } from 'pigeon-maps';
+import type { Point } from 'pigeon-maps';
 import { Map as PigeonMapCore } from 'pigeon-maps';
 import { useEffect, useRef, useState, useSyncExternalStore } from 'react';
-import { fitRouteViewport } from './routeGeometry';
+import { fitRouteViewport, projectRouteToPixels, toSvgPath } from './routeGeometry';
 import { SmoothTile } from './SmoothTile';
 
 const ROUTE_PADDING = 42;
 const DEFAULT_SIZE = 320;
+const STRAVA_ORANGE = '#fc4c02';
 
 const containerSx: SxObject = {
-  // Pigeon's root is the tile layer's own stacking level; keep it above the
-  // placeholder underlay instead of relying on DOM order.
-  '& > div': {
-    backgroundColor: 'transparent !important',
-    position: 'relative',
-    zIndex: 1,
-  },
   backgroundColor: 'var(--mui-palette-background-paper)',
   height: '100%',
-  // Groups the underlay, tiles and route into one layer so none of them can
-  // paint above whatever the host renders over the map.
+  // Groups the underlay, tiles, scrim and route into one layer so none of them
+  // can paint above whatever the host renders over the map.
   isolation: 'isolate',
   overflow: 'hidden',
   pointerEvents: 'none',
@@ -43,6 +37,37 @@ const underlaySx: SxObject = {
   zIndex: 0,
 };
 
+const tileLayerSx: SxObject = {
+  // Pigeon paints its own opaque background, which would hide the placeholder.
+  '& > div': {
+    backgroundColor: 'transparent !important',
+  },
+  // Mutes the basemap's landcover so the route and card copy lead, while roads,
+  // trails and water still read as a map.
+  filter: 'saturate(0.62)',
+  inset: 0,
+  position: 'absolute',
+  zIndex: 1,
+};
+
+/**
+ * Knocks the basemap back just far enough for the copy to win, weighted toward
+ * the bottom where the densest text sits. Outdoors is a vivid, fully labelled
+ * style so it needs more help than the already-muted dark basemap.
+ */
+const getScrimSx = (dark: boolean): SxObject => {
+  const [top, middle, bottom] = dark ? ([16, 28, 44] as const) : ([32, 42, 55] as const);
+  const paper = (percent: number) =>
+    `color-mix(in srgb, var(--mui-palette-background-paper) ${percent}%, transparent)`;
+
+  return {
+    background: `linear-gradient(180deg, ${paper(top)} 0%, ${paper(middle)} 45%, ${paper(bottom)} 100%)`,
+    inset: 0,
+    position: 'absolute',
+    zIndex: 2,
+  };
+};
+
 const routeSvgSx: SxObject = {
   height: '100%',
   left: 0,
@@ -50,54 +75,8 @@ const routeSvgSx: SxObject = {
   position: 'absolute',
   top: 0,
   width: '100%',
+  zIndex: 3,
 };
-
-type RouteOverlayProps = PigeonProps & {
-  points: Array<Point>;
-};
-
-function RouteOverlay({ latLngToPixel, mapState, points }: RouteOverlayProps) {
-  if (!latLngToPixel || !mapState || mapState.width <= 0 || mapState.height <= 0) {
-    return null;
-  }
-
-  const path = points
-    .map((point, index) => {
-      const [x, y] = latLngToPixel(point);
-      return `${index === 0 ? 'M' : 'L'}${x.toFixed(2)} ${y.toFixed(2)}`;
-    })
-    .join(' ');
-
-  return (
-    <Box
-      aria-hidden="true"
-      component="svg"
-      sx={routeSvgSx}
-      viewBox={`0 0 ${mapState.width} ${mapState.height}`}
-    >
-      <Box
-        component="path"
-        d={path}
-        fill="none"
-        stroke="color-mix(in srgb, var(--mui-palette-background-default) 85%, transparent)"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth={8}
-        vectorEffect="non-scaling-stroke"
-      />
-      <Box
-        component="path"
-        d={path}
-        fill="none"
-        stroke="#fc4c02"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth={4}
-        vectorEffect="non-scaling-stroke"
-      />
-    </Box>
-  );
-}
 
 const subscribeToSystemDark = (onStoreChange: () => void) => {
   const media = window.matchMedia('(prefers-color-scheme: dark)');
@@ -137,7 +116,9 @@ function tileUrl({
   y: number;
   zoom: number;
 }) {
-  const style = dark ? 'alidade_smooth_dark' : 'alidade_smooth';
+  // Outdoors carries trails, contours and greenery, so it still reads as a map
+  // under a scrim. Alidade Smooth Dark is the closest dark counterpart.
+  const style = dark ? 'alidade_smooth_dark' : 'outdoors';
   const density = dpr && dpr > 1 ? '@2x' : '';
   return `https://tiles.stadiamaps.com/tiles/${style}/${zoom}/${x}/${y}${density}.png?api_key=${stadiaApiKey}`;
 }
@@ -165,6 +146,15 @@ export function RouteMap({ points, stadiaApiKey }: RouteMapProps) {
     width: size.width,
   });
   const underlayTile = tileCoordinates(viewport.center, viewport.zoom);
+  const routePath = toSvgPath(
+    projectRouteToPixels({
+      center: viewport.center,
+      height: size.height,
+      points,
+      width: size.width,
+      zoom: viewport.zoom,
+    }),
+  );
   const provider = (x: number, y: number, zoom: number, dpr?: number) =>
     tileUrl({ dark, dpr, stadiaApiKey, x, y, zoom });
 
@@ -200,24 +190,47 @@ export function RouteMap({ points, stadiaApiKey }: RouteMapProps) {
         })}
         sx={underlaySx}
       />
-      <PigeonMapCore
-        animate={false}
-        attribution={false}
-        center={viewport.center}
-        dprs={[1, 2]}
-        height={size.height}
-        // Pigeon only reads width/height in its constructor, so remount on resize.
-        key={`${Math.round(size.width)}x${Math.round(size.height)}`}
-        mouseEvents={false}
-        provider={provider}
-        tileComponent={SmoothTile}
-        touchEvents={false}
-        width={size.width}
-        zoom={viewport.zoom}
-        zoomSnap={false}
-      >
-        <RouteOverlay points={points} />
-      </PigeonMapCore>
+      <Box sx={tileLayerSx}>
+        <PigeonMapCore
+          animate={false}
+          attribution={false}
+          center={viewport.center}
+          dprs={[1, 2]}
+          height={size.height}
+          // Pigeon only reads width/height in its constructor, so remount on resize.
+          key={`${Math.round(size.width)}x${Math.round(size.height)}`}
+          mouseEvents={false}
+          provider={provider}
+          tileComponent={SmoothTile}
+          touchEvents={false}
+          width={size.width}
+          zoom={viewport.zoom}
+          zoomSnap={false}
+        />
+      </Box>
+      <Box sx={getScrimSx(dark)} />
+      <Box component="svg" sx={routeSvgSx} viewBox={`0 0 ${size.width} ${size.height}`}>
+        <Box
+          component="path"
+          d={routePath}
+          fill="none"
+          stroke="color-mix(in srgb, var(--mui-palette-background-paper) 78%, transparent)"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={9}
+          vectorEffect="non-scaling-stroke"
+        />
+        <Box
+          component="path"
+          d={routePath}
+          fill="none"
+          stroke={STRAVA_ORANGE}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={4.5}
+          vectorEffect="non-scaling-stroke"
+        />
+      </Box>
     </Box>
   );
 }

--- a/packages/maps/src/RouteMap.tsx
+++ b/packages/maps/src/RouteMap.tsx
@@ -13,6 +13,9 @@ const ROUTE_PADDING = 42;
 const DEFAULT_SIZE = 320;
 const STRAVA_ORANGE = '#fc4c02';
 
+const paperMix = (percent: number) =>
+  `color-mix(in srgb, var(--mui-palette-background-paper) ${percent}%, transparent)`;
+
 const containerSx: SxObject = {
   backgroundColor: 'var(--mui-palette-background-paper)',
   height: '100%',
@@ -37,31 +40,30 @@ const underlaySx: SxObject = {
   zIndex: 0,
 };
 
-const tileLayerSx: SxObject = {
+const getTileLayerSx = (dark: boolean): SxObject => ({
   // Pigeon paints its own opaque background, which would hide the placeholder.
   '& > div': {
     backgroundColor: 'transparent !important',
   },
-  // Mutes the basemap's landcover so the route and card copy lead, while roads,
-  // trails and water still read as a map.
-  filter: 'saturate(0.62)',
+  // Outdoors is vivid and fully labelled, so light mode also lifts its darkest
+  // ink — road casings and place labels — toward the landcover. Without that the
+  // basemap's own labels, not the route, become the worst thing under the copy.
+  filter: dark ? 'saturate(0.85)' : 'saturate(0.5) brightness(1.1) contrast(0.76)',
   inset: 0,
   position: 'absolute',
   zIndex: 1,
-};
+});
 
 /**
- * Knocks the basemap back just far enough for the copy to win, weighted toward
- * the bottom where the densest text sits. Outdoors is a vivid, fully labelled
- * style so it needs more help than the already-muted dark basemap.
+ * A mild, near-uniform knock-back that sets how present the basemap feels.
+ * Legibility is the host's job: whatever renders text over this map is expected
+ * to back its own text regions, since only it knows where the copy sits.
  */
 const getScrimSx = (dark: boolean): SxObject => {
-  const [top, middle, bottom] = dark ? ([16, 28, 44] as const) : ([32, 42, 55] as const);
-  const paper = (percent: number) =>
-    `color-mix(in srgb, var(--mui-palette-background-paper) ${percent}%, transparent)`;
+  const [top, bottom] = dark ? ([10, 20] as const) : ([20, 28] as const);
 
   return {
-    background: `linear-gradient(180deg, ${paper(top)} 0%, ${paper(middle)} 45%, ${paper(bottom)} 100%)`,
+    background: `linear-gradient(180deg, ${paperMix(top)} 0%, ${paperMix(bottom)} 100%)`,
     inset: 0,
     position: 'absolute',
     zIndex: 2,
@@ -190,7 +192,7 @@ export function RouteMap({ points, stadiaApiKey }: RouteMapProps) {
         })}
         sx={underlaySx}
       />
-      <Box sx={tileLayerSx}>
+      <Box sx={getTileLayerSx(dark)}>
         <PigeonMapCore
           animate={false}
           attribution={false}
@@ -214,10 +216,10 @@ export function RouteMap({ points, stadiaApiKey }: RouteMapProps) {
           component="path"
           d={routePath}
           fill="none"
-          stroke="color-mix(in srgb, var(--mui-palette-background-paper) 78%, transparent)"
+          stroke={dark ? 'rgb(0 0 0 / 0.5)' : paperMix(92)}
           strokeLinecap="round"
           strokeLinejoin="round"
-          strokeWidth={9}
+          strokeWidth={7}
           vectorEffect="non-scaling-stroke"
         />
         <Box
@@ -227,7 +229,7 @@ export function RouteMap({ points, stadiaApiKey }: RouteMapProps) {
           stroke={STRAVA_ORANGE}
           strokeLinecap="round"
           strokeLinejoin="round"
-          strokeWidth={4.5}
+          strokeWidth={3}
           vectorEffect="non-scaling-stroke"
         />
       </Box>

--- a/packages/maps/src/SmoothTile.tsx
+++ b/packages/maps/src/SmoothTile.tsx
@@ -1,0 +1,36 @@
+import type { SxObject } from '@dg/ui/theme';
+import { Box } from '@mui/material';
+import type { TileComponentProps } from 'pigeon-maps';
+
+const tileImageSx: SxObject = {
+  display: 'block',
+  height: '100%',
+  width: '100%',
+};
+
+/** A single-layer tile with a fade that keeps theme changes from flashing. */
+export function SmoothTile({ tile, tileLoaded }: TileComponentProps) {
+  const containerSx: SxObject = {
+    height: tile.height,
+    left: tile.left,
+    opacity: tile.active ? 1 : 0,
+    overflow: 'hidden',
+    position: 'absolute',
+    top: tile.top,
+    transition: 'opacity 0.2s',
+    width: tile.width,
+  };
+
+  return (
+    <Box sx={containerSx}>
+      <Box
+        alt=""
+        component="img"
+        onLoad={tileLoaded}
+        src={tile.url}
+        srcSet={tile.srcSet}
+        sx={tileImageSx}
+      />
+    </Box>
+  );
+}

--- a/packages/maps/src/__tests__/routeGeometry.test.ts
+++ b/packages/maps/src/__tests__/routeGeometry.test.ts
@@ -1,0 +1,56 @@
+import type { Point } from 'pigeon-maps';
+import { decodePolyline, fitRouteViewport } from '../routeGeometry';
+
+describe('route geometry', () => {
+  it('decodes the canonical Google polyline fixture', () => {
+    expect(decodePolyline('_p~iF~ps|U_ulLnnqC_mqNvxq`@')).toEqual([
+      [38.5, -120.2],
+      [40.7, -120.95],
+      [43.252, -126.453],
+    ]);
+  });
+
+  it('rejects a truncated encoded value', () => {
+    expect(() => decodePolyline('_')).toThrow('Invalid encoded polyline');
+  });
+
+  it('fits every route point inside the requested padding', () => {
+    const points = decodePolyline('_p~iF~ps|U_ulLnnqC_mqNvxq`@');
+    const width = 320;
+    const height = 280;
+    const padding = 40;
+    const viewport = fitRouteViewport({ height, padding, points, width });
+
+    const worldPixel = ([latitude, longitude]: Point): Point => {
+      const scale = 256 * 2 ** viewport.zoom;
+      const latitudeRadians = (latitude * Math.PI) / 180;
+      return [
+        ((longitude + 180) / 360) * scale,
+        ((1 - Math.log(Math.tan(latitudeRadians) + 1 / Math.cos(latitudeRadians)) / Math.PI) / 2) *
+          scale,
+      ];
+    };
+    const centerPixel = worldPixel(viewport.center);
+
+    for (const point of points) {
+      const pixel = worldPixel(point);
+      const x = pixel[0] - centerPixel[0] + width / 2;
+      const y = pixel[1] - centerPixel[1] + height / 2;
+      expect(x).toBeGreaterThanOrEqual(padding - 0.001);
+      expect(x).toBeLessThanOrEqual(width - padding + 0.001);
+      expect(y).toBeGreaterThanOrEqual(padding - 0.001);
+      expect(y).toBeLessThanOrEqual(height - padding + 0.001);
+    }
+  });
+
+  it('uses a close zoom for a single-point route', () => {
+    expect(
+      fitRouteViewport({
+        height: 300,
+        padding: 40,
+        points: [[47.6062, -122.3321]],
+        width: 300,
+      }),
+    ).toEqual({ center: [47.6062, -122.3321], zoom: 15 });
+  });
+});

--- a/packages/maps/src/__tests__/routeGeometry.test.ts
+++ b/packages/maps/src/__tests__/routeGeometry.test.ts
@@ -1,5 +1,9 @@
-import type { Point } from 'pigeon-maps';
-import { decodePolyline, fitRouteViewport } from '../routeGeometry';
+import {
+  decodePolyline,
+  fitRouteViewport,
+  projectRouteToPixels,
+  toSvgPath,
+} from '../routeGeometry';
 
 describe('route geometry', () => {
   it('decodes the canonical Google polyline fixture', () => {
@@ -21,26 +25,26 @@ describe('route geometry', () => {
     const padding = 40;
     const viewport = fitRouteViewport({ height, padding, points, width });
 
-    const worldPixel = ([latitude, longitude]: Point): Point => {
-      const scale = 256 * 2 ** viewport.zoom;
-      const latitudeRadians = (latitude * Math.PI) / 180;
-      return [
-        ((longitude + 180) / 360) * scale,
-        ((1 - Math.log(Math.tan(latitudeRadians) + 1 / Math.cos(latitudeRadians)) / Math.PI) / 2) *
-          scale,
-      ];
-    };
-    const centerPixel = worldPixel(viewport.center);
-
-    for (const point of points) {
-      const pixel = worldPixel(point);
-      const x = pixel[0] - centerPixel[0] + width / 2;
-      const y = pixel[1] - centerPixel[1] + height / 2;
+    for (const { x, y } of projectRouteToPixels({ ...viewport, height, points, width })) {
       expect(x).toBeGreaterThanOrEqual(padding - 0.001);
       expect(x).toBeLessThanOrEqual(width - padding + 0.001);
       expect(y).toBeGreaterThanOrEqual(padding - 0.001);
       expect(y).toBeLessThanOrEqual(height - padding + 0.001);
     }
+  });
+
+  it('centers a single-point route and renders it as a one-command path', () => {
+    const points = decodePolyline('_p~iF~ps|U');
+    const pixels = projectRouteToPixels({
+      center: points[0] as [number, number],
+      height: 200,
+      points,
+      width: 300,
+      zoom: 15,
+    });
+
+    expect(pixels).toEqual([{ x: 150, y: 100 }]);
+    expect(toSvgPath(pixels)).toBe('M150.00 100.00');
   });
 
   it('uses a close zoom for a single-point route', () => {

--- a/packages/maps/src/routeGeometry.ts
+++ b/packages/maps/src/routeGeometry.ts
@@ -4,7 +4,7 @@ const TILE_SIZE = 256;
 const MAX_MERCATOR_LATITUDE = 85.051_128_78;
 const DEFAULT_ROUTE_ZOOM = 15;
 
-type ProjectedPoint = {
+export type ProjectedPoint = {
   x: number;
   y: number;
 };
@@ -116,4 +116,41 @@ export function fitRouteViewport({
     center: unproject({ x: (minX + maxX) / 2, y: (minY + maxY) / 2 }),
     zoom,
   };
+}
+
+/**
+ * Maps route points onto viewport pixels using the same 256px slippy-map
+ * projection Pigeon uses, so the overlay can live outside the map instead of
+ * depending on Pigeon's own projection callback.
+ */
+export function projectRouteToPixels({
+  center,
+  height,
+  points,
+  width,
+  zoom,
+}: {
+  center: Point;
+  height: number;
+  points: Array<Point>;
+  width: number;
+  zoom: number;
+}): Array<ProjectedPoint> {
+  const scale = TILE_SIZE * 2 ** zoom;
+  const projectedCenter = project(center);
+
+  return points.map((point) => {
+    const projected = project(point);
+    return {
+      x: (projected.x - projectedCenter.x) * scale + width / 2,
+      y: (projected.y - projectedCenter.y) * scale + height / 2,
+    };
+  });
+}
+
+/** Builds an SVG path command string from already-projected route pixels. */
+export function toSvgPath(pixels: Array<ProjectedPoint>) {
+  return pixels
+    .map(({ x, y }, index) => `${index === 0 ? 'M' : 'L'}${x.toFixed(2)} ${y.toFixed(2)}`)
+    .join(' ');
 }

--- a/packages/maps/src/routeGeometry.ts
+++ b/packages/maps/src/routeGeometry.ts
@@ -1,0 +1,119 @@
+import type { Point } from 'pigeon-maps';
+
+const TILE_SIZE = 256;
+const MAX_MERCATOR_LATITUDE = 85.051_128_78;
+const DEFAULT_ROUTE_ZOOM = 15;
+
+type ProjectedPoint = {
+  x: number;
+  y: number;
+};
+
+export type RouteViewport = {
+  center: Point;
+  zoom: number;
+};
+
+function decodeValue(encoded: string, startIndex: number) {
+  let index = startIndex;
+  let result = 0;
+  let shift = 0;
+
+  while (index < encoded.length) {
+    const byte = encoded.charCodeAt(index) - 63;
+    index += 1;
+    result |= (byte & 0x1f) << shift;
+    shift += 5;
+    if (byte < 0x20) {
+      const value = result & 1 ? ~(result >> 1) : result >> 1;
+      return { index, value };
+    }
+  }
+
+  throw new Error('Invalid encoded polyline');
+}
+
+/** Decodes a Google encoded polyline into latitude/longitude points. */
+export function decodePolyline(encoded: string): Array<Point> {
+  const points: Array<Point> = [];
+  let index = 0;
+  let latitude = 0;
+  let longitude = 0;
+
+  while (index < encoded.length) {
+    const latitudeValue = decodeValue(encoded, index);
+    const longitudeValue = decodeValue(encoded, latitudeValue.index);
+    index = longitudeValue.index;
+    latitude += latitudeValue.value;
+    longitude += longitudeValue.value;
+    points.push([latitude / 1e5, longitude / 1e5]);
+  }
+
+  return points;
+}
+
+function project([latitude, longitude]: Point): ProjectedPoint {
+  const clampedLatitude = Math.max(
+    -MAX_MERCATOR_LATITUDE,
+    Math.min(MAX_MERCATOR_LATITUDE, latitude),
+  );
+  const latitudeRadians = (clampedLatitude * Math.PI) / 180;
+
+  return {
+    x: (longitude + 180) / 360,
+    y: (1 - Math.log(Math.tan(latitudeRadians) + 1 / Math.cos(latitudeRadians)) / Math.PI) / 2,
+  };
+}
+
+function unproject({ x, y }: ProjectedPoint): Point {
+  const longitude = x * 360 - 180;
+  const latitudeRadians = Math.atan(Math.sinh(Math.PI * (1 - 2 * y)));
+  return [(latitudeRadians * 180) / Math.PI, longitude];
+}
+
+/**
+ * Fits route bounds to a Web Mercator viewport with an even pixel inset.
+ * Pigeon uses the same 256px slippy-map projection.
+ */
+export function fitRouteViewport({
+  height,
+  maxZoom = 18,
+  minZoom = 1,
+  padding,
+  points,
+  width,
+}: {
+  height: number;
+  maxZoom?: number;
+  minZoom?: number;
+  padding: number;
+  points: Array<Point>;
+  width: number;
+}): RouteViewport {
+  if (points.length === 0) {
+    return { center: [0, 0], zoom: minZoom };
+  }
+
+  const projected = points.map(project);
+  const xs = projected.map(({ x }) => x);
+  const ys = projected.map(({ y }) => y);
+  const minX = Math.min(...xs);
+  const maxX = Math.max(...xs);
+  const minY = Math.min(...ys);
+  const maxY = Math.max(...ys);
+  const availableWidth = Math.max(width - padding * 2, 1);
+  const availableHeight = Math.max(height - padding * 2, 1);
+  const longitudeZoom =
+    maxX === minX ? DEFAULT_ROUTE_ZOOM : Math.log2(availableWidth / (TILE_SIZE * (maxX - minX)));
+  const latitudeZoom =
+    maxY === minY ? DEFAULT_ROUTE_ZOOM : Math.log2(availableHeight / (TILE_SIZE * (maxY - minY)));
+  const zoom = Math.max(
+    minZoom,
+    Math.min(maxZoom, DEFAULT_ROUTE_ZOOM, longitudeZoom, latitudeZoom),
+  );
+
+  return {
+    center: unproject({ x: (minX + maxX) / 2, y: (minY + maxY) / 2 }),
+    zoom,
+  };
+}

--- a/packages/maps/tsconfig.json
+++ b/packages/maps/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig.json",
   "compilerOptions": {
-    "lib": ["dom", "dom.iterable", "ESNext"]
+    "lib": ["dom", "dom.iterable", "ESNext"],
+    "types": ["jest", "node"]
   },
   "extends": "@dg/tsconfig/library.json"
 }

--- a/packages/ui/theme/color.ts
+++ b/packages/ui/theme/color.ts
@@ -27,6 +27,11 @@ export const BRAND_PAIRS = {
   primaryContrastText: ['#fff', 'rgba(0, 0, 0, 0.87)'],
   primaryDark: ['hsl(183, 33%, 27.3%, 1)', 'hsl(24, 88%, 49%, 1)'],
   primaryLight: ['hsl(183, 33%, 51.2%, 1)', 'hsl(24, 88%, 76%, 1)'],
+  // The warm accent hue, muted so a route reads as ink on the map rather than a
+  // highlighter. Both schemes stay near the same luminance: light needs to be
+  // darker than the cream paper, dark needs to stay clear of the light body copy
+  // it passes behind, so neither can simply take the h1 warm tone.
+  routeLine: ['hsl(24deg, 58%, 46%, 1)', 'hsl(24deg, 58%, 50%, 1)'],
   secondary: ['hsl(183deg, 33%, 39%, 0.75)', 'hsl(24deg, 88%, 70%, 0.75)'],
   secondaryContrastText: ['#fff', 'rgba(0, 0, 0, 0.87)'],
   secondaryDark: ['hsl(183, 33%, 27.3%, 0.75)', 'hsl(24, 88%, 49%, 0.75)'],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -389,10 +389,19 @@ importers:
       react-dom:
         specifier: 19.3.0-canary-756fdd47-20260727
         version: 19.3.0-canary-756fdd47-20260727(react@19.3.0-canary-756fdd47-20260727)
+      server-only:
+        specifier: 'catalog:'
+        version: 0.0.1
     devDependencies:
+      '@dg/testing':
+        specifier: workspace:*
+        version: link:../testing
       '@dg/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
       '@types/node':
         specifier: 'catalog:'
         version: 26.1.1
@@ -408,6 +417,9 @@ importers:
       dotenv-mono:
         specifier: 'catalog:'
         version: 1.5.1
+      jest:
+        specifier: 'catalog:'
+        version: 30.4.2(@types/node@26.1.1)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.1)(supports-color@8.1.1))(supports-color@8.1.1)
       typescript:
         specifier: 'catalog:'
         version: '@typescript/typescript6@6.0.2'


### PR DESCRIPTION
# What changed?

- Back the homepage Strava activity card with a real basemap: Stadia Outdoors in light mode (trails, streams, contours, place labels) and Alidade Smooth Dark in dark mode, both distinct from the personal watercolor map
- Layer the card so the scrim sits under the route: tiles → scrim → route → text, so the line keeps full Strava orange and the map still reads as terrain under the copy
- Project route points onto the viewport ourselves instead of borrowing Pigeon's projection callback, which frees the route to paint as the top layer
- No attribution or credit chrome on the card at all
- Preserve a deliberate standard-card fallback for activities without route data
- Add unit coverage for polyline decoding, viewport fitting, pixel projection, route selection, and the no-route state

# Verification

- `turbo check`, `turbo check:types`, `turbo test`
- Production build served locally and captured through CDP in both schemes at desktop and mobile widths (`next dev` hangs on the homepage in this worktree)
- Verified in the rendered DOM that there is no `.pigeon-attribution`, no Stadia/OpenMapTiles/OSM link or text, that Pigeon receives a measured tile box (362px, not -1), and that tiles still request `@2x` via srcSet

# Release info

- [ ] Major
- [ ] Minor
- [x] Patch