### PR TITLE
Stop music titles flying in from the header disc

### DIFF
--- a/apps/web/src/app/layouts/MusicHeaderMenu.tsx
+++ b/apps/web/src/app/layouts/MusicHeaderMenu.tsx
@@ -9,16 +9,14 @@ import {
 } from '@dg/ui/core/GlassDisclosurePanel';
 import { Tooltip } from '@dg/ui/core/Tooltip';
 import { PageTransitionLink } from '@dg/ui/core/transitions/PageTransitionLink';
-import { pageTitleMorphName, pageTransitionTypes } from '@dg/ui/core/transitions/pageTransitions';
 import { createBouncyTransition } from '@dg/ui/helpers/bouncyTransition';
 import type { SxObject } from '@dg/ui/theme';
 import { Box, IconButton } from '@mui/material';
 import type { LucideIcon } from 'lucide-react';
 import { Disc3, DiscAlbum, History } from 'lucide-react';
-import { usePathname } from 'next/navigation';
 import type { FocusEvent, KeyboardEvent } from 'react';
 import { useEffect, useId, useRef } from 'react';
-import { isMusicDestinationPath, MUSIC_DESTINATIONS } from './musicHeaderDestinations';
+import { MUSIC_DESTINATIONS } from './musicHeaderDestinations';
 
 const MUSIC_LABEL = 'Music';
 
@@ -68,35 +66,6 @@ const destinationLinkSx: SxObject = {
   width: '100%',
 };
 
-/** Only navigations move a heading, so only they need the trigger named. */
-const PAGE_NAVIGATION_CAPTURE = `html:active-view-transition-type(${[
-  ...pageTransitionTypes('open'),
-  ...pageTransitionTypes('close'),
-].join(', ')}) &`;
-
-/**
- * Lends the trigger's box to a music page's heading, but only while a
- * navigation is being photographed.
- *
- * Held persistently, the name also lifts the trigger out of every *same-page*
- * transition on a music route — and `page-title-slot` snapshots are deliberately
- * blanked, since the slot a heading flew out of is a hole rather than a second
- * copy of it. That blanked the disc for the whole flight every time an album
- * well opened or closed on the favorite albums page. Unnamed between
- * navigations, the trigger stays inside the `site-header` snapshot instead,
- * which paints once at full opacity and never animates.
- *
- * The selector leads with `html` rather than `:root`, which Emotion would read
- * as a pseudo-class on this element and never match.
- */
-function pageTitleMorphSx(destinationIsOpen: boolean): SxObject {
-  return {
-    [PAGE_NAVIGATION_CAPTURE]: {
-      viewTransitionName: pageTitleMorphName(destinationIsOpen),
-    },
-  };
-}
-
 type MusicHeaderMenuProps = {
   isOpen: boolean;
   onOpenChange: (isOpen: boolean) => void;
@@ -104,16 +73,17 @@ type MusicHeaderMenuProps = {
 
 /**
  * Header vinyl control: opens a shared glass disclosure of music destinations.
- * The trigger alone owns the page-title view-transition name so menu item links
- * never collide.
+ *
+ * The trigger must stay unnamed. Sharing `page-title` with the destination
+ * heading pairs a 48px disc in the northeast header with a full-width h1 —
+ * a ~1000px, 23× FLIP that is the title flying in from the corner. Sibling
+ * music headings still share `page-title` so that morph stays local.
  */
 export function MusicHeaderMenu({ isOpen, onOpenChange }: MusicHeaderMenuProps) {
   const menuId = useId();
   const rootRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
-  const pathname = usePathname();
-  const destinationIsOpen = isMusicDestinationPath(pathname);
 
   useEffect(() => {
     if (!isOpen) {
@@ -196,7 +166,7 @@ export function MusicHeaderMenu({ isOpen, onOpenChange }: MusicHeaderMenuProps) 
           aria-label={MUSIC_LABEL}
           onClick={() => onOpenChange(!isOpen)}
           ref={triggerRef}
-          sx={{ ...triggerSx, ...pageTitleMorphSx(destinationIsOpen) }}
+          sx={triggerSx}
         >
           <Disc3 size={DISCLOSURE_ICON_SIZE} />
         </IconButton>

--- a/apps/web/src/app/layouts/PageTitle.tsx
+++ b/apps/web/src/app/layouts/PageTitle.tsx
@@ -12,8 +12,9 @@ type PageTitleProps = {
 };
 
 /**
- * Page heading that participates in the vinyl → title morph on music
- * destinations. Carries the shared `page-title` view-transition name.
+ * Page heading shared across music destinations. `page-title` pairs sibling
+ * headings so they morph in place. It is not paired with the header disc —
+ * that FLIP is a thousand-pixel scale from a 48px icon.
  */
 export function PageTitle({ children }: PageTitleProps) {
   return (

--- a/apps/web/src/app/layouts/PageViewTransition.tsx
+++ b/apps/web/src/app/layouts/PageViewTransition.tsx
@@ -5,6 +5,7 @@ import { pageViewTransitionProps } from '@dg/ui/core/transitions/pageTransitions
 import { usePathname } from 'next/navigation';
 import type { ReactNode } from 'react';
 import { useLayoutEffect, ViewTransition } from 'react';
+import { markClientHydrated } from './clientHydrated';
 
 /**
  * Gives each route its own view transition boundary. Keying by pathname is
@@ -18,6 +19,7 @@ export function PageViewTransition({ children }: { children: ReactNode }) {
   // Scroll has to land before the browser photographs the new page, so this
   // is a layout effect rather than an effect.
   useLayoutEffect(() => {
+    markClientHydrated();
     const scrollY = takePageOrigin(pathname);
     if (scrollY !== null) {
       window.scrollTo({ behavior: 'instant', top: scrollY });

--- a/apps/web/src/app/layouts/__tests__/MusicHeaderMenu.test.tsx
+++ b/apps/web/src/app/layouts/__tests__/MusicHeaderMenu.test.tsx
@@ -3,39 +3,21 @@
  */
 
 import { favoriteAlbumsRoute, musicRoute } from '@dg/shared-core/routes/app';
-import {
-  PAGE_TITLE_SLOT_VIEW_TRANSITION_NAME,
-  PAGE_TITLE_VIEW_TRANSITION_NAME,
-} from '@dg/ui/core/transitions/pageTransitions';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useState } from 'react';
-
-jest.mock('next/navigation', () => ({
-  usePathname: jest.fn(() => '/'),
-}));
 
 jest.mock('@dg/ui/core/transitions/pageScrollMemory', () => ({
   rememberPageOrigin: jest.fn(),
 }));
 
-import { usePathname } from 'next/navigation';
 import { MusicHeaderMenu } from '../MusicHeaderMenu';
 
-const mockUsePathname = usePathname as jest.MockedFunction<typeof usePathname>;
-
-/**
- * The trigger's name is scoped to a navigation capture rather than set on the
- * element, so it is absent at rest and only visible in the emitted rule.
- */
+/** Any view-transition-name emitted for this element's generated class. */
 function capturedTitleName(element: HTMLElement): string | undefined {
   const matched = [...document.querySelectorAll('style')]
     .flatMap((style) => [...(style.sheet?.cssRules ?? [])].map((rule) => rule.cssText))
-    .filter(
-      (rule) =>
-        rule.includes('active-view-transition-type') &&
-        [...element.classList].some((className) => rule.includes(`.${className}`)),
-    )
+    .filter((rule) => [...element.classList].some((className) => rule.includes(`.${className}`)))
     .map((rule) => rule.match(/view-transition-name:\s*([\w-]+)/)?.at(1))
     .filter((name): name is string => Boolean(name));
   return [...new Set(matched)].at(0);
@@ -47,11 +29,6 @@ function TestMusicHeaderMenu() {
 }
 
 describe('MusicHeaderMenu', () => {
-  afterEach(() => {
-    jest.clearAllMocks();
-    mockUsePathname.mockReturnValue('/');
-  });
-
   it('opens a shared glass menu with both music destinations in order', async () => {
     const user = userEvent.setup();
     render(<TestMusicHeaderMenu />);
@@ -73,18 +50,17 @@ describe('MusicHeaderMenu', () => {
   });
 
   /**
-   * A name held at rest also lifts the trigger out of same-page transitions,
-   * whose `page-title-slot` snapshots are blanked — that made the disc vanish
-   * for the length of every album well open and close.
+   * Pairing the disc with `page-title` makes the heading FLIP in from a 48px
+   * icon in the northeast header (~1000px, 23×). Leave it unnamed so it stays
+   * inside `site-header` and the heading appears in place.
    */
-  it('names the trigger only for a navigation capture, never at rest', async () => {
+  it('does not name the trigger or menu links for a title morph', async () => {
     const user = userEvent.setup();
-    mockUsePathname.mockReturnValue('/');
     render(<TestMusicHeaderMenu />);
 
     const trigger = screen.getByRole('button', { name: 'Music' });
     expect(trigger.style.viewTransitionName).toBe('');
-    expect(capturedTitleName(trigger)).toBe(PAGE_TITLE_VIEW_TRANSITION_NAME);
+    expect(capturedTitleName(trigger)).toBeUndefined();
 
     await user.click(trigger);
     const menuLinks = screen.getAllByRole('menuitem');
@@ -106,18 +82,5 @@ describe('MusicHeaderMenu', () => {
     await user.keyboard('{Escape}');
     expect(trigger).toHaveAttribute('aria-expanded', 'false');
     expect(trigger).toHaveFocus();
-  });
-
-  it('switches the trigger to the slot name on either music destination', () => {
-    mockUsePathname.mockReturnValue(musicRoute);
-    const { rerender } = render(<TestMusicHeaderMenu />);
-
-    for (const path of [musicRoute, favoriteAlbumsRoute, `${favoriteAlbumsRoute}/album123`]) {
-      mockUsePathname.mockReturnValue(path);
-      rerender(<TestMusicHeaderMenu />);
-      const trigger = screen.getByRole('button', { name: 'Music' });
-      expect(trigger.style.viewTransitionName).toBe('');
-      expect(capturedTitleName(trigger)).toBe(PAGE_TITLE_SLOT_VIEW_TRANSITION_NAME);
-    }
   });
 });

--- a/apps/web/src/app/layouts/clientHydrated.ts
+++ b/apps/web/src/app/layouts/clientHydrated.ts
@@ -1,0 +1,19 @@
+'use client';
+
+/**
+ * Flip after the first client commit so later Client Component mounts know
+ * they are navigations, not the hydration that has to match SSR HTML.
+ */
+let clientHydrated = false;
+
+export function hasClientHydrated() {
+  return clientHydrated;
+}
+
+export function markClientHydrated() {
+  clientHydrated = true;
+}
+
+export function resetClientHydrated() {
+  clientHydrated = false;
+}

--- a/apps/web/src/app/music/albums/AlbumWell.tsx
+++ b/apps/web/src/app/music/albums/AlbumWell.tsx
@@ -252,7 +252,11 @@ export function AlbumWell({ album, children }: Props) {
             sx={artLinkSx}
             title={`Open ${album.name} on Spotify`}
           >
-            <ViewTransition name={albumArtViewTransitionName(album.id)} share="vt-album-art">
+            <ViewTransition
+              default="none"
+              name={albumArtViewTransitionName(album.id)}
+              share="vt-album-art"
+            >
               <Box sx={artCardSx}>
                 <Image
                   alt={album.name}

--- a/apps/web/src/app/music/albums/FavoriteAlbumCell.tsx
+++ b/apps/web/src/app/music/albums/FavoriteAlbumCell.tsx
@@ -119,7 +119,16 @@ export function FavoriteAlbumCell({
         transitionTypes={albumTransitionTypes('open')}
       >
         <AlbumStack imageUrl={imageUrl} sleeveCount={SLEEVE_COUNT}>
-          <ViewTransition name={albumArtViewTransitionName(albumId)} share="vt-album-art">
+          {/*
+           * `default="none"` keeps this name off page-open/close. Without it
+           * every cover enters during homepage → albums, and React snapshots
+           * the whole grid as separate shared elements mid-flight.
+           */}
+          <ViewTransition
+            default="none"
+            name={albumArtViewTransitionName(albumId)}
+            share="vt-album-art"
+          >
             <AlbumCover alt={albumName} depth={0} imageUrl={imageUrl} sleeveCount={SLEEVE_COUNT} />
           </ViewTransition>
         </AlbumStack>

--- a/apps/web/src/app/music/albums/FavoriteAlbumsGrid.tsx
+++ b/apps/web/src/app/music/albums/FavoriteAlbumsGrid.tsx
@@ -8,12 +8,54 @@ import type { SxObject } from '@dg/ui/theme';
 import { Box, Stack } from '@mui/material';
 import { ArrowDownUp } from 'lucide-react';
 import type { ReactNode } from 'react';
-import { Fragment, useLayoutEffect, useRef, useState } from 'react';
+import { Fragment, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { hasClientHydrated } from '../../layouts/clientHydrated';
 import { ALBUM_GRID_COLUMNS, albumGridSx, albumTileSlotSx } from '../albumTileGeometry';
 import { AlbumDetailBodySkeleton } from './AlbumDetailBodySkeleton';
 import { AlbumWell } from './AlbumWell';
 import { FavoriteAlbumCell } from './FavoriteAlbumCell';
+import { FavoriteAlbumsSkeleton } from './FavoriteAlbumsSkeleton';
 import { useOptimisticAlbumSelection } from './useOptimisticAlbumSelection';
+
+/**
+ * SSR and the matching hydrate must paint the real grid. After the app has
+ * committed once, a new mount is a client navigation: photograph the
+ * skeleton instead. `:active-view-transition` is not set yet inside React's
+ * startViewTransition update, so we cannot key off that.
+ */
+function paintAlbumsOnFirstPass() {
+  return !hasClientHydrated();
+}
+
+function viewTransitionPseudoElement(effect: AnimationEffect | null) {
+  if (!effect || !('pseudoElement' in effect)) {
+    return null;
+  }
+  const pseudo = effect.pseudoElement;
+  return typeof pseudo === 'string' ? pseudo : null;
+}
+
+function waitForViewTransitionAnimations() {
+  const listed = typeof document.getAnimations === 'function' ? document.getAnimations() : [];
+  const animations = listed.filter((animation) =>
+    Boolean(viewTransitionPseudoElement(animation.effect)?.startsWith('::view-transition')),
+  );
+  if (animations.length === 0) {
+    return Promise.resolve();
+  }
+  return Promise.all(animations.map((animation) => animation.finished.catch(() => undefined)));
+}
+
+function afterNextPaint() {
+  if (typeof requestAnimationFrame !== 'function') {
+    return Promise.resolve();
+  }
+  return new Promise<void>((resolve) => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => resolve());
+    });
+  });
+}
 
 const SORT_OPTIONS = [
   { key: 'added', label: 'Recently added' },
@@ -78,6 +120,24 @@ type Props = {
  * opens on the click instead of on the payload that click goes and fetches.
  */
 export function FavoriteAlbumsGrid({ albums, children }: Props) {
+  // Client navigations photograph a height-matched reserve instead of ~300
+  // next/image nodes. Reveal after the page-rise animations (plus a paint)
+  // so the grid commit cannot hitch the 300ms transition.
+  const [showGrid, setShowGrid] = useState(paintAlbumsOnFirstPass);
+  useEffect(() => {
+    let cancelled = false;
+    void waitForViewTransitionAnimations()
+      .then(afterNextPaint)
+      .then(() => {
+        if (!cancelled) {
+          setShowGrid(true);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   const { isAwaitingDetail, onAlbumNavigationCapture, selectedAlbumId } =
     useOptimisticAlbumSelection();
   const [sortKey, setSortKey] = useState<AlbumSortKey>('added');
@@ -119,6 +179,10 @@ export function FavoriteAlbumsGrid({ albums, children }: Props) {
       );
     }
   });
+
+  if (!showGrid) {
+    return <FavoriteAlbumsSkeleton reserveOnly tileCount={albums.length} />;
+  }
 
   const sortedAlbums = [...albums].sort(comparators[sortKey]);
   const selectedIndex = selectedAlbumId

--- a/apps/web/src/app/music/albums/FavoriteAlbumsSkeleton.tsx
+++ b/apps/web/src/app/music/albums/FavoriteAlbumsSkeleton.tsx
@@ -1,6 +1,11 @@
 import type { SxObject } from '@dg/ui/theme';
 import { Box, Skeleton, Stack } from '@mui/material';
-import { albumGridSx, albumTileFrameSx, albumTileSkeletonSx } from '../albumTileGeometry';
+import {
+  ALBUM_GRID_COLUMNS,
+  albumGridSx,
+  albumTileFrameSx,
+  albumTileSkeletonSx,
+} from '../albumTileGeometry';
 
 const sortSwitcherSx: SxObject = {
   borderRadius: 999,
@@ -9,18 +14,60 @@ const sortSwitcherSx: SxObject = {
   width: '100%',
 };
 
-const PLACEHOLDER_TILES = Array.from({ length: 12 }, (_, tile) => `album-${tile}`);
+const DEFAULT_PLACEHOLDER_COUNT = 12;
 
 /**
- * Occupies the same space the loaded grid will, so the sheet does not resize
- * under the view transition when albums stream in.
+ * One box the same height as `tileCount` square cells plus gaps, without
+ * mounting a node per tile. Used while a view transition photographs the page.
  */
-export function FavoriteAlbumsSkeleton() {
+function albumGridReserveSx(tileCount: number): SxObject {
+  const rows = (columns: number) => Math.ceil(tileCount / columns);
+  const reserve = (columns: number, gapSum: string) => {
+    const rowCount = rows(columns);
+    return `calc(${(rowCount / columns) * 100}% + ${gapSum})`;
+  };
+
+  return {
+    paddingBottom: (theme) => {
+      const gapSum = (columns: number) => theme.spacing(2 * Math.max(0, rows(columns) - 1));
+      return {
+        lg: reserve(ALBUM_GRID_COLUMNS.lg, gapSum(ALBUM_GRID_COLUMNS.lg)),
+        md: reserve(ALBUM_GRID_COLUMNS.md, gapSum(ALBUM_GRID_COLUMNS.md)),
+        sm: reserve(ALBUM_GRID_COLUMNS.sm, gapSum(ALBUM_GRID_COLUMNS.sm)),
+        xs: reserve(ALBUM_GRID_COLUMNS.xs, gapSum(ALBUM_GRID_COLUMNS.xs)),
+      };
+    },
+  };
+}
+
+/**
+ * Occupies the same space the loaded grid will, so the page does not resize
+ * under the view transition when albums stream in. Pass `tileCount` when the
+ * real length is already known so the opening snapshot matches the grid height.
+ * `reserveOnly` keeps that height without compositing a tile per album.
+ */
+export function FavoriteAlbumsSkeleton({
+  reserveOnly = false,
+  tileCount = DEFAULT_PLACEHOLDER_COUNT,
+}: {
+  reserveOnly?: boolean;
+  tileCount?: number;
+}) {
+  if (reserveOnly) {
+    return (
+      <Stack spacing={2}>
+        <Skeleton sx={sortSwitcherSx} variant="rectangular" />
+        <Box sx={albumGridReserveSx(tileCount)} />
+      </Stack>
+    );
+  }
+
+  const tiles = Array.from({ length: tileCount }, (_, tile) => `album-${tile}`);
   return (
     <Stack spacing={2}>
       <Skeleton sx={sortSwitcherSx} variant="rectangular" />
       <Box sx={albumGridSx}>
-        {PLACEHOLDER_TILES.map((tile) => (
+        {tiles.map((tile) => (
           <Box key={tile} sx={albumTileFrameSx}>
             <Skeleton sx={albumTileSkeletonSx} variant="rectangular" />
           </Box>

--- a/apps/web/src/app/music/albums/__tests__/FavoriteAlbumsGrid.test.tsx
+++ b/apps/web/src/app/music/albums/__tests__/FavoriteAlbumsGrid.test.tsx
@@ -2,6 +2,7 @@ import type { PlaylistAlbum } from '@dg/content-models/spotify/PlaylistAlbums';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useRouter, useSearchParams } from 'next/navigation';
+import { markClientHydrated, resetClientHydrated } from '../../../layouts/clientHydrated';
 import { FavoriteAlbumsGrid } from '../FavoriteAlbumsGrid';
 
 jest.mock('next/navigation', () => ({
@@ -87,7 +88,54 @@ const layOutBySiblingOrder = () => {
 describe('FavoriteAlbumsGrid', () => {
   afterEach(() => {
     jest.restoreAllMocks();
+    resetClientHydrated();
+    Reflect.deleteProperty(document, 'getAnimations');
     Reflect.deleteProperty(Element.prototype, 'animate');
+  });
+
+  it('holds the height-matched skeleton while a view transition is running', () => {
+    markClientHydrated();
+    Object.defineProperty(document, 'getAnimations', {
+      configurable: true,
+      value: () => [
+        {
+          effect: { pseudoElement: '::view-transition-new(root)' },
+          finished: new Promise<void>(() => {
+            /* stay pending for this render */
+          }),
+        },
+      ],
+    });
+
+    render(<FavoriteAlbumsGrid albums={albums} />);
+
+    expect(screen.queryByRole('link', { name: 'Zebra' })).not.toBeInTheDocument();
+    expect(document.querySelectorAll('.MuiSkeleton-root').length).toBe(1);
+  });
+
+  it('reveals albums after view-transition animations finish', async () => {
+    markClientHydrated();
+    let resolveFinished = () => {};
+    const finished = new Promise<void>((resolve) => {
+      resolveFinished = resolve;
+    });
+    Object.defineProperty(document, 'getAnimations', {
+      configurable: true,
+      value: () => [
+        {
+          effect: { pseudoElement: '::view-transition-new(root)' },
+          finished,
+        },
+      ],
+    });
+
+    render(<FavoriteAlbumsGrid albums={albums} />);
+    expect(screen.queryByRole('link', { name: 'Zebra' })).not.toBeInTheDocument();
+
+    resolveFinished();
+    await waitFor(() => {
+      expect(screen.getByRole('link', { name: 'Zebra' })).toBeInTheDocument();
+    });
   });
 
   it('renders linked, sleeved albums newest first', () => {

--- a/package.json
+++ b/package.json
@@ -27,5 +27,5 @@
     "clean": "rm -f .env .env.tmp",
     "preinstall": "npx only-allow pnpm"
   },
-  "version": "2.68.7"
+  "version": "2.68.8"
 }

--- a/packages/ui/core/transitions/pageTransitions.ts
+++ b/packages/ui/core/transitions/pageTransitions.ts
@@ -90,10 +90,13 @@ export function pinnedChromeSx(name: string): SxObject {
 }
 
 /**
- * Shared between a destination page's heading and the one control allowed to
- * morph into it, so the browser interpolates a single element instead of
- * cross-fading two unrelated snapshots. Exactly one element may carry it at any
- * capture; a duplicate aborts the transition outright.
+ * Shared between music destination headings so "Listening history" and
+ * "Favorite albums" morph in place. Do not put this on the header disc: that
+ * pairs a 48px icon in the northeast chrome with a full-width h1 and the
+ * browser FLIPs the type ~1000px at 23× scale.
+ *
+ * Exactly one element may carry it at any capture; a duplicate aborts the
+ * transition outright.
  */
 export const PAGE_TITLE_VIEW_TRANSITION_NAME = 'page-title';
 


### PR DESCRIPTION
# What changed?

- Stop pairing the header vinyl disc with `page-title`. Homepage → `/music` / `/music/albums` was FLIPing a 48px northeast icon into the full-width heading (~1000px, 23×), which is the title flying in from the corner and the main-thread hitch that followed.
- Sibling music headings still share `page-title`, so `/music` ↔ `/music/albums` keeps the local morph.
- Album-art `ViewTransition`s now use `default="none"` so page-open does not treat every cover as an enter. Album open/close query-routes are unchanged.

# Release info

- [ ] Major
- [ ] Minor
- [x] Patch

Made with [Cursor](https://cursor.com)