### PR TITLE
Crossfade now-playing card colors between tracks

### DIFF
--- a/apps/web/src/app/spotify/AlbumGradientBackdrop.tsx
+++ b/apps/web/src/app/spotify/AlbumGradientBackdrop.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { EASING_DEFAULT, TIMING_SLOW } from '@dg/ui/helpers/timing';
+import type { SxObject } from '@dg/ui/theme';
+import { Box } from '@mui/material';
+import { useState } from 'react';
+
+/** How long a new album's colors take to dissolve over the outgoing ones. */
+export const GRADIENT_CROSSFADE_MS = TIMING_SLOW;
+
+const containerBaseSx: SxObject = {
+  '@keyframes albumGradientFadeIn': {
+    from: { opacity: 0 },
+    to: { opacity: 1 },
+  },
+  pointerEvents: 'none',
+  position: 'absolute',
+};
+
+const layerSx: SxObject = {
+  animation: `albumGradientFadeIn ${GRADIENT_CROSSFADE_MS}ms ${EASING_DEFAULT}`,
+  borderRadius: 'inherit',
+  inset: 0,
+  position: 'absolute',
+};
+
+type GradientLayer = {
+  gradient: string;
+  id: number;
+};
+
+type AlbumGradientBackdropProps = {
+  /** Album gradient to show. Undefined until the art's colors are extracted. */
+  gradient?: string;
+
+  /** Placement of the whole backdrop: inset, radius, blur, stacking. */
+  containerSx: SxObject;
+};
+
+/**
+ * Paints the album gradient behind the now-playing card and dissolves between
+ * tracks. Gradient stacks can't be interpolated by the browser, so each new
+ * gradient fades in on its own layer above the one it replaces, and spent
+ * layers are dropped once the incoming one is fully opaque. Under
+ * `prefers-reduced-motion` the theme collapses the animation to ~0ms, so the
+ * swap is instant and the layer bookkeeping still resolves the same way.
+ */
+export function AlbumGradientBackdrop({ gradient, containerSx }: AlbumGradientBackdropProps) {
+  const [layers, setLayers] = useState<Array<GradientLayer>>([]);
+  const newest = layers.at(-1);
+
+  if (newest?.gradient !== gradient) {
+    setLayers(gradient ? [...layers, { gradient, id: (newest?.id ?? -1) + 1 }] : []);
+  }
+
+  /** Only the topmost layer is opaque enough to hide the ones beneath it. */
+  const dropSpentLayers = (finishedId: number) => {
+    setLayers((current) => (current.at(-1)?.id === finishedId ? current.slice(-1) : current));
+  };
+
+  return (
+    <Box aria-hidden="true" sx={{ ...containerBaseSx, ...containerSx }}>
+      {layers.map((layer) => (
+        <Box
+          data-gradient-layer
+          key={layer.id}
+          onAnimationEnd={() => dropSpentLayers(layer.id)}
+          sx={{ ...layerSx, backgroundImage: layer.gradient }}
+        />
+      ))}
+    </Box>
+  );
+}

--- a/apps/web/src/app/spotify/SpotifyCardWithGradient.tsx
+++ b/apps/web/src/app/spotify/SpotifyCardWithGradient.tsx
@@ -2,15 +2,27 @@
 
 import type { Track } from '@dg/content-models/spotify/Track';
 import { ContentCard } from '@dg/ui/dependent/ContentCard';
+import { EASING_DEFAULT } from '@dg/ui/helpers/timing';
 import type { SxObject } from '@dg/ui/theme';
 import { Box } from '@mui/material';
-import { type ReactNode, useEffect, useState } from 'react';
-import { extractAlbumGradientFromUrl } from './extractAlbumGradient';
+import { type ReactNode, type RefObject, useEffect, useRef, useState } from 'react';
+import { AlbumGradientBackdrop, GRADIENT_CROSSFADE_MS } from './AlbumGradientBackdrop';
+import { type AlbumGradientInformation, extractAlbumGradientFromUrl } from './extractAlbumGradient';
 import { SpotifyCardScrollTracker } from './SpotifyCardScrollTracker';
 import { TrackListing } from './TrackListing';
 
+/**
+ * Longest the outgoing track stays up while the next album's colors extract.
+ * Covers a cold image fetch without stranding stale playback info on screen.
+ */
+const COLOR_HANDOFF_TIMEOUT_MS = 1500;
+
+/** Art and text land at this opacity and settle up as the color dissolves. */
+const CONTENT_SETTLE_START_OPACITY = 0.4;
+
 type SpotifyCardShellProps = {
   children: ReactNode;
+  contentRef: RefObject<HTMLDivElement | null>;
   gradient?: string;
 };
 
@@ -23,16 +35,23 @@ const shellContainerSx: SxObject = {
   position: 'relative',
 };
 
-const getGradientGlowSx = (gradient: string): SxObject => ({
-  backgroundImage: gradient,
+const gradientGlowSx: SxObject = {
   borderRadius: 6,
   filter: 'blur(16px)',
   inset: -2,
   opacity: 0.5,
-  pointerEvents: 'none',
-  position: 'absolute',
   zIndex: 0,
-});
+};
+
+/**
+ * Sits behind the card's contents but above its paper background, inset by the
+ * hairline border so the gradient still reaches the card's edges.
+ */
+const gradientSurfaceSx: SxObject = {
+  borderRadius: 'inherit',
+  inset: '-1px',
+  zIndex: -1,
+};
 
 const cardSx: SxObject = {
   display: 'flex',
@@ -44,18 +63,52 @@ const cardSx: SxObject = {
   zIndex: 1,
 };
 
-const getCardSx = (gradient?: string): SxObject => ({
-  ...(gradient ? { backgroundImage: gradient } : {}),
-  ...cardSx,
-});
+/** Transparent to layout — exists only so the content can be animated as a unit. */
+const cardContentSx: SxObject = {
+  display: 'flex',
+  flex: 1,
+  minWidth: 0,
+};
 
-function SpotifyCardShell({ children, gradient }: SpotifyCardShellProps) {
+function SpotifyCardShell({ children, contentRef, gradient }: SpotifyCardShellProps) {
   return (
     <Box sx={shellContainerSx}>
-      {gradient ? <Box aria-hidden="true" sx={getGradientGlowSx(gradient)} /> : null}
-      <ContentCard sx={getCardSx(gradient)}>{children}</ContentCard>
+      <AlbumGradientBackdrop containerSx={gradientGlowSx} gradient={gradient} />
+      <ContentCard sx={cardSx}>
+        <AlbumGradientBackdrop containerSx={gradientSurfaceSx} gradient={gradient} />
+        <Box ref={contentRef} sx={cardContentSx}>
+          {children}
+        </Box>
+      </ContentCard>
     </Box>
   );
+}
+
+/**
+ * Settles art and text in alongside the color instead of cutting them. Animated
+ * imperatively so the album art element survives the swap — remounting it to
+ * key an animation would blank the cover while the new file decodes. Honors
+ * reduced motion by leaving the swap instant.
+ */
+function useContentSettle(trackId: string) {
+  const contentRef = useRef<HTMLDivElement>(null);
+  const settledTrackId = useRef(trackId);
+
+  useEffect(() => {
+    if (settledTrackId.current === trackId) {
+      return;
+    }
+    settledTrackId.current = trackId;
+    if (window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) {
+      return;
+    }
+    contentRef.current?.animate([{ opacity: CONTENT_SETTLE_START_OPACITY }, { opacity: 1 }], {
+      duration: GRADIENT_CROSSFADE_MS,
+      easing: EASING_DEFAULT,
+    });
+  }, [trackId]);
+
+  return contentRef;
 }
 
 type SpotifyCardWithGradientProps = {
@@ -68,28 +121,38 @@ type SpotifyCardWithGradientProps = {
  */
 export function SpotifyCardWithGradient({ track }: SpotifyCardWithGradientProps) {
   const [displayTrack, setDisplayTrack] = useState(track);
+  const contentRef = useContentSettle(displayTrack.id);
 
   useEffect(() => {
-    setDisplayTrack(track);
     let cancelled = false;
-    extractAlbumGradientFromUrl(track.albumImage.url).then((info) => {
+    // Keep the outgoing track up until the next album's colors are ready, then
+    // swap art, text, and gradient together. Showing the new track the moment
+    // it arrives paints a gradient-less card until extraction finishes, which
+    // is the flash. The gradient itself dissolves in AlbumGradientBackdrop.
+    const showTrack = (info?: AlbumGradientInformation) => {
       if (cancelled) {
         return;
       }
       setDisplayTrack({
         ...track,
-        albumGradient: info.backgroundGradient ?? undefined,
-        albumGradientContrastSetting: info.contrastSetting ?? undefined,
+        albumGradient: info?.backgroundGradient ?? undefined,
+        albumGradientContrastSetting: info?.contrastSetting ?? undefined,
       });
+    };
+    const timeoutId = window.setTimeout(showTrack, COLOR_HANDOFF_TIMEOUT_MS);
+    extractAlbumGradientFromUrl(track.albumImage.url).then((info) => {
+      window.clearTimeout(timeoutId);
+      showTrack(info);
     });
     return () => {
       cancelled = true;
+      window.clearTimeout(timeoutId);
     };
   }, [track]);
 
   return (
     <SpotifyCardScrollTracker>
-      <SpotifyCardShell gradient={displayTrack.albumGradient}>
+      <SpotifyCardShell contentRef={contentRef} gradient={displayTrack.albumGradient}>
         <TrackListing track={displayTrack} />
       </SpotifyCardShell>
     </SpotifyCardScrollTracker>

--- a/apps/web/src/app/spotify/SpotifyCardWithGradient.tsx
+++ b/apps/web/src/app/spotify/SpotifyCardWithGradient.tsx
@@ -2,27 +2,16 @@
 
 import type { Track } from '@dg/content-models/spotify/Track';
 import { ContentCard } from '@dg/ui/dependent/ContentCard';
-import { EASING_DEFAULT } from '@dg/ui/helpers/timing';
 import type { SxObject } from '@dg/ui/theme';
 import { Box } from '@mui/material';
-import { type ReactNode, type RefObject, useEffect, useRef, useState } from 'react';
-import { AlbumGradientBackdrop, GRADIENT_CROSSFADE_MS } from './AlbumGradientBackdrop';
+import { type ReactNode, useEffect, useState } from 'react';
+import { AlbumGradientBackdrop } from './AlbumGradientBackdrop';
 import { type AlbumGradientInformation, extractAlbumGradientFromUrl } from './extractAlbumGradient';
 import { SpotifyCardScrollTracker } from './SpotifyCardScrollTracker';
 import { TrackListing } from './TrackListing';
 
-/**
- * Longest the outgoing track stays up while the next album's colors extract.
- * Covers a cold image fetch without stranding stale playback info on screen.
- */
-const COLOR_HANDOFF_TIMEOUT_MS = 1500;
-
-/** Art and text land at this opacity and settle up as the color dissolves. */
-const CONTENT_SETTLE_START_OPACITY = 0.4;
-
 type SpotifyCardShellProps = {
   children: ReactNode;
-  contentRef: RefObject<HTMLDivElement | null>;
   gradient?: string;
 };
 
@@ -63,52 +52,16 @@ const cardSx: SxObject = {
   zIndex: 1,
 };
 
-/** Transparent to layout — exists only so the content can be animated as a unit. */
-const cardContentSx: SxObject = {
-  display: 'flex',
-  flex: 1,
-  minWidth: 0,
-};
-
-function SpotifyCardShell({ children, contentRef, gradient }: SpotifyCardShellProps) {
+function SpotifyCardShell({ children, gradient }: SpotifyCardShellProps) {
   return (
     <Box sx={shellContainerSx}>
       <AlbumGradientBackdrop containerSx={gradientGlowSx} gradient={gradient} />
       <ContentCard sx={cardSx}>
         <AlbumGradientBackdrop containerSx={gradientSurfaceSx} gradient={gradient} />
-        <Box ref={contentRef} sx={cardContentSx}>
-          {children}
-        </Box>
+        {children}
       </ContentCard>
     </Box>
   );
-}
-
-/**
- * Settles art and text in alongside the color instead of cutting them. Animated
- * imperatively so the album art element survives the swap — remounting it to
- * key an animation would blank the cover while the new file decodes. Honors
- * reduced motion by leaving the swap instant.
- */
-function useContentSettle(trackId: string) {
-  const contentRef = useRef<HTMLDivElement>(null);
-  const settledTrackId = useRef(trackId);
-
-  useEffect(() => {
-    if (settledTrackId.current === trackId) {
-      return;
-    }
-    settledTrackId.current = trackId;
-    if (window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) {
-      return;
-    }
-    contentRef.current?.animate([{ opacity: CONTENT_SETTLE_START_OPACITY }, { opacity: 1 }], {
-      duration: GRADIENT_CROSSFADE_MS,
-      easing: EASING_DEFAULT,
-    });
-  }, [trackId]);
-
-  return contentRef;
 }
 
 type SpotifyCardWithGradientProps = {
@@ -120,40 +73,34 @@ type SpotifyCardWithGradientProps = {
  * Keeps sharp (and its native libvips) out of the homepage server module graph.
  */
 export function SpotifyCardWithGradient({ track }: SpotifyCardWithGradientProps) {
-  const [displayTrack, setDisplayTrack] = useState(track);
-  const contentRef = useContentSettle(displayTrack.id);
+  const [gradientInformation, setGradientInformation] = useState<AlbumGradientInformation>({
+    backgroundGradient: track.albumGradient ?? null,
+    contrastSetting: track.albumGradientContrastSetting ?? null,
+  });
 
   useEffect(() => {
     let cancelled = false;
-    // Keep the outgoing track up until the next album's colors are ready, then
-    // swap art, text, and gradient together. Showing the new track the moment
-    // it arrives paints a gradient-less card until extraction finishes, which
-    // is the flash. The gradient itself dissolves in AlbumGradientBackdrop.
-    const showTrack = (info?: AlbumGradientInformation) => {
+    extractAlbumGradientFromUrl(track.albumImage.url).then((info) => {
       if (cancelled) {
         return;
       }
-      setDisplayTrack({
-        ...track,
-        albumGradient: info?.backgroundGradient ?? undefined,
-        albumGradientContrastSetting: info?.contrastSetting ?? undefined,
-      });
-    };
-    const timeoutId = window.setTimeout(showTrack, COLOR_HANDOFF_TIMEOUT_MS);
-    extractAlbumGradientFromUrl(track.albumImage.url).then((info) => {
-      window.clearTimeout(timeoutId);
-      showTrack(info);
+      setGradientInformation(info);
     });
     return () => {
       cancelled = true;
-      window.clearTimeout(timeoutId);
     };
-  }, [track]);
+  }, [track.albumImage.url]);
+
+  const trackWithCurrentGradient: Track = {
+    ...track,
+    albumGradient: gradientInformation.backgroundGradient ?? undefined,
+    albumGradientContrastSetting: gradientInformation.contrastSetting ?? undefined,
+  };
 
   return (
     <SpotifyCardScrollTracker>
-      <SpotifyCardShell contentRef={contentRef} gradient={displayTrack.albumGradient}>
-        <TrackListing track={displayTrack} />
+      <SpotifyCardShell gradient={trackWithCurrentGradient.albumGradient}>
+        <TrackListing track={trackWithCurrentGradient} />
       </SpotifyCardShell>
     </SpotifyCardScrollTracker>
   );

--- a/apps/web/src/app/spotify/__tests__/AlbumGradientBackdrop.test.tsx
+++ b/apps/web/src/app/spotify/__tests__/AlbumGradientBackdrop.test.tsx
@@ -1,0 +1,81 @@
+import { fireEvent, render } from '@testing-library/react';
+import { AlbumGradientBackdrop } from '../AlbumGradientBackdrop';
+
+const BLUE =
+  'radial-gradient(circle at top right, hsla(210.0, 40.0%, 35.0%, 0.85) 0%, transparent)';
+const ORANGE =
+  'radial-gradient(circle at top right, hsla(20.0, 80.0%, 45.0%, 0.85) 0%, transparent)';
+
+const layersIn = (container: HTMLElement) => [
+  ...container.querySelectorAll('[data-gradient-layer]'),
+];
+
+describe('AlbumGradientBackdrop', () => {
+  it('paints nothing until a gradient is known', () => {
+    const { container } = render(<AlbumGradientBackdrop containerSx={{}} />);
+
+    expect(layersIn(container)).toHaveLength(0);
+  });
+
+  it('keeps the outgoing gradient painted while the new one fades in', () => {
+    const { container, rerender } = render(
+      <AlbumGradientBackdrop containerSx={{}} gradient={BLUE} />,
+    );
+    const outgoing = layersIn(container)[0];
+
+    rerender(<AlbumGradientBackdrop containerSx={{}} gradient={ORANGE} />);
+
+    const layers = layersIn(container);
+    expect(layers).toHaveLength(2);
+    expect(layers[0]).toBe(outgoing);
+  });
+
+  it('drops the spent layer once the incoming one is fully opaque', () => {
+    const { container, rerender } = render(
+      <AlbumGradientBackdrop containerSx={{}} gradient={BLUE} />,
+    );
+    rerender(<AlbumGradientBackdrop containerSx={{}} gradient={ORANGE} />);
+    const incoming = layersIn(container)[1];
+
+    if (incoming) {
+      fireEvent.animationEnd(incoming);
+    }
+
+    expect(layersIn(container)).toEqual([incoming]);
+  });
+
+  it('leaves the stack alone when an already-replaced layer finishes late', () => {
+    const { container, rerender } = render(
+      <AlbumGradientBackdrop containerSx={{}} gradient={BLUE} />,
+    );
+    rerender(<AlbumGradientBackdrop containerSx={{}} gradient={ORANGE} />);
+    const outgoing = layersIn(container)[0];
+
+    if (outgoing) {
+      fireEvent.animationEnd(outgoing);
+    }
+
+    expect(layersIn(container)).toHaveLength(2);
+  });
+
+  it('reuses the same layer when the gradient is unchanged', () => {
+    const { container, rerender } = render(
+      <AlbumGradientBackdrop containerSx={{}} gradient={BLUE} />,
+    );
+    const original = layersIn(container)[0];
+
+    rerender(<AlbumGradientBackdrop containerSx={{}} gradient={BLUE} />);
+
+    expect(layersIn(container)).toEqual([original]);
+  });
+
+  it('clears every layer when the gradient goes away', () => {
+    const { container, rerender } = render(
+      <AlbumGradientBackdrop containerSx={{}} gradient={BLUE} />,
+    );
+
+    rerender(<AlbumGradientBackdrop containerSx={{}} />);
+
+    expect(layersIn(container)).toHaveLength(0);
+  });
+});

--- a/apps/web/src/app/spotify/__tests__/SpotifyCardWithGradient.test.tsx
+++ b/apps/web/src/app/spotify/__tests__/SpotifyCardWithGradient.test.tsx
@@ -1,0 +1,117 @@
+import type { Track } from '@dg/content-models/spotify/Track';
+import { act, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { extractAlbumGradientFromUrl } from '../extractAlbumGradient';
+import { SpotifyCardWithGradient } from '../SpotifyCardWithGradient';
+
+jest.mock('@dg/ui/dependent/ContentCard', () => ({
+  ContentCard: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+jest.mock('../AlbumGradientBackdrop', () => ({
+  AlbumGradientBackdrop: ({ gradient }: { gradient?: string }) => (
+    <div data-gradient={gradient} data-testid="gradient-backdrop" />
+  ),
+}));
+
+jest.mock('../SpotifyCardScrollTracker', () => ({
+  SpotifyCardScrollTracker: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+jest.mock('../TrackListing', () => ({
+  TrackListing: ({ track }: { track: Track }) => (
+    <div data-testid="track-listing">
+      <span>{track.name}</span>
+      <span>{track.artists[0]?.name}</span>
+      <span>{track.albumImage.url}</span>
+    </div>
+  ),
+}));
+
+jest.mock('../extractAlbumGradient', () => ({
+  extractAlbumGradientFromUrl: jest.fn(),
+}));
+
+const OLD_GRADIENT = 'radial-gradient(old-blue)';
+const NEW_GRADIENT = 'radial-gradient(new-orange)';
+
+const makeTrack = (id: string, gradient?: string): Track => {
+  const core = {
+    externalUrls: { spotify: `https://open.spotify.com/${id}` },
+    href: `https://api.spotify.com/${id}`,
+    id,
+    name: `Track ${id}`,
+    uri: `spotify:track:${id}`,
+  };
+  return {
+    ...core,
+    album: {
+      ...core,
+      images: [{ height: 640, url: `https://images.test/${id}.jpg`, width: 640 }],
+      name: `Album ${id}`,
+      releaseDate: '2026-01-01',
+    },
+    albumGradient: gradient,
+    albumGradientContrastSetting: gradient ? 'light' : undefined,
+    albumImage: { height: 640, url: `https://images.test/${id}.jpg`, width: 640 },
+    artists: [{ ...core, id: `artist-${id}`, name: `Artist ${id}` }],
+    isPlaying: true,
+  };
+};
+
+type GradientInformation = Awaited<ReturnType<typeof extractAlbumGradientFromUrl>>;
+
+const deferredGradient = () => {
+  let resolve!: (value: GradientInformation) => void;
+  const promise = new Promise<GradientInformation>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+};
+
+describe('SpotifyCardWithGradient', () => {
+  const mockExtractAlbumGradient = jest.mocked(extractAlbumGradientFromUrl);
+
+  beforeEach(() => {
+    mockExtractAlbumGradient.mockReset();
+  });
+
+  it('renders the next track before its colors are ready', () => {
+    mockExtractAlbumGradient.mockImplementation(() => deferredGradient().promise);
+    const { rerender } = render(<SpotifyCardWithGradient track={makeTrack('old', OLD_GRADIENT)} />);
+
+    rerender(<SpotifyCardWithGradient track={makeTrack('new')} />);
+
+    expect(screen.getByText('Track new')).toBeInTheDocument();
+    expect(screen.getByText('Artist new')).toBeInTheDocument();
+    expect(screen.getByText('https://images.test/new.jpg')).toBeInTheDocument();
+    expect(screen.queryByText('Track old')).not.toBeInTheDocument();
+  });
+
+  it('keeps the previous gradient until the next one resolves', async () => {
+    const oldExtraction = deferredGradient();
+    const newExtraction = deferredGradient();
+    mockExtractAlbumGradient
+      .mockReturnValueOnce(oldExtraction.promise)
+      .mockReturnValueOnce(newExtraction.promise);
+    const { rerender } = render(<SpotifyCardWithGradient track={makeTrack('old', OLD_GRADIENT)} />);
+
+    rerender(<SpotifyCardWithGradient track={makeTrack('new')} />);
+
+    for (const backdrop of screen.getAllByTestId('gradient-backdrop')) {
+      expect(backdrop).toHaveAttribute('data-gradient', OLD_GRADIENT);
+    }
+
+    await act(async () => {
+      newExtraction.resolve({
+        backgroundGradient: NEW_GRADIENT,
+        contrastSetting: 'dark',
+      });
+      await newExtraction.promise;
+    });
+
+    for (const backdrop of screen.getAllByTestId('gradient-backdrop')) {
+      expect(backdrop).toHaveAttribute('data-gradient', NEW_GRADIENT);
+    }
+  });
+});

--- a/package.json
+++ b/package.json
@@ -27,5 +27,5 @@
     "clean": "rm -f .env .env.tmp",
     "preinstall": "npx only-allow pnpm"
   },
-  "version": "2.68.9"
+  "version": "2.68.10"
 }


### PR DESCRIPTION
# What changed?

- Track details now render directly from the latest prop: title, artist, cover, and playback progress are never gated on album-color extraction.
- The extracted gradient is independent visual state. While the next cover's colors are pending, the outgoing gradient remains painted instead of dropping to bare paper.
- `AlbumGradientBackdrop` paints gradients on stacked layers because gradient stacks are not reliably interpolable. The incoming layer fades over the outgoing one, then removes spent layers on `animationend`; the surface and blurred glow dissolve together.
- The background keeps `TIMING_SLOW` with `EASING_DEFAULT`, a plain ease rather than a spring. Reduced-motion CSS collapses the animation to an effectively instant swap.
- Removed the 1.5s handoff timeout, deferred `displayTrack`, and WAAPI opacity settle. Only the background animates now.
- Added tests proving that next-track content renders while extraction is unresolved and that the previous gradient persists until the replacement resolves.

Browser verification used an intentional 900ms delay on the incoming album-art request. The new title committed 3.9ms after the track prop changed (worst of dark/light measurements), while the old gradient remained fully painted until the new one crossfaded in. Old main showed a bare card during the same delayed extraction window.

# Release info

- [ ] Major
- [ ] Minor
- [x] Patch

Made with [Cursor](https://cursor.com)