### PR TITLE
Stop the album well's pinned header from eating tracklist rows

### DIFF
--- a/apps/web/src/app/music/albums/AlbumDetailBody.tsx
+++ b/apps/web/src/app/music/albums/AlbumDetailBody.tsx
@@ -5,7 +5,7 @@ import { Box, Typography } from '@mui/material';
 import {
   ALBUM_WELL_TRACK_COLUMN_GAP,
   ALBUM_WELL_TRACK_NUMBER_COLUMN,
-  albumWellMetaBandSx,
+  albumWellMetaRowSx,
   albumWellMetaTextSx,
 } from './albumWellStyles';
 
@@ -153,7 +153,7 @@ export function AlbumDetailBody({ album }: { album: AlbumDetail }) {
 
   return (
     <Box sx={{ display: 'contents' }}>
-      <Box sx={albumWellMetaBandSx}>
+      <Box sx={albumWellMetaRowSx}>
         <Box data-role="album-meta" sx={albumWellMetaTextSx}>
           <Typography
             color="text.secondary"

--- a/apps/web/src/app/music/albums/AlbumDetailBodySkeleton.tsx
+++ b/apps/web/src/app/music/albums/AlbumDetailBodySkeleton.tsx
@@ -3,7 +3,7 @@ import { Box, Skeleton } from '@mui/material';
 import {
   ALBUM_WELL_TRACK_COLUMN_GAP,
   ALBUM_WELL_TRACK_NUMBER_COLUMN,
-  albumWellMetaBandSx,
+  albumWellMetaRowSx,
   albumWellMetaTextSx,
 } from './albumWellStyles';
 
@@ -28,7 +28,7 @@ const rowSx: SxObject = {
 export function AlbumDetailBodySkeleton() {
   return (
     <Box data-role="album-detail-placeholder" sx={{ display: 'contents' }}>
-      <Box data-role="album-meta-skeleton" sx={albumWellMetaBandSx}>
+      <Box data-role="album-meta-skeleton" sx={albumWellMetaRowSx}>
         <Box sx={albumWellMetaTextSx}>
           <Skeleton sx={{ maxWidth: 320 }} variant="text" width="55%" />
           <Skeleton height={28} sx={{ maxWidth: 380 }} variant="text" width="65%" />

--- a/apps/web/src/app/music/albums/AlbumDetailBodySkeleton.tsx
+++ b/apps/web/src/app/music/albums/AlbumDetailBodySkeleton.tsx
@@ -20,10 +20,14 @@ const rowSx: SxObject = {
  * Holds the well open at roughly its loaded height while the tracklist streams
  * in, so the grid below does not jump once it lands. Mirrors the well's gutter
  * and text edge too, so the album name above it does not slide sideways either.
+ *
+ * `data-role="album-detail-placeholder"` is what the well's height reserve keys
+ * off: while this is on screen the well is floored at the height the previous
+ * album measured, and its removal is what releases that floor.
  */
 export function AlbumDetailBodySkeleton() {
   return (
-    <Box sx={{ display: 'contents' }}>
+    <Box data-role="album-detail-placeholder" sx={{ display: 'contents' }}>
       <Box data-role="album-meta-skeleton" sx={albumWellMetaBandSx}>
         <Box sx={albumWellMetaTextSx}>
           <Skeleton sx={{ maxWidth: 320 }} variant="text" width="55%" />

--- a/apps/web/src/app/music/albums/AlbumWell.tsx
+++ b/apps/web/src/app/music/albums/AlbumWell.tsx
@@ -34,8 +34,34 @@ const albumWellVtNameSx: SxObject = {
     },
 };
 
+/**
+ * Floor the card at the height the outgoing album's detail measured, for exactly
+ * as long as a placeholder is standing in for detail that has not landed.
+ *
+ * Switching straight from one album to another swaps a tracklist of dozens of
+ * rows for a placeholder of six, so without a floor the card — and every grid row
+ * under it — drops by the difference (~3300px at 1280) in the frame the click
+ * commits, then climbs back as the real tracklist arrives. Holding the floor
+ * turns that shrink-then-grow into a single eased step.
+ *
+ * `:has()` is what releases it: the moment real detail replaces the placeholder
+ * the floor stops applying, the card falls to its natural height, and the resize
+ * observer below tweens that one change. Nothing has to decide when detail has
+ * "really" arrived — the URL lands well before the streamed tracklist does, so
+ * every signal short of the placeholder's own absence releases too early.
+ */
+function reserveSx(reservePx: number | null): SxObject {
+  return reservePx == null
+    ? {}
+    : { '&:has([data-role="album-detail-placeholder"])': { minHeight: reservePx } };
+}
+
 const wellSx: SxObject = {
   ...albumWellVtNameSx,
+  // Content-height rows, so the floor below leaves its slack at the bottom of the
+  // card. Stretching would spread it between the name, meta, and tracklist rows
+  // and push everything but the title past the fold while the placeholder is up.
+  alignContent: 'start',
   backgroundColor: 'color-mix(in srgb, var(--mui-palette-background-paper) 88%, transparent)',
   border: '1px solid color-mix(in srgb, CanvasText 10%, transparent)',
   borderRadius: 3,
@@ -109,9 +135,14 @@ const nameLinkSx: SxObject = {
 };
 
 /**
- * Outer shell height. Locked to a pixel value only while tweening skeleton →
- * detail (or any later content resize); released to `auto` afterward so sticky
- * bands are not trapped under `overflow: hidden`.
+ * Outer shell height. Locked to a pixel value only while a content resize is
+ * tweening, then released to `auto`.
+ *
+ * `clip` rather than `hidden`: `hidden` makes this a scroll container, which
+ * re-parents the well's sticky art and name band to it. Their `top` offsets then
+ * apply against a box scrolled to 0, so both slid ~100px down the card the frame
+ * the height locked and snapped back when it released. `clip` hides the same
+ * overflow without a scrollport, leaving sticky anchored to the page.
  */
 function shellSx(heightPx: number | null): SxObject {
   const locking = heightPx != null;
@@ -122,7 +153,7 @@ function shellSx(heightPx: number | null): SxObject {
       transition: 'none',
     },
     height: locking ? heightPx : 'auto',
-    overflow: locking ? 'hidden' : 'visible',
+    overflow: locking ? 'clip' : 'visible',
     // Same tier as SpotifyHeaderCard's fr expand, but medium — open felt slow at slow.
     transition: locking ? createTransition('height', TIMING_MEDIUM, EASING_DEFAULT) : undefined,
   };
@@ -141,14 +172,31 @@ type Props = {
  * everything that needs a fetch arrives as children.
  *
  * Open/close height is a view-transition clip on `album-well` (scoped to
- * album-open/close only). After open, content that lands later — skeleton →
- * tracklist — grows the shell with a measured height tween so the jump never
+ * album-open/close only). After open, content that lands later — placeholder →
+ * tracklist — resizes the shell with a measured height tween so the change never
  * reads as a jolt, then releases back to `auto` for sticky.
+ *
+ * Switching straight from one album to another goes further and floors the card
+ * at the outgoing height until the arriving tracklist replaces the placeholder,
+ * so that swap costs the page no layout at all. See `reserveSx`.
  */
 export function AlbumWell({ album, children }: Props) {
   const measureRef = useRef<HTMLDivElement>(null);
   const lastHeightRef = useRef<number | null>(null);
   const [heightPx, setHeightPx] = useState<number | null>(null);
+  const [reservePx, setReservePx] = useState<number | null>(null);
+  const [openAlbumId, setOpenAlbumId] = useState(album.id);
+
+  if (album.id !== openAlbumId) {
+    // Claim the reserve in the same render that swaps the content in, so the
+    // placeholder never gets a frame at its own height to paint at. The shell is
+    // pinned to the same height as well: the floor drops the instant real detail
+    // replaces the placeholder, but the tween that follows can only start on the
+    // next resize observation, and an `auto` shell would reflow in between.
+    setOpenAlbumId(album.id);
+    setReservePx(lastHeightRef.current);
+    setHeightPx(lastHeightRef.current);
+  }
 
   useLayoutEffect(() => {
     const node = measureRef.current;
@@ -168,7 +216,7 @@ export function AlbumWell({ album, children }: Props) {
         return;
       }
 
-      // Two-stage grow: pin the outgoing height, then ease to the new content.
+      // Two-stage tween: pin the outgoing height, then ease to the new content.
       setHeightPx(previous);
       requestAnimationFrame(() => {
         setHeightPx(next);
@@ -186,13 +234,20 @@ export function AlbumWell({ album, children }: Props) {
       return;
     }
     setHeightPx(null);
+    // The reserve has already been released by the placeholder leaving; dropping
+    // it here keeps a stale floor from applying to some later placeholder.
+    setReservePx(null);
     lastHeightRef.current = measureRef.current?.scrollHeight ?? lastHeightRef.current;
   };
 
   return (
     <Box onTransitionEnd={handleTransitionEnd} sx={shellSx(heightPx)}>
       <Box ref={measureRef}>
-        <Box aria-label={`${album.name} details`} component="section" sx={wellSx}>
+        <Box
+          aria-label={`${album.name} details`}
+          component="section"
+          sx={{ ...wellSx, ...reserveSx(reservePx) }}
+        >
           <Link
             href={album.url}
             isExternal={true}

--- a/apps/web/src/app/music/albums/AlbumWell.tsx
+++ b/apps/web/src/app/music/albums/AlbumWell.tsx
@@ -11,6 +11,7 @@ import type { ReactNode, TransitionEvent } from 'react';
 import { useLayoutEffect, useRef, useState, ViewTransition } from 'react';
 import {
   ALBUM_WELL_ART_SIZE_XS,
+  ALBUM_WELL_NAME_BAND,
   ALBUM_WELL_NAME_GAP,
   ALBUM_WELL_NAME_LINE,
   ALBUM_WELL_PINNED_SURFACE,
@@ -70,14 +71,22 @@ const wellSx: SxObject = {
     0 8px 28px color-mix(in srgb, var(--mui-palette-common-black) 8%, transparent)`,
   columnGap: { sm: 3, xs: 0 },
   display: 'grid',
+  // Art sits beside the pinned bands from `sm` up, and under them on mobile,
+  // where stacking it on top would put it inside the strip the bands' backdrop
+  // covers and leave it half-erased before a single row had scrolled.
   gridTemplateAreas: {
     sm: '"art name" "art meta" "art tracks"',
-    xs: '"art" "name" "meta" "tracks"',
+    xs: '"name" "meta" "art" "tracks"',
   },
   gridTemplateColumns: {
     sm: `${WELL_ART_SIZE}px minmax(0, 1fr)`,
     xs: '1fr',
   },
+  // Trims the pinned name band's backdrop, which overshoots the card on every
+  // side so it can reach the card's edges from inside the text column. `clip`
+  // rather than `hidden` for the same reason the shell uses it: `hidden` would
+  // make this a scrollport and re-anchor the sticky art and bands to the card.
+  overflow: 'clip',
   p: { sm: 3, xs: 2 },
 };
 
@@ -95,9 +104,14 @@ const artCardSx: SxObject = {
 };
 
 /**
- * Sticks alongside the pinned name and meta. Grid items stretch by default,
- * which would both leave the anchor covering the empty column beside the
- * tracklist and give sticky no room to travel inside the grid area.
+ * Sticks beside the pinned name and meta from `sm` up, where it shares a row
+ * with them and has the whole card to travel through. Grid items stretch by
+ * default, which would both leave the anchor covering the empty column beside
+ * the tracklist and give sticky no room to travel inside the grid area.
+ *
+ * Static on mobile, where pinning a 160px cover on top of an already 150px
+ * pinned stack claimed over a third of the viewport, and left bare strips
+ * either side of a centred square for the tracklist to scroll through.
  */
 const artLinkSx: SxObject = {
   alignSelf: 'start',
@@ -105,29 +119,51 @@ const artLinkSx: SxObject = {
   gridArea: 'art',
   justifySelf: { sm: 'stretch', xs: 'center' },
   maxWidth: { sm: WELL_ART_SIZE, xs: ALBUM_WELL_ART_SIZE_XS },
-  position: 'sticky',
+  mb: { sm: 0, xs: 2 },
+  position: { sm: 'sticky', xs: 'static' },
   top: ALBUM_WELL_STICKY_TOP,
   width: '100%',
 };
 
+/**
+ * Runs the well's opaque surface from the top of the pinned name band up past
+ * the sorter's fade, so the tracklist has dissolved into the card before it
+ * reaches the band rather than ghosting through the fade's near-transparent
+ * tail and then meeting the band at a line.
+ *
+ * Taller than that gap needs to be, and wider than the text column, so it
+ * reaches the card's edges and covers the art column once a long tracklist runs
+ * the sticky art out of travel. The well clips both overshoots; everything
+ * above the fade is already covered by the bar's own surface.
+ */
+const pinnedBackdropSx: SxObject = {
+  backgroundColor: ALBUM_WELL_PINNED_SURFACE,
+  bottom: '100%',
+  content: '""',
+  height: '5rem',
+  insetInline: '-100%',
+  position: 'absolute',
+};
+
 const nameBandSx: SxObject = {
   ...albumWellBandSx,
+  '&::before': pinnedBackdropSx,
   backgroundColor: ALBUM_WELL_PINNED_SURFACE,
+  // Sized to the constant the meta band pins against rather than to the h2's
+  // own line box, which is shorter and left a gap between the two when stuck.
+  blockSize: ALBUM_WELL_NAME_BAND,
   fontWeight: 700,
   gridArea: 'name',
-  lineHeight: ALBUM_WELL_NAME_LINE,
   pb: ALBUM_WELL_NAME_GAP,
   position: 'sticky',
-  top: {
-    sm: ALBUM_WELL_STICKY_TOP.sm,
-    xs: `calc(${ALBUM_WELL_STICKY_TOP.xs} + ${ALBUM_WELL_ART_SIZE_XS}px)`,
-  },
+  top: ALBUM_WELL_STICKY_TOP,
   zIndex: 3,
 };
 
-/** One line so the band's height stays the constant the meta pins against. */
+/** One line, and the one that sets the band's fixed height from the inside. */
 const nameLinkSx: SxObject = {
   gridColumn: 2,
+  lineHeight: ALBUM_WELL_NAME_LINE,
   minWidth: 0,
   overflow: 'hidden',
   textOverflow: 'ellipsis',

--- a/apps/web/src/app/music/albums/AlbumWell.tsx
+++ b/apps/web/src/app/music/albums/AlbumWell.tsx
@@ -11,12 +11,10 @@ import type { ReactNode, TransitionEvent } from 'react';
 import { useLayoutEffect, useRef, useState, ViewTransition } from 'react';
 import {
   ALBUM_WELL_ART_SIZE_XS,
-  ALBUM_WELL_NAME_BAND,
   ALBUM_WELL_NAME_GAP,
   ALBUM_WELL_NAME_LINE,
-  ALBUM_WELL_PINNED_SURFACE,
   ALBUM_WELL_STICKY_TOP,
-  albumWellBandSx,
+  albumWellTextGridSx,
 } from './albumWellStyles';
 
 const WELL_ART_SIZE = 220;
@@ -71,22 +69,14 @@ const wellSx: SxObject = {
     0 8px 28px color-mix(in srgb, var(--mui-palette-common-black) 8%, transparent)`,
   columnGap: { sm: 3, xs: 0 },
   display: 'grid',
-  // Art sits beside the pinned bands from `sm` up, and under them on mobile,
-  // where stacking it on top would put it inside the strip the bands' backdrop
-  // covers and leave it half-erased before a single row had scrolled.
   gridTemplateAreas: {
     sm: '"art name" "art meta" "art tracks"',
-    xs: '"name" "meta" "art" "tracks"',
+    xs: '"art" "name" "meta" "tracks"',
   },
   gridTemplateColumns: {
     sm: `${WELL_ART_SIZE}px minmax(0, 1fr)`,
     xs: '1fr',
   },
-  // Trims the pinned name band's backdrop, which overshoots the card on every
-  // side so it can reach the card's edges from inside the text column. `clip`
-  // rather than `hidden` for the same reason the shell uses it: `hidden` would
-  // make this a scrollport and re-anchor the sticky art and bands to the card.
-  overflow: 'clip',
   p: { sm: 3, xs: 2 },
 };
 
@@ -104,14 +94,15 @@ const artCardSx: SxObject = {
 };
 
 /**
- * Sticks beside the pinned name and meta from `sm` up, where it shares a row
- * with them and has the whole card to travel through. Grid items stretch by
- * default, which would both leave the anchor covering the empty column beside
- * the tracklist and give sticky no room to travel inside the grid area.
+ * The one thing in the well that pins, and the only thing that can: it has its
+ * own column from `sm` up, so it travels beside the tracklist without ever
+ * covering a row. Grid items stretch by default, which would both leave the
+ * anchor covering the empty column beside the tracklist and give sticky no room
+ * to travel inside the grid area.
  *
- * Static on mobile, where pinning a 160px cover on top of an already 150px
- * pinned stack claimed over a third of the viewport, and left bare strips
- * either side of a centred square for the tracklist to scroll through.
+ * Static on mobile, where the single column puts it directly over the rows and
+ * a pinned 160px cover claimed a fifth of the viewport with bare strips either
+ * side of a centred square for the tracklist to scroll through.
  */
 const artLinkSx: SxObject = {
   alignSelf: 'start',
@@ -119,48 +110,19 @@ const artLinkSx: SxObject = {
   gridArea: 'art',
   justifySelf: { sm: 'stretch', xs: 'center' },
   maxWidth: { sm: WELL_ART_SIZE, xs: ALBUM_WELL_ART_SIZE_XS },
-  mb: { sm: 0, xs: 2 },
   position: { sm: 'sticky', xs: 'static' },
   top: ALBUM_WELL_STICKY_TOP,
   width: '100%',
 };
 
-/**
- * Runs the well's opaque surface from the top of the pinned name band up past
- * the sorter's fade, so the tracklist has dissolved into the card before it
- * reaches the band rather than ghosting through the fade's near-transparent
- * tail and then meeting the band at a line.
- *
- * Taller than that gap needs to be, and wider than the text column, so it
- * reaches the card's edges and covers the art column once a long tracklist runs
- * the sticky art out of travel. The well clips both overshoots; everything
- * above the fade is already covered by the bar's own surface.
- */
-const pinnedBackdropSx: SxObject = {
-  backgroundColor: ALBUM_WELL_PINNED_SURFACE,
-  bottom: '100%',
-  content: '""',
-  height: '5rem',
-  insetInline: '-100%',
-  position: 'absolute',
-};
-
-const nameBandSx: SxObject = {
-  ...albumWellBandSx,
-  '&::before': pinnedBackdropSx,
-  backgroundColor: ALBUM_WELL_PINNED_SURFACE,
-  // Sized to the constant the meta band pins against rather than to the h2's
-  // own line box, which is shorter and left a gap between the two when stuck.
-  blockSize: ALBUM_WELL_NAME_BAND,
+const nameSx: SxObject = {
+  ...albumWellTextGridSx,
   fontWeight: 700,
   gridArea: 'name',
   pb: ALBUM_WELL_NAME_GAP,
-  position: 'sticky',
-  top: ALBUM_WELL_STICKY_TOP,
-  zIndex: 3,
 };
 
-/** One line, and the one that sets the band's fixed height from the inside. */
+/** One line, so a long title can't reflow the card while detail streams in. */
 const nameLinkSx: SxObject = {
   gridColumn: 2,
   lineHeight: ALBUM_WELL_NAME_LINE,
@@ -304,7 +266,7 @@ export function AlbumWell({ album, children }: Props) {
           </Link>
 
           <Box sx={{ display: 'contents' }}>
-            <Typography component="h2" sx={nameBandSx} variant="h2">
+            <Typography component="h2" sx={nameSx} variant="h2">
               <Link href={album.url} isExternal={true} sx={nameLinkSx} title={album.name}>
                 {album.name}
               </Link>

--- a/apps/web/src/app/music/albums/__tests__/AlbumWell.test.tsx
+++ b/apps/web/src/app/music/albums/__tests__/AlbumWell.test.tsx
@@ -1,7 +1,27 @@
 import type { PlaylistAlbum } from '@dg/content-models/spotify/PlaylistAlbums';
 import { act, render, screen } from '@testing-library/react';
+import { AlbumDetailBodySkeleton } from '../AlbumDetailBodySkeleton';
 import { AlbumWell } from '../AlbumWell';
 import { ALBUM_WELL_TRACK_NUMBER_COLUMN } from '../albumWellStyles';
+
+/**
+ * The well's height reserve is a conditional CSS rule rather than a resolved
+ * style, so it is read off the stylesheet Emotion emits for the well. Emotion
+ * inserts through the CSSOM here, which leaves the `style` tags themselves empty.
+ */
+function wellRules() {
+  const classes = [...(document.querySelector('section')?.classList ?? [])];
+  const rules = [...document.styleSheets].flatMap((sheet) => {
+    try {
+      return [...sheet.cssRules].map((rule) => rule.cssText);
+    } catch {
+      return [];
+    }
+  });
+  return rules
+    .filter((rule) => classes.some((className) => rule.includes(`.${className}`)))
+    .join('\n');
+}
 
 const album: PlaylistAlbum = {
   addedAt: '2024-01-02T03:04:05Z',
@@ -102,7 +122,9 @@ describe('AlbumWell', () => {
       observerCallback?.([] as unknown as Array<ResizeObserverEntry>, {} as ResizeObserver);
     });
 
-    expect(shell).toHaveStyle({ height: '80px', overflow: 'hidden' });
+    // `clip`, not `hidden`: a scrollport here would re-anchor the well's sticky
+    // art and name band to the shell and slide them down their `top` offsets.
+    expect(shell).toHaveStyle({ height: '80px', overflow: 'clip' });
 
     act(() => {
       rafCallback?.(0);
@@ -119,10 +141,79 @@ describe('AlbumWell', () => {
     });
 
     expect(shell).not.toHaveStyle({ height: '240px' });
-    expect(getComputedStyle(shell).overflow).not.toBe('hidden');
+    expect(getComputedStyle(shell).overflow).toBe('visible');
 
     rafSpy.mockRestore();
     global.ResizeObserver = OriginalResizeObserver;
+  });
+
+  it('floors the well at the outgoing height while a placeholder stands in', () => {
+    let observerCallback: ResizeObserverCallback | undefined;
+    const OriginalResizeObserver = global.ResizeObserver;
+
+    global.ResizeObserver = class {
+      constructor(callback: ResizeObserverCallback) {
+        observerCallback = callback;
+      }
+      observe = jest.fn();
+      unobserve = jest.fn();
+      disconnect = jest.fn();
+    } as unknown as typeof ResizeObserver;
+
+    const { container, rerender } = render(
+      <AlbumWell album={album}>
+        <div>album one tracklist</div>
+      </AlbumWell>,
+    );
+
+    const shell = container.firstElementChild as HTMLElement;
+    const measure = shell.firstElementChild as HTMLElement;
+    const scrollHeight = 900;
+
+    Object.defineProperty(measure, 'scrollHeight', {
+      configurable: true,
+      get: () => scrollHeight,
+    });
+
+    // Settle on album one's tall tracklist.
+    act(() => {
+      observerCallback?.([] as unknown as Array<ResizeObserverEntry>, {} as ResizeObserver);
+    });
+
+    expect(wellRules()).not.toMatch(/min-height/);
+
+    // Switching albums swaps in a placeholder far shorter than what it replaces.
+    act(() => {
+      rerender(
+        <AlbumWell album={{ ...album, id: 'album-2', name: 'Other Album' }}>
+          <AlbumDetailBodySkeleton />
+        </AlbumWell>,
+      );
+    });
+
+    const floored = wellRules();
+
+    // Scoped to the placeholder, so its removal is what drops the floor.
+    expect(floored).toMatch(
+      /:has\(\[data-role="album-detail-placeholder"\]\)\s*\{\s*min-height:\s*900px/,
+    );
+    expect(screen.getByRole('region', { name: 'Other Album details' })).toBeInTheDocument();
+
+    // The floor's slack has to collect below the tracklist. Stretched rows would
+    // spread it through the card and strand the placeholder past the fold.
+    expect(floored).toMatch(/align-content:\s*start/);
+
+    global.ResizeObserver = OriginalResizeObserver;
+  });
+
+  it('has no floor to apply before an album has ever been measured', () => {
+    render(
+      <AlbumWell album={album}>
+        <AlbumDetailBodySkeleton />
+      </AlbumWell>,
+    );
+
+    expect(wellRules()).not.toMatch(/min-height/);
   });
 
   it('skips height tweening when the user prefers reduced motion', () => {

--- a/apps/web/src/app/music/albums/__tests__/AlbumWell.test.tsx
+++ b/apps/web/src/app/music/albums/__tests__/AlbumWell.test.tsx
@@ -2,15 +2,16 @@ import type { PlaylistAlbum } from '@dg/content-models/spotify/PlaylistAlbums';
 import { act, render, screen } from '@testing-library/react';
 import { AlbumDetailBodySkeleton } from '../AlbumDetailBodySkeleton';
 import { AlbumWell } from '../AlbumWell';
-import { ALBUM_WELL_TRACK_NUMBER_COLUMN } from '../albumWellStyles';
+import { ALBUM_WELL_NAME_BAND, ALBUM_WELL_TRACK_NUMBER_COLUMN } from '../albumWellStyles';
 
 /**
- * The well's height reserve is a conditional CSS rule rather than a resolved
- * style, so it is read off the stylesheet Emotion emits for the well. Emotion
- * inserts through the CSSOM here, which leaves the `style` tags themselves empty.
+ * Conditional rules, pseudo-elements and the height reserve never resolve into
+ * an element's own style, so they are read off the stylesheet Emotion emits for
+ * it. Emotion inserts through the CSSOM here, which leaves the `style` tags
+ * themselves empty.
  */
-function wellRules() {
-  const classes = [...(document.querySelector('section')?.classList ?? [])];
+function rulesFor(element: Element | null) {
+  const classes = [...(element?.classList ?? [])];
   const rules = [...document.styleSheets].flatMap((sheet) => {
     try {
       return [...sheet.cssRules].map((rule) => rule.cssText);
@@ -21,6 +22,10 @@ function wellRules() {
   return rules
     .filter((rule) => classes.some((className) => rule.includes(`.${className}`)))
     .join('\n');
+}
+
+function wellRules() {
+  return rulesFor(document.querySelector('section'));
 }
 
 const album: PlaylistAlbum = {
@@ -74,6 +79,31 @@ describe('AlbumWell', () => {
 
   it('reserves a gutter that no streamed track count can change', () => {
     expect(ALBUM_WELL_TRACK_NUMBER_COLUMN).toBe('1.5rem');
+  });
+
+  it('holds the name band at exactly the height the meta band pins against', () => {
+    render(<AlbumWell album={album} />);
+
+    // Left to its own line box the band comes up short of this, and the strip
+    // it leaves is where the tracklist showed between the two pinned surfaces.
+    const band = rulesFor(screen.getByRole('heading', { name: 'Example Album' }));
+
+    expect(band.replaceAll(/\s+/g, ' ')).toContain(`block-size: ${ALBUM_WELL_NAME_BAND}`);
+  });
+
+  it('backs the pinned name with opaque well surface running up past the fade', () => {
+    render(<AlbumWell album={album} />);
+
+    const band = rulesFor(screen.getByRole('heading', { name: 'Example Album' }));
+
+    // Above the band, so the tracklist is gone before it reaches the band's edge
+    // rather than ghosting through the sorter fade's near-transparent tail.
+    expect(band).toMatch(/::before/);
+    expect(band).toMatch(/bottom:\s*100%/);
+    // Wider than the text column, to reach the card's edges and cover the art.
+    expect(band).toMatch(/inset-inline:\s*-100%/);
+    // And the card trims both overshoots, so none of it escapes onto the page.
+    expect(wellRules()).toMatch(/overflow:\s*clip/);
   });
 
   it('tweens shell height when streamed content grows, then releases to auto', () => {

--- a/apps/web/src/app/music/albums/__tests__/AlbumWell.test.tsx
+++ b/apps/web/src/app/music/albums/__tests__/AlbumWell.test.tsx
@@ -2,11 +2,11 @@ import type { PlaylistAlbum } from '@dg/content-models/spotify/PlaylistAlbums';
 import { act, render, screen } from '@testing-library/react';
 import { AlbumDetailBodySkeleton } from '../AlbumDetailBodySkeleton';
 import { AlbumWell } from '../AlbumWell';
-import { ALBUM_WELL_NAME_BAND, ALBUM_WELL_TRACK_NUMBER_COLUMN } from '../albumWellStyles';
+import { ALBUM_WELL_TRACK_NUMBER_COLUMN } from '../albumWellStyles';
 
 /**
- * Conditional rules, pseudo-elements and the height reserve never resolve into
- * an element's own style, so they are read off the stylesheet Emotion emits for
+ * Breakpoint-conditional rules and the height reserve never resolve into an
+ * element's own style, so they are read off the stylesheet Emotion emits for
  * it. Emotion inserts through the CSSOM here, which leaves the `style` tags
  * themselves empty.
  */
@@ -81,29 +81,31 @@ describe('AlbumWell', () => {
     expect(ALBUM_WELL_TRACK_NUMBER_COLUMN).toBe('1.5rem');
   });
 
-  it('holds the name band at exactly the height the meta band pins against', () => {
-    render(<AlbumWell album={album} />);
+  it('leaves the album name in the flow, so it cannot cover a track row', () => {
+    render(
+      <AlbumWell album={album}>
+        <AlbumDetailBodySkeleton />
+      </AlbumWell>,
+    );
 
-    // Left to its own line box the band comes up short of this, and the strip
-    // it leaves is where the tracklist showed between the two pinned surfaces.
-    const band = rulesFor(screen.getByRole('heading', { name: 'Example Album' }));
-
-    expect(band.replaceAll(/\s+/g, ' ')).toContain(`block-size: ${ALBUM_WELL_NAME_BAND}`);
+    // Pinned, the name and the artist/facts under it swallowed three tracklist
+    // rows at 1280 and four at 390 — a frame read as track 10, album metadata,
+    // track 12. Only the art pins, and only where it has its own column.
+    expect(rulesFor(screen.getByRole('heading', { name: 'Example Album' }))).not.toMatch(
+      /position:\s*sticky/,
+    );
+    expect(rulesFor(document.querySelector('[data-role="album-meta-skeleton"]'))).not.toMatch(
+      /position:\s*sticky/,
+    );
   });
 
-  it('backs the pinned name with opaque well surface running up past the fade', () => {
+  it('pins the art alone, and only where it has a column of its own', () => {
     render(<AlbumWell album={album} />);
 
-    const band = rulesFor(screen.getByRole('heading', { name: 'Example Album' }));
+    const art = rulesFor(screen.getByRole('link', { name: 'Open Example Album on Spotify' }));
 
-    // Above the band, so the tracklist is gone before it reaches the band's edge
-    // rather than ghosting through the sorter fade's near-transparent tail.
-    expect(band).toMatch(/::before/);
-    expect(band).toMatch(/bottom:\s*100%/);
-    // Wider than the text column, to reach the card's edges and cover the art.
-    expect(band).toMatch(/inset-inline:\s*-100%/);
-    // And the card trims both overshoots, so none of it escapes onto the page.
-    expect(wellRules()).toMatch(/overflow:\s*clip/);
+    expect(art).toMatch(/position:\s*static/);
+    expect(art).toMatch(/position:\s*sticky/);
   });
 
   it('tweens shell height when streamed content grows, then releases to auto', () => {

--- a/apps/web/src/app/music/albums/albumWellStyles.ts
+++ b/apps/web/src/app/music/albums/albumWellStyles.ts
@@ -6,20 +6,30 @@ export const ALBUM_WELL_TRACK_NUMBER_COLUMN = '1.5rem';
 /** Space between the number gutter and the well's shared text edge. */
 export const ALBUM_WELL_TRACK_COLUMN_GAP = 1.5;
 
-/** Mobile art height included in the sticky-band offset. */
+/** Mobile art width. */
 export const ALBUM_WELL_ART_SIZE_XS = 160;
 
-/** Clears the glass header and the sorter's reserved fade band. */
-export const ALBUM_WELL_STICKY_TOP = {
-  sm: 'calc(var(--site-header-height, 5.5rem) + 115px)',
-  xs: 'calc(var(--site-header-height, 5.5rem) + 94px)',
-} as const;
+/**
+ * Clears the glass header, the sorter bar, and the whole of the sorter's fade,
+ * so nothing pinned here is ever tinted by the ramp's tail. Measured at 111px
+ * (sm) and 112px (xs) — the mobile bar's icon button is a shade taller than the
+ * pill row — so one offset covers both with a few pixels to spare.
+ */
+export const ALBUM_WELL_STICKY_TOP = 'calc(var(--site-header-height, 5.5rem) + 117px)';
 
 /** Stable one-line height for the responsive h2 album-name variant. */
 export const ALBUM_WELL_NAME_LINE = '2.25rem';
 
 /** Gap below the album name inside its pinned band. */
 export const ALBUM_WELL_NAME_GAP = '12px';
+
+/**
+ * The pinned name band's whole height, which the meta band pins directly under.
+ * The band sizes itself to this rather than to its own line box, so the two
+ * surfaces meet exactly: a band an h2 line-height shorter than this leaves a
+ * strip of tracklist scrolling between them once both are stuck.
+ */
+export const ALBUM_WELL_NAME_BAND = `calc(${ALBUM_WELL_NAME_LINE} + ${ALBUM_WELL_NAME_GAP})`;
 
 /** Opaque twin of the well surface, preventing tracks showing through pinned bands. */
 export const ALBUM_WELL_PINNED_SURFACE =
@@ -39,10 +49,7 @@ export const albumWellMetaBandSx: SxObject = {
   gridArea: 'meta',
   pb: 2,
   position: 'sticky',
-  top: {
-    sm: `calc(${ALBUM_WELL_STICKY_TOP.sm} + ${ALBUM_WELL_NAME_LINE} + ${ALBUM_WELL_NAME_GAP})`,
-    xs: `calc(${ALBUM_WELL_STICKY_TOP.xs} + ${ALBUM_WELL_ART_SIZE_XS}px + ${ALBUM_WELL_NAME_LINE} + ${ALBUM_WELL_NAME_GAP})`,
-  },
+  top: `calc(${ALBUM_WELL_STICKY_TOP} + ${ALBUM_WELL_NAME_BAND})`,
   zIndex: 2,
 };
 

--- a/apps/web/src/app/music/albums/albumWellStyles.ts
+++ b/apps/web/src/app/music/albums/albumWellStyles.ts
@@ -10,50 +10,44 @@ export const ALBUM_WELL_TRACK_COLUMN_GAP = 1.5;
 export const ALBUM_WELL_ART_SIZE_XS = 160;
 
 /**
- * Clears the glass header, the sorter bar, and the whole of the sorter's fade,
- * so nothing pinned here is ever tinted by the ramp's tail. Measured at 111px
- * (sm) and 112px (xs) — the mobile bar's icon button is a shade taller than the
- * pill row — so one offset covers both with a few pixels to spare.
+ * Where the well's art pins: clear of the glass header, the sorter bar, and the
+ * whole of the sorter's fade, so it is never tinted by the ramp's tail. The
+ * ramp measures 111px below the header at `sm` and 112px at `xs` — the mobile
+ * bar's icon button is a shade taller than the pill row — so one offset covers
+ * both with a few pixels to spare.
  */
 export const ALBUM_WELL_STICKY_TOP = 'calc(var(--site-header-height, 5.5rem) + 117px)';
 
 /** Stable one-line height for the responsive h2 album-name variant. */
 export const ALBUM_WELL_NAME_LINE = '2.25rem';
 
-/** Gap below the album name inside its pinned band. */
+/** Gap below the album name. */
 export const ALBUM_WELL_NAME_GAP = '12px';
 
-/**
- * The pinned name band's whole height, which the meta band pins directly under.
- * The band sizes itself to this rather than to its own line box, so the two
- * surfaces meet exactly: a band an h2 line-height shorter than this leaves a
- * strip of tracklist scrolling between them once both are stuck.
- */
-export const ALBUM_WELL_NAME_BAND = `calc(${ALBUM_WELL_NAME_LINE} + ${ALBUM_WELL_NAME_GAP})`;
-
-/** Opaque twin of the well surface, preventing tracks showing through pinned bands. */
-export const ALBUM_WELL_PINNED_SURFACE =
-  'color-mix(in srgb, var(--mui-palette-background-paper) 88%, var(--mui-palette-background-default))';
-
-/** Shared gutter-and-text grid used by every pinned well band. */
-export const albumWellBandSx: SxObject = {
+/** Shared gutter-and-text grid, so the name and meta share the tracklist's edge. */
+export const albumWellTextGridSx: SxObject = {
   columnGap: ALBUM_WELL_TRACK_COLUMN_GAP,
   display: 'grid',
   gridTemplateColumns: `${ALBUM_WELL_TRACK_NUMBER_COLUMN} minmax(0, 1fr)`,
 };
 
-/** Sticky artist/facts band shared by streamed detail and its skeleton. */
-export const albumWellMetaBandSx: SxObject = {
-  ...albumWellBandSx,
-  backgroundColor: ALBUM_WELL_PINNED_SURFACE,
+/**
+ * Artist and facts, shared by streamed detail and its skeleton.
+ *
+ * Deliberately not sticky. Pinned here it covered three tracklist rows at 1280
+ * and four at 390 — a static frame read as track 10, album metadata, track 12 —
+ * and every treatment that stopped rows showing through it only made the rows
+ * it swallowed disappear more completely. Nothing in the album header is
+ * navigation, so it scrolls away like the rest of the card and the tracklist
+ * has no overlay to pass under.
+ */
+export const albumWellMetaRowSx: SxObject = {
+  ...albumWellTextGridSx,
   gridArea: 'meta',
   pb: 2,
-  position: 'sticky',
-  top: `calc(${ALBUM_WELL_STICKY_TOP} + ${ALBUM_WELL_NAME_BAND})`,
-  zIndex: 2,
 };
 
-/** Text column inside the pinned artist/facts band. */
+/** Text column inside the artist/facts row. */
 export const albumWellMetaTextSx: SxObject = {
   display: 'grid',
   gridColumn: 2,

--- a/package.json
+++ b/package.json
@@ -27,5 +27,5 @@
     "clean": "rm -f .env .env.tmp",
     "preinstall": "npx only-allow pnpm"
   },
-  "version": "2.68.4"
+  "version": "2.68.5"
 }

--- a/packages/ui/core/__tests__/StickyFadeBar.test.tsx
+++ b/packages/ui/core/__tests__/StickyFadeBar.test.tsx
@@ -18,4 +18,32 @@ describe('StickyFadeBar', () => {
       bottom: 'calc(1.375rem - 1px)',
     });
   });
+
+  it('keeps its chrome painted through an album open or close', () => {
+    const { container } = render(
+      <StickyFadeBar>
+        <span>July 2026</span>
+      </StickyFadeBar>,
+    );
+
+    const surface = container.querySelector('[data-sticky-surface]') as HTMLElement;
+    const rules = [...document.styleSheets]
+      .flatMap((sheet) => {
+        try {
+          return [...sheet.cssRules].map((rule) => rule.cssText);
+        } catch {
+          return [];
+        }
+      })
+      .filter((rule) => [...surface.classList].some((name) => rule.includes(`.${name}`)))
+      .join('\n');
+
+    const hiding = rules.split('\n').filter((rule) => /opacity:\s*0/.test(rule));
+
+    // A navigation still hides the band it would otherwise sweep across content.
+    expect(hiding.join('\n')).toContain('html:active-view-transition');
+    // An album open/close does not, so no artwork shows through the pinned bar.
+    expect(hiding.join('\n')).toContain(':not(:active-view-transition-type(album-open))');
+    expect(hiding.join('\n')).toContain(':not(:active-view-transition-type(album-close))');
+  });
 });

--- a/packages/ui/core/transitions/pageTransitions.ts
+++ b/packages/ui/core/transitions/pageTransitions.ts
@@ -42,19 +42,30 @@ export const SITE_FOOTER_VIEW_TRANSITION_NAME = 'site-footer';
  * row under a bar washes to cream from the top down and reads as blank tiles
  * with a sliver of artwork below.
  *
- * So the chrome just doesn't paint while a transition runs. Both sides read
- * this rule at capture time, so neither page carries a band, and the strip above
- * a pinned bar is briefly unmasked instead — the lesser of the two, and it lands
- * back the instant the flight ends. Hiding beats a group of its own: a name per
- * piece is the only way to lift them out of the page bitmap, and a page with
- * several bars needs a unique one for each, which no widely supported keyword
- * gives us.
+ * So the chrome just doesn't paint while a navigation's transition runs. Both
+ * sides read this rule at capture time, so neither page carries a band, and the
+ * strip above a pinned bar is briefly unmasked instead — the lesser of the two,
+ * and it lands back the instant the flight ends. Hiding beats a group of its own:
+ * a name per piece is the only way to lift them out of the page bitmap, and a
+ * page with several bars needs a unique one for each, which no widely supported
+ * keyword gives us.
+ *
+ * Album open/close is exempt, because there is no sweep to guard against: those
+ * transitions deliberately miss the page rise/fall map, so the page underneath
+ * never travels. Hiding there only costs — the chrome is what covers the artwork
+ * scrolled up behind the heading and the sorter, so dropping it flashes a band of
+ * album covers through the pinned bar for the length of the transition.
  *
  * The selector leads with `html` rather than `:root`, which Emotion would read
  * as a pseudo-class on this element and never match.
  */
 export const stickyDecorSx: SxObject = {
-  'html:active-view-transition &': {
+  [[
+    'html:active-view-transition',
+    `:not(:active-view-transition-type(${ALBUM_TRANSITION_TYPES.open}))`,
+    `:not(:active-view-transition-type(${ALBUM_TRANSITION_TYPES.close}))`,
+    ' &',
+  ].join('')]: {
     opacity: 0,
   },
 };


### PR DESCRIPTION
# What changed?

Three rounds, all on `/music/albums`.

## Round 1 — switching albums lurched the page

Clicking a second album while one was already open dropped the open well's
height out of the document in a single frame — 3315px at 1280 — so every grid
row below snapped up before the new well animated back down. That collapse is
also what hid the sticky bar's chrome for the whole transition, so artwork
scrolled up behind the heading painted straight through.

- **Floor the well at the outgoing album's height** for exactly as long as a
  placeholder stands in for detail that hasn't landed, keyed off the
  placeholder's own presence with `:has()`. Its removal is what releases the
  floor, so no signal has to guess when detail "really" arrived. One eased step
  replaces the shrink-then-grow lurch.
- **`align-content: start` on the well grid**, so the floor's slack collects
  below the tracklist. Stretched auto rows spread it through the card and pushed
  everything but the title past the fold while the placeholder was up.
- **`overflow: clip` instead of `hidden`** on the height-locked shell. `hidden`
  made the shell a scroll container, which re-anchored the well's sticky art to
  it and slid it ~100px down the card the frame the height locked.

## Rounds 2 and 3 — the pinned album header was eating tracklist rows

Round 2 chased the dirty band under the sorter by making the album's pinned
name and meta opaque and closing the gaps around them. That fixed the tinting
and fixed nothing that mattered: an opaque band that hides a track row is worse
than a translucent one, because the row is now gone rather than ghosting.

Measured by walking the whole tracklist at 40px steps and intersecting every
row against the pinned chrome, the album header covered **three rows at 1280
and four at 390** at every scroll position. A static frame read as track 10,
album metadata, track 12. The band's opaque top edge also landed mid-row, which
is what cut `4:48` through the middle — a hard alpha edge over live text, not
the fade.

Reserving space for the header can't fix this. Rows pass under an overlay no
matter how the list is padded, so something is always hidden. Nothing in the
album header is navigation — it is the name, the artist, and some facts — so it
now **scrolls away with the rest of the card**.

The art still pins, because from `sm` up it has a **column of its own** and
travels beside the tracklist without ever covering a row. It stays static at
`xs`, where the single column would put it straight over the rows.

That leaves the sorter's gradient as the only thing painted over the tracklist,
and its coverage is continuous by construction: the bar's opaque surface
overlaps the ramp's opaque end by one pixel (surface `123.4–178.0`, fade
`177.0–234.0` at 1280), and the gradient's first stop is fully opaque. Coverage
falls from 1 to 0 with no step, so text dissolves and no glyph can meet an edge.

## Measured

At 390 and 1280, light and dark, sweeping the entire open well at 40px steps:

| | before | after |
|---|---|---|
| tracklist rows covered by album chrome | 3 @1280, 4 @390 | **0** |
| tracks that never become fully readable | 3–4 at any given scroll | **0 of 45** |
| readable run missing a track number | yes — 10, metadata, 12 | **0 occurrences** |
| elements overlapping a mid-list row | pinned name + meta | **none** |
| gap in the sorter's coverage stack | — | −1px overlap at both seams |
| worst per-frame document drop on switch | 2876–3315px (one frame) | 0–251px (eased tween) |

Round 1's height floor and `align-content: start` still hold, reduced motion
still skips the tween, and the art morph works both directions.

`turbo check`, `turbo check:types` and `turbo test` pass for `@dg/web` and
`@dg/ui` (188 + 61 tests). The two round-2 cases covering the band's fixed
height and backdrop are replaced by cases asserting the name and meta are not
sticky, and that the art pins only where it has its own column.

# Release info

- [ ] Major
- [ ] Minor
- [x] Patch
