### PR TITLE
Compute concentric nested border radii

### DIFF
--- a/apps/web/src/app/home/GatteySitesCard.tsx
+++ b/apps/web/src/app/home/GatteySitesCard.tsx
@@ -3,8 +3,10 @@ import { ContentCard } from '@dg/ui/dependent/ContentCard';
 import { Image } from '@dg/ui/dependent/Image';
 import { Link } from '@dg/ui/dependent/Link';
 import { createBouncyTransition } from '@dg/ui/helpers/bouncyTransition';
+import { getConcentricBorderRadius } from '@dg/ui/helpers/concentricBorderRadius';
 import { truncated } from '@dg/ui/helpers/truncated';
 import type { SxObject } from '@dg/ui/theme';
+import { getShape } from '@dg/ui/theme/shape';
 import { Box, Stack, Typography } from '@mui/material';
 import { ArrowUpRight } from 'lucide-react';
 
@@ -14,12 +16,12 @@ type GatteySitesCardProps = {
 
 const MARK_ROLE = 'side-project-mark';
 
-/**
- * Rows sit 13px inside the card: 20px of card padding plus its 1px border, less
- * the 8px each row bleeds back out. Keeping their corners concentric with the
- * card's 32px radius means subtracting that gap.
- */
-const ROW_BORDER_RADIUS = '19px';
+const CARD_PADDING_PX = 20;
+const CARD_BORDER_WIDTH_PX = 1;
+const ROW_BLEED_PX = 8;
+const ROW_INSET_PX = CARD_PADDING_PX + CARD_BORDER_WIDTH_PX - ROW_BLEED_PX;
+const { cardBorderRadius } = getShape();
+const ROW_BORDER_RADIUS = getConcentricBorderRadius(cardBorderRadius, ROW_INSET_PX);
 
 const markSx: SxObject = {
   flexShrink: 0,
@@ -31,7 +33,7 @@ const markSx: SxObject = {
 };
 
 const cardSx: SxObject = {
-  padding: 2.5,
+  padding: `${CARD_PADDING_PX}px`,
 };
 
 const layoutSx: SxObject = {
@@ -72,7 +74,7 @@ const projectLinkSx: SxObject = {
   borderRadius: ROW_BORDER_RADIUS,
   display: 'flex',
   gap: 1.5,
-  marginInline: -1,
+  marginInline: `-${ROW_BLEED_PX}px`,
   padding: 1,
   textDecoration: 'none',
   ...createBouncyTransition('background-color'),

--- a/apps/web/src/types/mui.d.ts
+++ b/apps/web/src/types/mui.d.ts
@@ -30,6 +30,7 @@ declare module '@mui/material/styles' {
   }
   interface Theme {
     shape: {
+      cardBorderRadius: number;
       gridGap: number;
       gridGapLarge: number;
       gridItemDimension: number;
@@ -38,6 +39,7 @@ declare module '@mui/material/styles' {
   }
   interface ThemeOptions {
     shape: {
+      cardBorderRadius: number;
       gridGap: number;
       gridGapLarge: number;
       gridItemDimension: number;

--- a/package.json
+++ b/package.json
@@ -27,5 +27,5 @@
     "clean": "rm -f .env .env.tmp",
     "preinstall": "npx only-allow pnpm"
   },
-  "version": "2.68.6"
+  "version": "2.68.7"
 }

--- a/packages/maps/types/mui.d.ts
+++ b/packages/maps/types/mui.d.ts
@@ -30,6 +30,7 @@ declare module '@mui/material/styles' {
   }
   interface Theme {
     shape: {
+      cardBorderRadius: number;
       gridGap: number;
       gridGapLarge: number;
       gridItemDimension: number;
@@ -38,6 +39,7 @@ declare module '@mui/material/styles' {
   }
   interface ThemeOptions {
     shape: {
+      cardBorderRadius: number;
       gridGap: number;
       gridGapLarge: number;
       gridItemDimension: number;

--- a/packages/ui/core/GlassContainer.tsx
+++ b/packages/ui/core/GlassContainer.tsx
@@ -2,6 +2,7 @@ import type { BoxProps } from '@mui/material';
 import { Box } from '@mui/material';
 import { createBouncyTransition } from '../helpers/bouncyTransition';
 import type { SxObject } from '../theme';
+import { getShape } from '../theme/shape';
 
 export interface GlassContainerProps extends Omit<BoxProps, 'sx'> {
   /**
@@ -20,12 +21,13 @@ const GLASS_SHADOW = `
   inset 0 1px 0 color-mix(in srgb, var(--mui-palette-common-white) 15%, transparent),
   0px 1px 5px color-mix(in srgb, var(--mui-palette-common-black) 12%, transparent),
   0px 6px 16px color-mix(in srgb, var(--mui-palette-common-black) 8%, transparent)`;
+const { cardBorderRadius } = getShape();
 
 const glassContainerBaseSx: SxObject = {
   backdropFilter: 'blur(12px) saturate(150%)',
   backgroundColor: GLASS_BG,
   border: GLASS_BORDER,
-  borderRadius: '32px',
+  borderRadius: `${cardBorderRadius}px`,
   boxShadow: GLASS_SHADOW,
   position: 'relative',
   ...createBouncyTransition(['background-color', 'border-color', 'box-shadow'], 375),

--- a/packages/ui/helpers/__tests__/concentricBorderRadius.test.ts
+++ b/packages/ui/helpers/__tests__/concentricBorderRadius.test.ts
@@ -1,0 +1,19 @@
+import { getConcentricBorderRadius } from '../concentricBorderRadius';
+
+describe('getConcentricBorderRadius', () => {
+  it('subtracts the inset from the parent radius', () => {
+    expect(getConcentricBorderRadius(32, 13)).toBe('19px');
+  });
+
+  it('clamps an inset larger than the parent radius to zero', () => {
+    expect(getConcentricBorderRadius(8, 12)).toBe('0px');
+  });
+
+  it('keeps a zero-radius parent square', () => {
+    expect(getConcentricBorderRadius(0, 4)).toBe('0px');
+  });
+
+  it('does not let a negative inset enlarge the child radius', () => {
+    expect(getConcentricBorderRadius(16, -4)).toBe('16px');
+  });
+});

--- a/packages/ui/helpers/concentricBorderRadius.ts
+++ b/packages/ui/helpers/concentricBorderRadius.ts
@@ -1,0 +1,4 @@
+export function getConcentricBorderRadius(parentRadiusPx: number, insetPx: number): string {
+  const radiusPx = Math.max(0, parentRadiusPx - Math.max(0, insetPx));
+  return `${radiusPx}px`;
+}

--- a/packages/ui/theme/index.ts
+++ b/packages/ui/theme/index.ts
@@ -87,7 +87,7 @@ export function getTheme(): Theme {
           root: ({ theme }) => ({
             background: theme.vars.palette.background.paper,
             borderColor: theme.vars.palette.card.border,
-            borderRadius: theme.spacing(4),
+            borderRadius: theme.shape.cardBorderRadius,
             borderStyle: 'solid',
             borderWidth: 'thin',
             boxShadow: theme.vars.extraShadows.card.main,

--- a/packages/ui/theme/shape.ts
+++ b/packages/ui/theme/shape.ts
@@ -1,10 +1,10 @@
 import type { ThemeOptions } from '@mui/material';
 
-/**
- * Sets up the spacing features for the grid in rem units
- */
+const CARD_BORDER_RADIUS_PX = 32;
+
 export function getShape() {
   const shape: ThemeOptions['shape'] = {
+    cardBorderRadius: CARD_BORDER_RADIUS_PX,
     gridGap: 2,
     gridGapLarge: 3.65,
     gridItemDimension: 17.25,

--- a/packages/ui/types/mui.d.ts
+++ b/packages/ui/types/mui.d.ts
@@ -30,6 +30,7 @@ declare module '@mui/material/styles' {
   }
   interface Theme {
     shape: {
+      cardBorderRadius: number;
       gridGap: number;
       gridGapLarge: number;
       gridItemDimension: number;
@@ -38,6 +39,7 @@ declare module '@mui/material/styles' {
   }
   interface ThemeOptions {
     shape: {
+      cardBorderRadius: number;
       gridGap: number;
       gridGapLarge: number;
       gridItemDimension: number;


### PR DESCRIPTION
# What changed?

- Add `getConcentricBorderRadius(parentRadiusPx, insetPx)` in `@dg/ui/helpers/concentricBorderRadius`. It returns a clamped CSS pixel radius.
- Add `theme.shape.cardBorderRadius` as the 32px card-radius source of truth and use it for MUI cards and glass containers.
- Compute the side-project row radius from the card radius and its 13px inset.
- Cover subtraction, oversized insets, square parents, and negative insets with unit tests.

Visual comparison against the current production homepage kept the card and side-project rows unchanged.

# Release info

- [ ] Major
- [ ] Minor
- [x] Patch

# Verification

- `turbo check --filter=@dg/ui --filter=@dg/web --filter=@dg/maps`
- `turbo check:types --filter=@dg/ui --filter=@dg/web --filter=@dg/maps`
- `turbo test --filter=@dg/ui --filter=@dg/web`