### PR TITLE
Match dropdown motion to the cards and share one dropdown everywhere

### DIFF
--- a/apps/web/src/app/music/albums/__tests__/FavoriteAlbumsGrid.test.tsx
+++ b/apps/web/src/app/music/albums/__tests__/FavoriteAlbumsGrid.test.tsx
@@ -1,5 +1,5 @@
 import type { PlaylistAlbum } from '@dg/content-models/spotify/PlaylistAlbums';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { FavoriteAlbumsGrid } from '../FavoriteAlbumsGrid';
@@ -60,9 +60,15 @@ const albums: Array<PlaylistAlbum> = [
 const renderedAlbumNames = () =>
   screen.getAllByRole('img').map((image) => image.getAttribute('alt'));
 
-/** Clicks a sort option in the GlassSwitcher (hidden radio inside a label). */
+/**
+ * Clicks a sort option in the GlassSwitcher (hidden radio inside a label).
+ *
+ * Scoped to the desktop row on purpose: the switcher also renders a mobile
+ * disclosure with its own radio per option, and only CSS picks between them.
+ */
 const clickSort = async (user: ReturnType<typeof userEvent.setup>, label: string) => {
-  await user.click(screen.getByRole('radio', { hidden: true, name: label }));
+  const desktopSwitcher = document.querySelector('[data-role="glass-switcher"]') as HTMLElement;
+  await user.click(within(desktopSwitcher).getByRole('radio', { hidden: true, name: label }));
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -27,5 +27,5 @@
     "clean": "rm -f .env .env.tmp",
     "preinstall": "npx only-allow pnpm"
   },
-  "version": "2.68.3"
+  "version": "2.68.4"
 }

--- a/packages/ui/core/ColorSchemeToggleClient.tsx
+++ b/packages/ui/core/ColorSchemeToggleClient.tsx
@@ -15,8 +15,10 @@ import {
   DISCLOSURE_PANEL_WIDTH,
   DISCLOSURE_ROW_GAP,
   DISCLOSURE_ROW_HEIGHT,
+  disclosureListSx,
   GlassDisclosurePanel,
   GlassDisclosureRow,
+  GlassDisclosureThumb,
 } from './GlassDisclosurePanel';
 import { MouseAwareGlassContainer } from './MouseAwareGlassContainer';
 
@@ -143,30 +145,6 @@ function createStandaloneListSx(isOpen: boolean): SxObject {
     transform: isOpen ? 'none' : `translateY(-${DISCLOSURE_ROW_HEIGHT / 4}px)`,
     transition: `${createTransition(['opacity', 'transform'], TIMING_MEDIUM)}, visibility 0s linear ${isOpen ? 0 : TIMING_MEDIUM}ms`,
     visibility: isOpen ? 'visible' : 'hidden',
-  };
-}
-
-const embeddedListSx: SxObject = {
-  display: 'grid',
-  position: 'relative',
-  rowGap: `${DISCLOSURE_ROW_GAP}px`,
-};
-
-/** Sliding highlight behind the selected row, echoing the albums sorter thumb. */
-function createThumbSx(selectedIndex: number): SxObject {
-  return {
-    [REDUCED_MOTION]: { transition: 'none' },
-    backgroundColor: 'var(--mui-palette-action-selected)',
-    border: '1px solid color-mix(in srgb, var(--mui-palette-primary-main) 30%, transparent)',
-    borderRadius: '999px',
-    height: DISCLOSURE_ROW_HEIGHT,
-    left: 0,
-    position: 'absolute',
-    right: 0,
-    top: 0,
-    transform: `translateY(${selectedIndex * (DISCLOSURE_ROW_HEIGHT + DISCLOSURE_ROW_GAP)}px)`,
-    transition: createTransition(['background-color', 'transform'], TIMING_MEDIUM),
-    zIndex: 0,
   };
 }
 
@@ -327,9 +305,9 @@ export function ColorSchemeToggleClient({
       onKeyDown={handleListKeyDown}
       ref={listRef}
       role="radiogroup"
-      sx={embedded ? embeddedListSx : createStandaloneListSx(isOpen)}
+      sx={embedded ? disclosureListSx : createStandaloneListSx(isOpen)}
     >
-      <Box sx={createThumbSx(selectedIndex)} />
+      <GlassDisclosureThumb selectedIndex={selectedIndex} />
       {OPTIONS.map((option) => (
         <GlassDisclosureRow
           component="label"

--- a/packages/ui/core/GlassDisclosurePanel.tsx
+++ b/packages/ui/core/GlassDisclosurePanel.tsx
@@ -3,7 +3,13 @@
 import { Box, Typography } from '@mui/material';
 import type { ReactNode } from 'react';
 import { createBouncyTransition } from '../helpers/bouncyTransition';
-import { createTransition, TIMING_SLOW } from '../helpers/timing';
+import {
+  createTransition,
+  EASING_BOUNCY,
+  TIMING_BOUNCY,
+  TIMING_MEDIUM,
+  TIMING_NORMAL,
+} from '../helpers/timing';
 import type { SxObject } from '../theme';
 import { GlassContainer } from './GlassContainer';
 
@@ -21,24 +27,57 @@ const panelBaseSx: SxObject = {
   display: 'grid',
   padding: `${DISCLOSURE_PANEL_PADDING}px`,
   position: 'absolute',
-  right: 0,
   rowGap: `${DISCLOSURE_ROW_GAP}px`,
   top: DISCLOSURE_ROW_HEIGHT + DISCLOSURE_ROW_GAP,
   width: DISCLOSURE_PANEL_WIDTH,
   zIndex: 2,
 };
 
+/**
+ * Which edge the panel shares with its trigger. The panel is wider than every
+ * trigger that opens one, so it always grows sideways: pinned to the trigger's
+ * inline-end it grows inward from page chrome on the right, and pinned to the
+ * inline-start it grows inward from a control on the left. Getting this backwards
+ * puts the panel off the side of the viewport rather than merely off-centre.
+ */
+export type DisclosureAlign = 'start' | 'end';
+
+const alignSx: Record<DisclosureAlign, SxObject> = {
+  end: { insetInlineEnd: 0 },
+  start: { insetInlineStart: 0 },
+};
+
+/**
+ * One shorthand, three different jobs — the properties genuinely need different
+ * curves, so composing them by hand beats a helper that spreads a single easing
+ * across all of them.
+ *
+ * `EASING_BOUNCY` is a full spring: it overshoots to 1.337 and rings down
+ * through several oscillations before settling, so it needs `TIMING_BOUNCY` to
+ * read as a bounce rather than a stutter. That is the duration `ContentCard`
+ * gives it, which is why the cards feel right and this panel is matched to them.
+ *
+ * Only `transform` springs. Opacity clamps at 1, so an overshoot there flattens
+ * into a hitch instead of a bounce, and a panel that spends the whole spring
+ * fading in reads as sluggish — it fades on `TIMING_NORMAL` and is fully opaque
+ * while the slide is still settling.
+ *
+ * `visibility` is what keeps a closed panel out of the a11y tree and the tab
+ * order, so its delay tracks the opacity duration rather than the longer
+ * transform: any longer and the panel stays reachable after it looks gone.
+ */
 function createPanelMotionSx(isOpen: boolean): SxObject {
   return {
     [REDUCED_MOTION]: { transition: 'none' },
     opacity: isOpen ? 1 : 0,
     pointerEvents: isOpen ? 'auto' : 'none',
     transform: isOpen ? 'none' : `translateY(-${DISCLOSURE_ROW_HEIGHT / 4}px)`,
+    transition: [
+      createTransition('transform', TIMING_BOUNCY, EASING_BOUNCY),
+      createTransition('opacity', TIMING_NORMAL),
+      `visibility 0s linear ${isOpen ? 0 : TIMING_NORMAL}ms`,
+    ].join(', '),
     visibility: isOpen ? 'visible' : 'hidden',
-    ...createBouncyTransition(['opacity', 'transform'], TIMING_SLOW),
-    transition: `${createTransition(['opacity', 'transform'], TIMING_SLOW)}, visibility 0s linear ${
-      isOpen ? 0 : TIMING_SLOW
-    }ms`,
   };
 }
 
@@ -69,6 +108,12 @@ const rowBaseSx: SxObject = {
   zIndex: 1,
 };
 
+/** Text-only rows drop the icon cell rather than indenting past an empty one. */
+const labelOnlyRowSx: SxObject = {
+  gridTemplateColumns: '1fr',
+  paddingInlineStart: 1.75,
+};
+
 const iconCellSx: SxObject = {
   display: 'grid',
   placeItems: 'center',
@@ -88,21 +133,29 @@ type GlassDisclosurePanelProps = {
   isOpen: boolean;
   /** Accessible name for the disclosure surface. */
   label: string;
+  /** Trigger edge the panel is pinned to. Defaults to the inline end. */
+  align?: DisclosureAlign;
   id?: string;
   role?: string;
   sx?: SxObject;
 };
 
 /**
- * Shared glass disclosure panel for header menus.
+ * Shared glass disclosure panel behind every dropdown on the site.
  *
  * Deliberately a plain `GlassContainer` rather than a mouse-aware one: the panel
  * hangs off a trigger inside a capsule that already tilts toward the cursor, so
  * it inherits that tilt. Its own gravity transform would only double it, and the
  * transform would make the panel a containing block and stacking context for no
  * gain.
+ *
+ * Mount this as a *sibling* of the trigger, never inside another glass surface.
+ * `backdrop-filter` makes an element the backdrop root for its whole subtree, and
+ * a panel hangs below its trigger's box — so nested in glass it samples an area
+ * with nothing behind it and paints fully transparent.
  */
 export function GlassDisclosurePanel({
+  align = 'end',
   children,
   id,
   isOpen,
@@ -117,15 +170,49 @@ export function GlassDisclosurePanel({
       id={id}
       inert={!isOpen}
       role={role}
-      sx={{ ...panelBaseSx, ...createPanelMotionSx(isOpen), ...sx }}
+      sx={{ ...panelBaseSx, ...alignSx[align], ...createPanelMotionSx(isOpen), ...sx }}
     >
       {children}
     </GlassContainer>
   );
 }
 
+/**
+ * Sliding highlight behind the selected row of a single-select disclosure.
+ *
+ * Absolute inside the row list, so the list must be the positioned ancestor and
+ * rows must keep their own stacking above it.
+ */
+export function GlassDisclosureThumb({ selectedIndex }: { selectedIndex: number }) {
+  return (
+    <Box
+      sx={{
+        [REDUCED_MOTION]: { transition: 'none' },
+        backgroundColor: 'var(--mui-palette-action-selected)',
+        border: '1px solid color-mix(in srgb, var(--mui-palette-primary-main) 30%, transparent)',
+        borderRadius: '999px',
+        height: DISCLOSURE_ROW_HEIGHT,
+        insetInline: 0,
+        position: 'absolute',
+        top: 0,
+        transform: `translateY(${selectedIndex * (DISCLOSURE_ROW_HEIGHT + DISCLOSURE_ROW_GAP)}px)`,
+        transition: createTransition(['background-color', 'transform'], TIMING_MEDIUM),
+        zIndex: 0,
+      }}
+    />
+  );
+}
+
+/** Row list for a single-select disclosure, positioned for its thumb. */
+export const disclosureListSx: SxObject = {
+  display: 'grid',
+  position: 'relative',
+  rowGap: `${DISCLOSURE_ROW_GAP}px`,
+};
+
 type GlassDisclosureRowProps = {
-  icon: ReactNode;
+  /** Omitted for text-only option sets, which render as full-width rows. */
+  icon?: ReactNode;
   label: string;
   children?: ReactNode;
   component?: React.ElementType;
@@ -146,11 +233,17 @@ export function GlassDisclosureRow({
   sx,
 }: GlassDisclosureRowProps) {
   return (
-    <Box component={component} onClick={onClick} sx={{ ...rowBaseSx, ...sx }}>
+    <Box
+      component={component}
+      onClick={onClick}
+      sx={{ ...rowBaseSx, ...(icon ? undefined : labelOnlyRowSx), ...sx }}
+    >
       {children}
-      <Box aria-hidden component="span" sx={iconCellSx}>
-        {icon}
-      </Box>
+      {icon ? (
+        <Box aria-hidden component="span" sx={iconCellSx}>
+          {icon}
+        </Box>
+      ) : null}
       <Typography component="span" sx={labelSx} variant="caption">
         {label}
       </Typography>

--- a/packages/ui/core/GlassSwitcher.tsx
+++ b/packages/ui/core/GlassSwitcher.tsx
@@ -1,12 +1,19 @@
 'use client';
 
-import { Box, IconButton, Menu, MenuItem, Radio, RadioGroup, Typography } from '@mui/material';
-import type { MouseEvent, ReactNode } from 'react';
-import { useId, useState } from 'react';
+import { Box, IconButton, Radio, RadioGroup, Typography } from '@mui/material';
+import type { FocusEvent, KeyboardEvent, ReactNode } from 'react';
+import { useEffect, useId, useRef, useState } from 'react';
 import { createBouncyTransition } from '../helpers/bouncyTransition';
 import { createTransition, TIMING_MEDIUM } from '../helpers/timing';
 import type { SxElement, SxObject } from '../theme';
 import { GlassContainer } from './GlassContainer';
+import {
+  DISCLOSURE_ROW_GAP,
+  disclosureListSx,
+  GlassDisclosurePanel,
+  GlassDisclosureRow,
+  GlassDisclosureThumb,
+} from './GlassDisclosurePanel';
 import { MouseAwareGlassContainer } from './MouseAwareGlassContainer';
 import { Tooltip } from './Tooltip';
 
@@ -119,34 +126,70 @@ const optionLabelSx: SxObject = {
 /** Size to match adjacent header glass container (Logo ~52px + container py 0.75 each side) */
 const MOBILE_CONTAINER_SIZE = 64;
 
-/** Mobile icon button - fills container for large touch target */
-const mobileButtonSx: SxObject = {
+/**
+ * Show only on mobile (xs), hide on sm+. Reserves the collapsed circle so the
+ * panel hangs out of flow and opening it never reflows the sticky bar it sits in.
+ */
+const mobileOnlySx: SxObject = {
+  display: { sm: 'none', xs: 'block' },
+  height: MOBILE_CONTAINER_SIZE,
+  position: 'relative',
+  width: MOBILE_CONTAINER_SIZE,
+};
+
+/**
+ * The glass circle sits *behind* the trigger as a sibling rather than wrapping
+ * it, for the same reason the header capsule does: `backdrop-filter` would make
+ * it the backdrop root for the panel hanging below it, which has nothing behind
+ * it to sample and so paints transparent.
+ */
+const mobileGlassSx: SxObject = {
+  borderRadius: '50%',
+  inset: 0,
+  position: 'absolute',
+};
+
+/** Fills the reserved circle, so the whole glass disc is the tap target. */
+const mobileTriggerSx: SxObject = {
   '& svg': {
+    ...createBouncyTransition('scale'),
+    display: 'block',
     height: spacingPx(SPACING.iconSize),
     width: spacingPx(SPACING.iconSize),
+  },
+  '&:hover svg': {
+    scale: 1.2,
   },
   color: 'var(--mui-palette-primary-main)',
   height: '100%',
+  inset: 0,
+  position: 'absolute',
   width: '100%',
 };
 
-const menuItemSx: SxObject = {
-  '& svg': {
-    height: spacingPx(SPACING.iconSize),
-    marginRight: 1.5,
-    width: spacingPx(SPACING.iconSize),
-  },
-  color: 'var(--mui-palette-primary-main)',
+/** Hangs the panel clear of the 64px disc rather than the 48px header row. */
+const mobilePanelSx: SxObject = {
+  top: MOBILE_CONTAINER_SIZE + DISCLOSURE_ROW_GAP,
 };
 
-/** Show only on mobile (xs), hide on sm+ - circular, same height as adjacent content */
-const mobileOnlySx: SxObject = {
-  alignItems: 'center',
-  borderRadius: '50%',
-  display: { sm: 'none', xs: 'flex' },
-  height: MOBILE_CONTAINER_SIZE,
-  justifyContent: 'center',
-  width: MOBILE_CONTAINER_SIZE,
+const optionRowSx: SxObject = {
+  '&:has(input:focus-visible)': {
+    outline: '-webkit-focus-ring-color auto 1px',
+  },
+  cursor: 'pointer',
+};
+
+/**
+ * Stretched over its row so the whole row is the tap target, and kept at zero
+ * opacity rather than `display: none` so it stays focusable and announced.
+ */
+const mobileInputSx: SxObject = {
+  appearance: 'none',
+  cursor: 'pointer',
+  inset: 0,
+  margin: 0,
+  opacity: 0,
+  position: 'absolute',
 };
 
 /** Show only on desktop (sm+), hide on mobile */
@@ -223,7 +266,12 @@ export function GlassSwitcher({
   const menuId = useId();
   // Unique radio name so multiple switchers on a page don't share a native group
   const radioGroupName = useId();
-  const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
+  // The mobile panel renders alongside the desktop row, so it needs its own group
+  const mobileRadioGroupName = useId();
+  const [isMobileOpen, setIsMobileOpen] = useState(false);
+  const mobileRootRef = useRef<HTMLDivElement>(null);
+  const mobileListRef = useRef<HTMLDivElement>(null);
+  const mobileTriggerRef = useRef<HTMLButtonElement>(null);
 
   const selectedIndex = Math.max(
     0,
@@ -232,17 +280,50 @@ export function GlassSwitcher({
   const selectedOption = options[selectedIndex];
   const optionCount = options.length;
 
-  const handleMenuOpen = (event: MouseEvent<HTMLButtonElement>) => {
-    setMenuAnchor(event.currentTarget);
+  // Focus lands on the selected row when the panel opens, wherever it opened from
+  useEffect(() => {
+    if (!isMobileOpen) {
+      return;
+    }
+    mobileListRef.current?.querySelector<HTMLInputElement>('input:checked')?.focus();
+  }, [isMobileOpen]);
+
+  useEffect(() => {
+    if (!isMobileOpen) {
+      return;
+    }
+    const closeOnOutsidePress = (event: PointerEvent) => {
+      if (!mobileRootRef.current?.contains(event.target as Node)) {
+        setIsMobileOpen(false);
+      }
+    };
+    document.addEventListener('pointerdown', closeOnOutsidePress);
+    return () => {
+      document.removeEventListener('pointerdown', closeOnOutsidePress);
+    };
+  }, [isMobileOpen]);
+
+  const collapseMobile = () => {
+    setIsMobileOpen(false);
+    mobileTriggerRef.current?.focus();
   };
 
-  const handleMenuClose = () => {
-    setMenuAnchor(null);
+  const handleMobileKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (isMobileOpen && event.key === 'Escape') {
+      event.preventDefault();
+      collapseMobile();
+    }
   };
 
-  const handleMenuSelect = (newValue: string) => {
+  const handleMobileFocusOut = (event: FocusEvent<HTMLDivElement>) => {
+    if (isMobileOpen && !event.currentTarget.contains(event.relatedTarget)) {
+      setIsMobileOpen(false);
+    }
+  };
+
+  const handleMobileSelect = (newValue: string) => {
     onChange(newValue);
-    handleMenuClose();
+    collapseMobile();
   };
 
   const desktopSx: SxElement = sx
@@ -257,39 +338,68 @@ export function GlassSwitcher({
 
   return (
     <>
-      {/* Mobile: IconButton + Menu - uses GlassContainer (no mouse effects on touch) */}
-      <GlassContainer data-role="glass-switcher" sx={mobileSx}>
+      {/* Mobile: glass disc trigger + the shared disclosure panel */}
+      <Box
+        data-role="glass-switcher-mobile"
+        onBlur={handleMobileFocusOut}
+        onKeyDown={handleMobileKeyDown}
+        ref={mobileRootRef}
+        sx={mobileSx}
+      >
+        <GlassContainer aria-hidden={true} data-switcher-glass={true} sx={mobileGlassSx} />
+        {/*
+         * No tooltip here, unlike the desktop options: this trigger only shows at
+         * xs, where there is no hover to reveal one, and `aria-label` already
+         * names it.
+         */}
         <IconButton
-          aria-controls={menuAnchor ? menuId : undefined}
-          aria-expanded={menuAnchor ? 'true' : undefined}
+          aria-controls={isMobileOpen ? menuId : undefined}
+          aria-expanded={isMobileOpen}
           aria-haspopup="true"
           aria-label={ariaLabel}
-          onClick={handleMenuOpen}
-          sx={mobileButtonSx}
+          onClick={() => (isMobileOpen ? collapseMobile() : setIsMobileOpen(true))}
+          ref={mobileTriggerRef}
+          sx={mobileTriggerSx}
         >
           {mobileIcon ?? selectedOption?.icon}
         </IconButton>
-        <Menu
-          anchorEl={menuAnchor}
-          anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
+        <GlassDisclosurePanel
+          align="start"
           id={menuId}
-          onClose={handleMenuClose}
-          open={Boolean(menuAnchor)}
-          transformOrigin={{ horizontal: 'right', vertical: 'top' }}
+          isOpen={isMobileOpen}
+          label={ariaLabel ?? ''}
+          role="radiogroup"
+          sx={mobilePanelSx}
         >
-          {options.map((option) => (
-            <MenuItem
-              key={option.value}
-              onClick={() => handleMenuSelect(option.value)}
-              selected={value === option.value}
-              sx={menuItemSx}
-            >
-              {option.icon}
-              {option.label}
-            </MenuItem>
-          ))}
-        </Menu>
-      </GlassContainer>
+          {/*
+           * The rows need their own positioned wrapper: the thumb is absolute, and
+           * against the panel it would resolve to the padding box and overhang the
+           * rows by the panel's padding on each side.
+           */}
+          <Box ref={mobileListRef} sx={disclosureListSx}>
+            <GlassDisclosureThumb selectedIndex={selectedIndex} />
+            {options.map((option) => (
+              <GlassDisclosureRow
+                component="label"
+                icon={option.icon}
+                key={option.value}
+                label={option.label}
+                sx={optionRowSx}
+              >
+                <Box
+                  checked={option.value === value}
+                  component="input"
+                  name={mobileRadioGroupName}
+                  onChange={() => handleMobileSelect(option.value)}
+                  sx={mobileInputSx}
+                  type="radio"
+                  value={option.value}
+                />
+              </GlassDisclosureRow>
+            ))}
+          </Box>
+        </GlassDisclosurePanel>
+      </Box>
 
       {/* Desktop: Horizontal RadioGroup with thumb indicator */}
       <MouseAwareGlassContainer data-role="glass-switcher" sx={desktopSx}>

--- a/packages/ui/core/__tests__/GlassDisclosurePanel.test.tsx
+++ b/packages/ui/core/__tests__/GlassDisclosurePanel.test.tsx
@@ -1,6 +1,15 @@
 import { render, screen } from '@testing-library/react';
 import { Disc3, Sun } from 'lucide-react';
+import { EASING_BOUNCY, TIMING_BOUNCY, TIMING_NORMAL } from '../../helpers/timing';
 import { GlassDisclosurePanel, GlassDisclosureRow } from '../GlassDisclosurePanel';
+
+/** The emitted rule for a panel, which is where its transition actually lives. */
+function panelRule(panel: HTMLElement): string {
+  const rules = [...document.querySelectorAll('style')]
+    .flatMap((style) => [...(style.sheet?.cssRules ?? [])].map((rule) => rule.cssText))
+    .filter((rule) => [...panel.classList].some((name) => rule.includes(`.${name}`)));
+  return rules.join('\n');
+}
 
 describe('GlassDisclosurePanel', () => {
   it('renders a shared glass surface with row chrome', () => {
@@ -24,5 +33,70 @@ describe('GlassDisclosurePanel', () => {
     );
 
     expect(screen.getByLabelText('Closed menu')).toHaveAttribute('inert');
+  });
+
+  /**
+   * The spring was previously crammed into 300ms and applied to opacity too,
+   * which read as a stutter rather than the bounce the cards get.
+   */
+  it('springs the transform over the full bouncy duration, easing opacity separately', () => {
+    render(
+      <GlassDisclosurePanel isOpen label="Open menu" role="menu">
+        <GlassDisclosureRow icon={<Sun />} label="Light" />
+      </GlassDisclosurePanel>,
+    );
+
+    const rule = panelRule(screen.getByRole('menu', { name: 'Open menu' }));
+
+    expect(rule).toContain(`transform ${TIMING_BOUNCY}ms ${EASING_BOUNCY}`);
+    expect(rule).toContain(`opacity ${TIMING_NORMAL}ms`);
+    // A spring overshoots, and opacity clamps at 1, so it must not get the curve
+    expect(rule).not.toContain(`opacity ${TIMING_NORMAL}ms ${EASING_BOUNCY}`);
+    // A stray longhand would restyle every property in the shorthand above it
+    expect(rule).not.toContain('transition-timing-function');
+  });
+
+  /**
+   * `visibility` is what takes a closed panel out of the tab order, so it has to
+   * flip once the panel is invisible rather than waiting out the longer transform.
+   */
+  it('delays hiding by the fade duration, not the transform duration', () => {
+    render(
+      <GlassDisclosurePanel isOpen={false} label="Closing menu">
+        <GlassDisclosureRow icon={<Sun />} label="Light" />
+      </GlassDisclosurePanel>,
+    );
+
+    const rule = panelRule(screen.getByLabelText('Closing menu'));
+
+    expect(rule).toContain(`visibility 0s linear ${TIMING_NORMAL}ms`);
+    expect(rule).not.toContain(`visibility 0s linear ${TIMING_BOUNCY}ms`);
+  });
+
+  it('pins the panel to either trigger edge', () => {
+    const { rerender } = render(
+      <GlassDisclosurePanel isOpen label="Panel">
+        <GlassDisclosureRow icon={<Disc3 />} label="Music" />
+      </GlassDisclosurePanel>,
+    );
+    expect(panelRule(screen.getByLabelText('Panel'))).toContain('inset-inline-end: 0');
+
+    rerender(
+      <GlassDisclosurePanel align="start" isOpen label="Panel">
+        <GlassDisclosureRow icon={<Disc3 />} label="Music" />
+      </GlassDisclosurePanel>,
+    );
+    expect(panelRule(screen.getByLabelText('Panel'))).toContain('inset-inline-start: 0');
+  });
+
+  it('drops the icon cell for text-only rows', () => {
+    render(
+      <GlassDisclosurePanel isOpen label="Sort">
+        <GlassDisclosureRow label="Recently added" />
+      </GlassDisclosurePanel>,
+    );
+
+    const row = screen.getByText('Recently added').parentElement as HTMLElement;
+    expect(panelRule(row)).toContain('grid-template-columns: 1fr');
   });
 });

--- a/packages/ui/core/__tests__/GlassSwitcher.test.tsx
+++ b/packages/ui/core/__tests__/GlassSwitcher.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
   createGridStyles,
@@ -7,6 +7,14 @@ import {
   SPACING,
   spacingPx,
 } from '../GlassSwitcher';
+
+/**
+ * Both breakpoint branches render at once — CSS decides which is visible — so
+ * every query has to say which one it means.
+ */
+const desktop = () => within(document.querySelector('[data-role="glass-switcher"]') as HTMLElement);
+const mobile = () =>
+  within(document.querySelector('[data-role="glass-switcher-mobile"]') as HTMLElement);
 
 /** Shape expected from createThumbStyles for assertions (SxObject union blocks direct access). */
 type ThumbStyleShape = {
@@ -63,10 +71,10 @@ describe('GlassSwitcher', () => {
       />,
     );
 
-    const group = screen.getByRole('radiogroup', { name: 'Example switcher' });
+    const group = desktop().getByRole('radiogroup', { name: 'Example switcher' });
     expect(group).toBeInTheDocument();
 
-    const radios = screen.getAllByRole('radio', { hidden: true });
+    const radios = desktop().getAllByRole('radio', { hidden: true });
     expect(radios).toHaveLength(2);
     const firstRadio = radios[0];
     const secondRadio = radios[1];
@@ -97,12 +105,90 @@ describe('GlassSwitcher', () => {
       />,
     );
 
-    expect(screen.getByText('Recently added')).toBeInTheDocument();
-    expect(screen.getByText('Album')).toBeInTheDocument();
+    expect(desktop().getByText('Recently added')).toBeInTheDocument();
+    expect(desktop().getByText('Album')).toBeInTheDocument();
     expect(screen.queryAllByRole('tooltip')).toHaveLength(0);
     expect(screen.getByTestId('mobile-icon')).toBeInTheDocument();
 
-    await user.click(screen.getByRole('radio', { hidden: true, name: 'Album' }));
+    await user.click(desktop().getByRole('radio', { hidden: true, name: 'Album' }));
     expect(handleChange).toHaveBeenCalledWith('album');
+  });
+});
+
+describe('GlassSwitcher mobile disclosure', () => {
+  const renderSwitcher = (onChange = jest.fn()) => {
+    render(
+      <GlassSwitcher
+        aria-label="Sort albums"
+        mobileIcon={<span data-testid="mobile-icon" />}
+        onChange={onChange}
+        options={[
+          { label: 'Recently added', value: 'added' },
+          { label: 'Album', value: 'album' },
+        ]}
+        value="added"
+      />,
+    );
+    return { onChange, trigger: mobile().getByRole('button', { name: 'Sort albums' }) };
+  };
+
+  it('opens the shared glass panel instead of a MUI menu', async () => {
+    const user = userEvent.setup();
+    const { trigger } = renderSwitcher();
+
+    // The old implementation portalled a MUI menu to the body
+    expect(document.querySelector('.MuiMenu-root')).toBeNull();
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+    const panel = mobile().getByRole('radiogroup', { hidden: true });
+    expect(panel).toHaveAttribute('inert');
+
+    await user.click(trigger);
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    expect(panel).not.toHaveAttribute('inert');
+    expect(panel).toHaveAccessibleName('Sort albums');
+  });
+
+  it('keeps the selected sort option programmatically identifiable', async () => {
+    const user = userEvent.setup();
+    const { onChange, trigger } = renderSwitcher();
+    await user.click(trigger);
+
+    const radios = mobile().getAllByRole('radio');
+    expect(radios).toHaveLength(2);
+    expect(mobile().getByRole('radio', { name: 'Recently added' })).toBeChecked();
+    expect(mobile().getByRole('radio', { name: 'Album' })).not.toBeChecked();
+
+    await user.click(mobile().getByRole('radio', { name: 'Album' }));
+    expect(onChange).toHaveBeenCalledWith('album');
+  });
+
+  it('closes on selection and on Escape, returning focus to the trigger', async () => {
+    const user = userEvent.setup();
+    const { trigger } = renderSwitcher();
+
+    await user.click(trigger);
+    await user.click(mobile().getByRole('radio', { name: 'Album' }));
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(trigger).toHaveFocus();
+
+    await user.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    await user.keyboard('{Escape}');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(trigger).toHaveFocus();
+  });
+
+  it('gives the two branches separate native radio groups', () => {
+    renderSwitcher();
+
+    const nameOf = (input: Element) => input.getAttribute('name');
+    const desktopNames = new Set(desktop().getAllByRole('radio', { hidden: true }).map(nameOf));
+    const mobileNames = new Set(mobile().getAllByRole('radio', { hidden: true }).map(nameOf));
+
+    expect(desktopNames.size).toBe(1);
+    expect(mobileNames.size).toBe(1);
+    expect([...desktopNames][0]).not.toBe([...mobileNames][0]);
   });
 });

--- a/packages/ui/helpers/bouncyTransition.ts
+++ b/packages/ui/helpers/bouncyTransition.ts
@@ -1,12 +1,20 @@
-import { createTransition, EASING_BOUNCY, EASING_DEFAULT, TIMING_BOUNCY } from './timing';
+import { createTransition, EASING_BOUNCY, TIMING_BOUNCY } from './timing';
 
+/**
+ * Spring transition for the given properties, as a single `transition` shorthand.
+ *
+ * Emitting one declaration matters: a separate `transition-timing-function`
+ * longhand takes no property list of its own, so it restyles every entry in
+ * whatever shorthand it lands after — including one a consumer set deliberately.
+ * `GlassContainer` spreads this into its base styles, so anything layering its
+ * own per-property easing on a glass surface would silently lose it.
+ */
 export function createBouncyTransition(
   properties: string | Array<string>,
   duration = TIMING_BOUNCY,
-  easing = EASING_DEFAULT,
+  easing = EASING_BOUNCY,
 ) {
   return {
     transition: createTransition(properties, duration, easing),
-    transitionTimingFunction: EASING_BOUNCY,
   };
 }


### PR DESCRIPTION
# What changed?

Two related things, both landing in `GlassDisclosurePanel`.

## The dropdown bounce now matches the cards

`EASING_BOUNCY` is a full spring: roughly thirty `linear()` control points that
overshoot to `1.337`, dip to `0.895`, rise to `1.033` and ring down through
several more oscillations before settling. It is built for `TIMING_BOUNCY`
(750ms), which is what `ContentCard` gives it — that is why the cards feel good.
The header panel ran it over `TIMING_SLOW` (300ms). Compressing that many
oscillations into 300ms is what read as stutter rather than bounce.

I confirmed with computed styles what was actually winning before changing
anything. The panel spread `createBouncyTransition(['opacity','transform'],
TIMING_SLOW)` and then overwrote the `transition` key on the next line, so there
was a shorthand declaring `ease-out` plus a longhand declaring the spring.
The longhand landed after the shorthand, so the effective style was
`transition-property: opacity, transform, visibility` at
`0.3s, 0.3s, 0s` with the **full spring on all three**. So this is not a swap
from ease-out to a spring — the spring was already running, just far too fast,
and on opacity too.

Now:

| property | duration | easing |
|---|---|---|
| `transform` | `TIMING_BOUNCY` (750ms) | `EASING_BOUNCY` |
| `opacity` | `TIMING_NORMAL` (150ms) | `ease-out` |
| `visibility` | `0s`, delayed `TIMING_NORMAL` on close | — |

**The curve itself is unchanged.** The transform runs the same spring over the
same duration as `ContentCard`, so the two are the same motion rather than
merely similar. It does not feel sluggish despite 750ms because the panel only
travels 12px: the spring is within 3% of its target by ~47% of the way through,
which is about ±1px here, so everything after the first ~200ms is imperceptible
settle. Opacity is deliberately off the spring — it clamps at 1, so an overshoot
flattens instead of springing.

The `visibility` delay tracks the **fade** rather than the transform. Tying it
to 750ms would leave the panel painted and in the a11y tree for 600ms after it
had already faded to nothing.

`REDUCED_MOTION` still wins: Emotion emits the nested media block after the flat
declarations, and `transition: none` resets the whole shorthand. Verified under
emulated `prefers-reduced-motion: reduce`.

### A helper bug that made the above impossible

`createBouncyTransition` returned a `transition` shorthand *plus* a bare
`transition-timing-function` longhand. That longhand carries no property list of
its own, so it restyles **every** entry of whatever shorthand precedes it. Since
`GlassContainer` spreads this helper into its base styles, every glass surface
carried a stray spring longhand, and per-property easing on a glass element was
silently impossible — my first attempt at the fix was quietly overridden by it.

It now emits a single shorthand. No caller passed the third `easing` argument and
no caller set `transition` after the spread, so the effective easing is unchanged
everywhere; verified `ContentCard`, its overlay, the capsule glass and the trigger
hover scale all still compute the spring at their previous durations.

## One dropdown presentation on the site

`GlassSwitcher`'s mobile branch was a raw MUI `Menu` with `MenuItem`s — a flat
opaque panel that looked nothing like the header menus. It is deleted, not
restyled, and the branch now renders the same `GlassDisclosurePanel` behind the
music and theme menus. That makes the panel's motion work visible in a third
place.

Notes on that:

- **Anchoring.** The panel is pinned to the trigger's inline *start* here via a
  new `align` prop. The header pins to the inline end because its capsule is at
  the right edge; the sorter sits at the page's left edge, where inline-end
  anchoring would have put a 208px panel at `left: -128px`, off screen.
- **Glass.** The disc is an absolutely positioned sibling behind the trigger, not
  a parent, for the same reason the capsule is: `backdrop-filter` would make it
  the backdrop root for a panel that hangs below it with nothing behind to
  sample, painting it transparent.
- **Selection semantics** stay a native radio group. The two breakpoint branches
  both render (CSS picks), so the mobile group gets its own `name` rather than
  merging with the desktop row.
- **Text-only rows.** Sort options have no icons, so `GlassDisclosureRow`'s icon
  is now optional and such rows collapse to one full-width column instead of
  indenting past an empty 48px cell. I did not invent icons for the sort options.
- No tooltip on the mobile trigger — there wasn't one before, it only shows at
  `xs` where there's no hover, and `aria-label` names it. The desktop options'
  tooltips and their `:focus-visible` guard are untouched.
- The selected-row thumb was duplicated between the theme picker and this, so it
  is now a shared `GlassDisclosureThumb`.

The desktop inline segmented control is deliberately unchanged — that's a
different control shape, not the thing in the screenshot.

# Verification

Recorded both header menus and the mobile sorter opening and closing, light and
dark, at 390 and 1280, with a content-card hover in the same clip so the bounce
is directly comparable.

Checked by hand on `/music/albums`, where the panel hangs off a sticky bar:

- Not clipped on any edge at 390, at the top of the page or scrolled 700px down;
  every row stays hit-testable above the scrolling grid.
- The sticky ancestor has `overflow: visible` and the panel gets its own
  `backdrop-filter`, so `html, body { overflow-x: clip }` doesn't bite.
- No persistent `view-transition-name` added to the panel or its trigger. The
  header disc stays at full opacity through an album open and close, and the
  capsule glass still has zero children.
- Opening a header menu closes the sorter and vice versa; no simultaneous panels.
- Console is clean through the whole sequence.

`turbo check`, `turbo check:types` and `turbo test` all pass — 347 tests across
5 packages.

# Release info

- [ ] Major
- [ ] Minor
- [x] Patch

Made with [Cursor](https://cursor.com)