### PR TITLE
Make the header menus and tooltips work without scripting

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import '@dg/ui/theme/classNameSetupOnImport';
 import '@dg/ui/core/transitions/pageTransitions.css';
 
+import { JsOnlyStyle } from '@dg/ui/core/JsOnlyStyle';
 import { Section } from '@dg/ui/core/Section';
 import { ServerTimeProvider } from '@dg/ui/core/ServerTimeContext';
 import { StickyBarTopMask } from '@dg/ui/core/StickyFadeBar';
@@ -38,6 +39,7 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
     <html lang="en" style={SYSTEM_COLOR_SCHEME_STYLE} suppressHydrationWarning={true}>
       <head>
         <ColorSchemeScript />
+        <JsOnlyStyle />
       </head>
       <body>
         <AppRouterCacheProvider>

--- a/apps/web/src/app/layouts/MusicHeaderMenu.tsx
+++ b/apps/web/src/app/layouts/MusicHeaderMenu.tsx
@@ -4,6 +4,7 @@ import { favoriteAlbumsRoute, musicRoute } from '@dg/shared-core/routes/app';
 import {
   DISCLOSURE_ICON_SIZE,
   DISCLOSURE_ROW_HEIGHT,
+  disclosureHostProps,
   GlassDisclosurePanel,
   GlassDisclosureRow,
 } from '@dg/ui/core/GlassDisclosurePanel';
@@ -11,7 +12,7 @@ import { Tooltip } from '@dg/ui/core/Tooltip';
 import { PageTransitionLink } from '@dg/ui/core/transitions/PageTransitionLink';
 import { createBouncyTransition } from '@dg/ui/helpers/bouncyTransition';
 import type { SxObject } from '@dg/ui/theme';
-import { Box, IconButton } from '@mui/material';
+import { Box } from '@mui/material';
 import type { LucideIcon } from 'lucide-react';
 import { Disc3, DiscAlbum, History } from 'lucide-react';
 import type { FocusEvent, KeyboardEvent } from 'react';
@@ -39,10 +40,28 @@ const anchorSx: SxObject = {
   width: DISCLOSURE_ROW_HEIGHT,
 };
 
+/**
+ * Holds nothing but the trigger. The panel is a sibling rather than this
+ * element's content, so it is ours to animate — a `<details>` hides its own
+ * content outright, which would cut the open and close motion — and so it never
+ * ends up nested in the capsule's glass.
+ */
+const detailsSx: SxObject = {
+  display: 'block',
+};
+
+/**
+ * The `<summary>` is the trigger. It carries the disclosure state the platform
+ * tracks for us, which is the whole reason a keyboard and a screen reader still
+ * agree with the screen when there is no script to keep `aria-expanded` honest.
+ */
 const triggerSx: SxObject = {
   '& svg': {
     ...createBouncyTransition('scale'),
     display: 'block',
+  },
+  '&::-webkit-details-marker': {
+    display: 'none',
   },
   '&:hover': {
     color: 'var(--mui-palette-primary-light)',
@@ -51,12 +70,23 @@ const triggerSx: SxObject = {
     scale: 1.2,
   },
   alignItems: 'center',
+  borderRadius: '999px',
   color: 'var(--mui-palette-primary-main)',
+  cursor: 'pointer',
   display: 'flex',
   height: DISCLOSURE_ROW_HEIGHT,
   justifyContent: 'center',
-  padding: 0,
+  /* Both spellings: `list-style` covers the marker everywhere but WebKit. */
+  listStyle: 'none',
   width: DISCLOSURE_ROW_HEIGHT,
+};
+
+/** Fills the trigger so the whole 48px target reveals the hint, not just the glyph. */
+const tooltipAnchorSx: SxObject = {
+  alignItems: 'center',
+  height: '100%',
+  justifyContent: 'center',
+  width: '100%',
 };
 
 const destinationLinkSx: SxObject = {
@@ -74,6 +104,11 @@ type MusicHeaderMenuProps = {
 /**
  * Header vinyl control: opens a shared glass disclosure of music destinations.
  *
+ * The `<details>` element owns the open state, so the menu opens and its links
+ * work with scripting off. React follows that state rather than owning it, and
+ * only pushes back when the sibling theme disclosure takes over — which is what
+ * keeps the two mutually exclusive without either fighting the DOM.
+ *
  * The trigger must stay unnamed. Sharing `page-title` with the destination
  * heading pairs a 48px disc in the northeast header with a full-width h1 —
  * a ~1000px, 23× FLIP that is the title flying in from the corner. Sibling
@@ -82,8 +117,17 @@ type MusicHeaderMenuProps = {
 export function MusicHeaderMenu({ isOpen, onOpenChange }: MusicHeaderMenuProps) {
   const menuId = useId();
   const rootRef = useRef<HTMLDivElement>(null);
-  const triggerRef = useRef<HTMLButtonElement>(null);
+  const detailsRef = useRef<HTMLDetailsElement>(null);
+  const triggerRef = useRef<HTMLElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
+
+  // Mirror a caller-driven close onto the element that actually holds the state
+  useEffect(() => {
+    const details = detailsRef.current;
+    if (details && details.open !== isOpen) {
+      details.open = isOpen;
+    }
+  }, [isOpen]);
 
   useEffect(() => {
     if (!isOpen) {
@@ -157,21 +201,34 @@ export function MusicHeaderMenu({ isOpen, onOpenChange }: MusicHeaderMenuProps) 
   };
 
   return (
-    <Box onBlur={handleFocusOut} onKeyDown={handleRootKeyDown} ref={rootRef} sx={anchorSx}>
-      <Tooltip placement="bottom" title={MUSIC_LABEL}>
-        <IconButton
-          aria-controls={isOpen ? menuId : undefined}
-          aria-expanded={isOpen}
+    <Box
+      {...disclosureHostProps}
+      onBlur={handleFocusOut}
+      onKeyDown={handleRootKeyDown}
+      ref={rootRef}
+      sx={anchorSx}
+    >
+      <Box
+        component="details"
+        onToggle={() => onOpenChange(detailsRef.current?.open ?? false)}
+        ref={detailsRef}
+        sx={detailsSx}
+      >
+        <Box
+          aria-controls={menuId}
           aria-haspopup="menu"
           aria-label={MUSIC_LABEL}
-          onClick={() => onOpenChange(!isOpen)}
+          component="summary"
           ref={triggerRef}
           sx={triggerSx}
         >
-          <Disc3 size={DISCLOSURE_ICON_SIZE} />
-        </IconButton>
-      </Tooltip>
-      <GlassDisclosurePanel id={menuId} isOpen={isOpen} label={MUSIC_LABEL} role="menu">
+          {/* Named by the trigger's own label, so the hint is decoration only. */}
+          <Tooltip placement="bottom" sx={tooltipAnchorSx} title={MUSIC_LABEL}>
+            <Disc3 aria-hidden size={DISCLOSURE_ICON_SIZE} />
+          </Tooltip>
+        </Box>
+      </Box>
+      <GlassDisclosurePanel id={menuId} label={MUSIC_LABEL} role="menu">
         <Box onKeyDown={handleListKeyDown} ref={listRef} sx={{ display: 'contents' }}>
           {MUSIC_DESTINATIONS.map((destination) => {
             const Icon = DESTINATION_ICONS[destination.href] ?? Disc3;

--- a/apps/web/src/app/layouts/__tests__/HeaderControls.test.tsx
+++ b/apps/web/src/app/layouts/__tests__/HeaderControls.test.tsx
@@ -22,25 +22,40 @@ describe('HeaderControls', () => {
     document.documentElement.style.colorScheme = 'light dark';
   });
 
+  /**
+   * The two disclosures track their open state differently on purpose — the
+   * music menu delegates to `<details>` so it survives scripting being off,
+   * while the theme picker is script-only — so exclusivity is asserted against
+   * each one's own source of truth rather than a shared attribute.
+   */
   it('keeps the theme and music disclosures mutually exclusive', async () => {
     const user = userEvent.setup();
     render(<HeaderControls />);
 
     const theme = screen.getByRole('button', { name: 'Color scheme: system' });
-    const music = screen.getByRole('button', { name: 'Music' });
-    const sharedSurface = music.closest('[data-header-controls]');
+    const music = document.querySelector('details > summary');
+    const musicDisclosure = document.querySelector('details');
+    if (!(music instanceof HTMLElement) || !(musicDisclosure instanceof HTMLDetailsElement)) {
+      throw new Error('no <details> music menu rendered');
+    }
 
-    expect(sharedSurface).toBe(theme.closest('[data-header-controls]'));
+    expect(music.closest('[data-header-controls]')).toBe(theme.closest('[data-header-controls]'));
     expect(music.compareDocumentPosition(theme) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
 
     await user.click(theme);
     expect(theme).toHaveAttribute('aria-expanded', 'true');
-    expect(music).not.toHaveAttribute('aria-expanded', 'true');
+    expect(musicDisclosure.open).toBe(false);
 
     await user.click(music);
     await waitFor(() => {
       expect(theme).toHaveAttribute('aria-expanded', 'false');
-      expect(music).toHaveAttribute('aria-expanded', 'true');
+      expect(musicDisclosure.open).toBe(true);
+    });
+
+    await user.click(theme);
+    await waitFor(() => {
+      expect(theme).toHaveAttribute('aria-expanded', 'true');
+      expect(musicDisclosure.open).toBe(false);
     });
   });
 

--- a/apps/web/src/app/layouts/__tests__/MusicHeaderMenu.test.tsx
+++ b/apps/web/src/app/layouts/__tests__/MusicHeaderMenu.test.tsx
@@ -13,6 +13,36 @@ jest.mock('@dg/ui/core/transitions/pageScrollMemory', () => ({
 
 import { MusicHeaderMenu } from '../MusicHeaderMenu';
 
+/**
+ * The trigger is a `<summary>`, which `aria-query` has no role mapping for, so
+ * `getByRole` cannot reach it however it is spelled. Browsers do expose it — as
+ * a button carrying the parent's expanded state — so the element is the contract
+ * here and the role query is simply not available to assert it.
+ */
+function getTrigger(): HTMLElement {
+  const trigger = document.querySelector('details > summary');
+  if (!(trigger instanceof HTMLElement)) {
+    throw new Error('no <summary> trigger rendered');
+  }
+  return trigger;
+}
+
+function getDisclosure(): HTMLDetailsElement {
+  const details = document.querySelector('details');
+  if (!(details instanceof HTMLDetailsElement)) {
+    throw new Error('no <details> disclosure rendered');
+  }
+  return details;
+}
+
+/** Every emitted rule whose selector mentions the given text. */
+function rulesMatching(selectorText: string): Array<string> {
+  return [...document.querySelectorAll('style')]
+    .flatMap((style) => [...(style.sheet?.cssRules ?? [])])
+    .filter((rule) => rule.cssText.split('{').at(0)?.includes(selectorText))
+    .map((rule) => rule.cssText);
+}
+
 /** Any view-transition-name emitted for this element's generated class. */
 function capturedTitleName(element: HTMLElement): string | undefined {
   const matched = [...document.querySelectorAll('style')]
@@ -33,13 +63,18 @@ describe('MusicHeaderMenu', () => {
     const user = userEvent.setup();
     render(<TestMusicHeaderMenu />);
 
-    const trigger = screen.getByRole('button', { name: 'Music' });
+    const trigger = getTrigger();
+    const disclosure = getDisclosure();
     expect(trigger).toHaveAttribute('aria-haspopup', 'menu');
-    expect(trigger).not.toHaveAttribute('aria-expanded', 'true');
+    expect(trigger).toHaveAccessibleName('Music');
+    expect(disclosure.open).toBe(false);
 
     await user.click(trigger);
-    expect(trigger).toHaveAttribute('aria-expanded', 'true');
-    expect(screen.getByRole('menu', { name: 'Music' })).toBeInTheDocument();
+    expect(disclosure.open).toBe(true);
+
+    // Visible, not merely present: the panel is revealed by CSS off `details[open]`
+    const menu = screen.getByRole('menu', { name: 'Music' });
+    expect(trigger).toHaveAttribute('aria-controls', menu.id);
 
     const links = screen.getAllByRole('menuitem');
     expect(links.map((link) => link.getAttribute('href'))).toEqual([
@@ -47,6 +82,31 @@ describe('MusicHeaderMenu', () => {
       musicRoute,
     ]);
     expect(links.map((link) => link.textContent)).toEqual(['Favorite albums', 'Listening history']);
+  });
+
+  /**
+   * The whole point of building on `<details>`: the open state lives on an
+   * element the platform toggles itself, and the panel is revealed by a selector
+   * rather than by a React render, so both survive scripting being off.
+   */
+  it('discloses the menu from markup alone, with no state that scripting has to correct', () => {
+    render(<TestMusicHeaderMenu />);
+
+    const trigger = getTrigger();
+    const menu = screen.getByRole('menu', { hidden: true });
+    expect(menu).toHaveAttribute('aria-label', 'Music');
+
+    // A server-rendered `aria-expanded` or `inert` would be frozen at "closed"
+    expect(trigger).not.toHaveAttribute('aria-expanded');
+    expect(trigger).not.toHaveAttribute('role');
+    expect(menu).not.toHaveAttribute('inert');
+    expect(menu).not.toHaveAttribute('aria-hidden');
+
+    const revealRules = rulesMatching(':has(> details[open])');
+    expect(revealRules.some((rule) => rule.includes('visibility: visible'))).toBe(true);
+    expect(revealRules.some((rule) => rule.includes(`.${menu.className.split(' ').at(-1)}`))).toBe(
+      true,
+    );
   });
 
   /**
@@ -58,7 +118,7 @@ describe('MusicHeaderMenu', () => {
     const user = userEvent.setup();
     render(<TestMusicHeaderMenu />);
 
-    const trigger = screen.getByRole('button', { name: 'Music' });
+    const trigger = getTrigger();
     expect(trigger.style.viewTransitionName).toBe('');
     expect(capturedTitleName(trigger)).toBeUndefined();
 
@@ -71,16 +131,41 @@ describe('MusicHeaderMenu', () => {
     }
   });
 
+  it('moves focus into the menu on open', async () => {
+    const user = userEvent.setup();
+    render(<TestMusicHeaderMenu />);
+
+    await user.click(getTrigger());
+    expect(screen.getAllByRole('menuitem').at(0)).toHaveFocus();
+  });
+
   it('closes on Escape and returns focus to the trigger', async () => {
     const user = userEvent.setup();
     render(<TestMusicHeaderMenu />);
 
-    const trigger = screen.getByRole('button', { name: 'Music' });
+    const trigger = getTrigger();
     await user.click(trigger);
-    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    expect(getDisclosure().open).toBe(true);
 
     await user.keyboard('{Escape}');
-    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(getDisclosure().open).toBe(false);
     expect(trigger).toHaveFocus();
+  });
+
+  it('walks the destinations with the arrow keys', async () => {
+    const user = userEvent.setup();
+    render(<TestMusicHeaderMenu />);
+
+    await user.click(getTrigger());
+    const [firstLink, secondLink] = screen.getAllByRole('menuitem');
+
+    await user.keyboard('{ArrowDown}');
+    expect(secondLink).toHaveFocus();
+    await user.keyboard('{ArrowDown}');
+    expect(firstLink).toHaveFocus();
+    await user.keyboard('{End}');
+    expect(secondLink).toHaveFocus();
+    await user.keyboard('{Home}');
+    expect(firstLink).toHaveFocus();
   });
 });

--- a/apps/web/src/app/music/albums/FavoriteAlbumsGrid.tsx
+++ b/apps/web/src/app/music/albums/FavoriteAlbumsGrid.tsx
@@ -2,6 +2,7 @@
 
 import type { PlaylistAlbum } from '@dg/content-models/spotify/PlaylistAlbums';
 import { GlassSwitcher } from '@dg/ui/core/GlassSwitcher';
+import { jsOnlyProps } from '@dg/ui/core/JsOnlyStyle';
 import { StickyFadeBar } from '@dg/ui/core/StickyFadeBar';
 import { EASING_DEFAULT, TIMING_SLOW } from '@dg/ui/helpers/timing';
 import type { SxObject } from '@dg/ui/theme';
@@ -238,7 +239,14 @@ export function FavoriteAlbumsGrid({ albums, children }: Props) {
 
   return (
     <Stack spacing={2}>
-      <StickyFadeBar>
+      {/*
+       * The whole bar goes with the sorter when scripting is off, rather than
+       * leaving a dead control or an empty band behind it. Sorting is the only
+       * thing this bar is for, and it reorders a grid that React holds in state;
+       * every album and every album link is already on the page in the default
+       * order, so nothing here is the only route to anything.
+       */}
+      <StickyFadeBar {...jsOnlyProps}>
         <GlassSwitcher
           aria-label="Sort albums"
           mobileIcon={<ArrowDownUp size={18} />}

--- a/package.json
+++ b/package.json
@@ -27,5 +27,5 @@
     "clean": "rm -f .env .env.tmp",
     "preinstall": "npx only-allow pnpm"
   },
-  "version": "2.68.8"
+  "version": "2.68.9"
 }

--- a/packages/ui/core/ColorSchemeToggleClient.tsx
+++ b/packages/ui/core/ColorSchemeToggleClient.tsx
@@ -20,6 +20,7 @@ import {
   GlassDisclosureRow,
   GlassDisclosureThumb,
 } from './GlassDisclosurePanel';
+import { jsOnlyProps } from './JsOnlyStyle';
 import { MouseAwareGlassContainer } from './MouseAwareGlassContainer';
 
 /**
@@ -333,7 +334,17 @@ export function ColorSchemeToggleClient({
     </Box>
   );
 
+  /**
+   * Hidden outright when scripting is off. A stored preference lives in
+   * `localStorage` and is applied by a head script, so with no script there is
+   * nothing to write it with and nothing to read it back — the picker would be
+   * three radio buttons that silently do nothing. The site instead follows
+   * `prefers-color-scheme`, which is what `color-scheme: light dark` on the
+   * document already does in CSS alone, so the scheme is still right; it just
+   * can't be overridden.
+   */
   const rootProps = {
+    ...jsOnlyProps,
     onBlur: handleFocusOut,
     onKeyDown: handleRootKeyDown,
     ref: rootRef,

--- a/packages/ui/core/GlassDisclosurePanel.tsx
+++ b/packages/ui/core/GlassDisclosurePanel.tsx
@@ -48,6 +48,20 @@ const alignSx: Record<DisclosureAlign, SxObject> = {
 };
 
 /**
+ * Marks the element whose `<details open>` state drives the panel inside it.
+ *
+ * A panel needs a no-script way to know it is open, and `<details>` is the only
+ * disclosure the platform tracks on its own. Selecting on the host rather than
+ * on the details itself lets the panel stay a *sibling* of the disclosure, out
+ * of the details' own content, so its motion is ours to animate and the glass
+ * nesting rules below still hold.
+ */
+export const DISCLOSURE_HOST_ATTRIBUTE = 'data-disclosure-host';
+
+/** Spread onto the element that wraps a `<details>` trigger and its panel. */
+export const disclosureHostProps = { [DISCLOSURE_HOST_ATTRIBUTE]: true } as const;
+
+/**
  * One shorthand, three different jobs — the properties genuinely need different
  * curves, so composing them by hand beats a helper that spreads a single easing
  * across all of them.
@@ -80,6 +94,21 @@ function createPanelMotionSx(isOpen: boolean): SxObject {
     visibility: isOpen ? 'visible' : 'hidden',
   };
 }
+
+/**
+ * Closed until a host `<details>` says otherwise, with no React state involved.
+ *
+ * `visibility` is doing the accessibility work here that `inert` cannot: a
+ * script-driven panel can be marked inert as it closes, but an attribute
+ * rendered on the server never changes without scripting, so a panel that
+ * shipped `inert` would stay unusable for exactly the visitors this path is for.
+ * A `visibility: hidden` panel is already out of the tab order and out of the
+ * accessibility tree, which is what `inert` was insuring against.
+ */
+const detailsDrivenMotionSx: SxObject = {
+  ...createPanelMotionSx(false),
+  [`[${DISCLOSURE_HOST_ATTRIBUTE}]:has(> details[open]) &`]: createPanelMotionSx(true),
+};
 
 const rowBaseSx: SxObject = {
   '& svg': {
@@ -130,7 +159,12 @@ const labelSx: SxObject = {
 
 type GlassDisclosurePanelProps = {
   children: ReactNode;
-  isOpen: boolean;
+  /**
+   * Script-owned open state. Omit it to let a host `<details open>` drive the
+   * panel from CSS alone, which is what keeps a disclosure working with
+   * scripting off — see `DISCLOSURE_HOST_ATTRIBUTE`.
+   */
+  isOpen?: boolean;
   /** Accessible name for the disclosure surface. */
   label: string;
   /** Trigger edge the panel is pinned to. Defaults to the inline end. */
@@ -163,14 +197,20 @@ export function GlassDisclosurePanel({
   role,
   sx,
 }: GlassDisclosurePanelProps) {
+  const isScriptDriven = isOpen !== undefined;
   return (
     <GlassContainer
-      aria-hidden={!isOpen}
+      aria-hidden={isScriptDriven ? !isOpen : undefined}
       aria-label={label}
       id={id}
-      inert={!isOpen}
+      inert={isScriptDriven ? !isOpen : undefined}
       role={role}
-      sx={{ ...panelBaseSx, ...alignSx[align], ...createPanelMotionSx(isOpen), ...sx }}
+      sx={{
+        ...panelBaseSx,
+        ...alignSx[align],
+        ...(isScriptDriven ? createPanelMotionSx(isOpen) : detailsDrivenMotionSx),
+        ...sx,
+      }}
     >
       {children}
     </GlassContainer>

--- a/packages/ui/core/JsOnlyStyle.tsx
+++ b/packages/ui/core/JsOnlyStyle.tsx
@@ -1,0 +1,34 @@
+/** Marks chrome that cannot do its job without scripting. */
+const JS_ONLY_ATTRIBUTE = 'data-js-only';
+
+/**
+ * Spread onto a control that is inert without scripting, so it is hidden rather
+ * than left on screen pretending to work. Use it only where the control's whole
+ * purpose needs JS — never as a shortcut around building a no-script path.
+ */
+export const jsOnlyProps = { [JS_ONLY_ATTRIBUTE]: true } as const;
+
+/**
+ * Hides `jsOnlyProps` chrome when scripting is off.
+ *
+ * A `<noscript>` stylesheet rather than a class the page's own script strips:
+ * browsers that run scripts never parse the contents at all, so there is no
+ * marker to race, and browsers that don't apply it before first paint — a class
+ * toggled by script flashes the control it is about to remove.
+ *
+ * Belongs in `<head>`, where `<noscript>` may hold a stylesheet.
+ *
+ * Written as raw HTML because a browser that runs scripts parses `<noscript>`
+ * contents as *text*, so rendering a real `<style>` child would leave the server
+ * markup and the hydrated tree disagreeing about what is in here.
+ */
+export function JsOnlyStyle() {
+  return (
+    <noscript
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: fixed literal, no input reaches it
+      dangerouslySetInnerHTML={{
+        __html: `<style>[${JS_ONLY_ATTRIBUTE}]{display:none!important}</style>`,
+      }}
+    />
+  );
+}

--- a/packages/ui/core/Tooltip.tsx
+++ b/packages/ui/core/Tooltip.tsx
@@ -6,24 +6,23 @@ import React, { useId, useRef } from 'react';
 import { EASING_EASE_OUT, TIMING_FAST } from '../helpers/timing';
 import type { SxObject } from '../theme';
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Popover-based Tooltip Component
-// ─────────────────────────────────────────────────────────────────────────────
-// Uses the native Popover API for proper accessibility:
-// - Screen readers only announce tooltip when visible
-// - Uses CSS Anchor Positioning for adaptive bottom/top placement
-// - Tooltip flips from bottom to top when near viewport edge
-
 export type TooltipPlacement = 'top' | 'bottom';
 
 /** Gap kept between a tooltip and the viewport edge, matching theme spacing(1). */
 const VIEWPORT_EDGE_PADDING = 8;
 
+/** Marks the wrapper that owns a tooltip, so the surface can select on its state. */
+const ANCHOR_ATTRIBUTE = 'data-tooltip-anchor';
+
 /**
- * Nudges an open tooltip inline so it stays inset from the viewport edges.
+ * Nudges a tooltip inline so it stays inset from the viewport edges.
  *
  * Anchor positioning centers the tooltip on its trigger, so triggers near a
  * screen edge push the tooltip flush against it (or off screen entirely).
+ *
+ * Purely an enhancement: the tooltip reveals itself in CSS, and this only
+ * refines where an already-positioned surface sits. Measuring needs a layout
+ * box, which a `visibility: hidden` surface still has.
  */
 const insetFromViewportEdges = (tooltip: HTMLElement) => {
   tooltip.style.translate = '0';
@@ -40,18 +39,11 @@ const insetFromViewportEdges = (tooltip: HTMLElement) => {
 };
 
 export interface TooltipProps {
-  /**
-   * The content to display in the tooltip
-   */
+  /** The content to display in the tooltip. */
   title: ReactNode;
-  /**
-   * The element that triggers the tooltip on hover/focus
-   */
+  /** The element that triggers the tooltip on hover/focus. */
   children: ReactNode;
-  /**
-   * Unique identifier for the tooltip
-   * If not provided, a stable ID will be generated
-   */
+  /** Unique identifier for the tooltip. Generated when omitted. */
   id?: string;
   /**
    * Preferred placement of the tooltip.
@@ -59,17 +51,117 @@ export interface TooltipProps {
    * - 'top': Shows above trigger, flips to bottom if no room
    */
   placement?: TooltipPlacement;
+  /**
+   * Merged into the anchor, for triggers that need it to fill their box so the
+   * whole tap target reveals the hint rather than just the glyph inside it.
+   */
+  sx?: SxObject;
 }
 
 type TooltipAnchorSx = SxObject & { anchorName?: string };
 type TooltipPopoverSx = SxObject & { positionAnchor?: string };
 
 /**
- * Popover-based tooltip component with adaptive bottom/top placement.
+ * Opening is immediate; closing waits a beat so a cursor travelling the gap
+ * between trigger and surface doesn't blink the tooltip out. `visibility` is
+ * what keeps a closed tooltip from swallowing pointer events, so it flips only
+ * once the fade it trails has finished.
+ */
+const createTransition = (isRevealed: boolean) => ({
+  transition: [
+    `opacity ${TIMING_FAST}ms ${EASING_EASE_OUT} ${isRevealed ? 0 : TIMING_FAST}ms`,
+    `visibility 0s linear ${isRevealed ? 0 : TIMING_FAST * 2}ms`,
+  ].join(', '),
+});
+
+/**
+ * Reveal state, shared by every selector that can open a tooltip.
  *
- * Uses native Popover API for proper accessibility - screen readers only
- * announce content when the tooltip is visible. CSS Anchor Positioning
- * automatically flips the tooltip from bottom to top when near viewport edges.
+ * `pointerEvents` turns on with the tooltip so the pointer can cross the gap
+ * into the surface without unhovering the anchor it descends from, which is
+ * what stops a tooltip flickering out from under the cursor.
+ */
+const revealedSx: SxObject = {
+  opacity: 1,
+  pointerEvents: 'auto',
+  visibility: 'visible',
+  ...createTransition(true),
+};
+
+/**
+ * Every way a tooltip opens, expressed as CSS so it needs no scripting.
+ *
+ * Hover is the anchor's own. Keyboard focus can land on either side of it: a
+ * wrapped trigger (a `<button>` inside the anchor) takes focus underneath,
+ * while a trigger the anchor has to sit *inside* — a `<summary>`, which must be
+ * its `<details>`' first child and so cannot be wrapped — takes it one level up.
+ *
+ * `:focus-visible` rather than `:focus` because a mouse click focuses its
+ * target, so plain focus would pop a tooltip open on click and leave it there.
+ */
+const HOVERED_SELECTOR = `[${ANCHOR_ATTRIBUTE}]:hover > &`;
+const TRIGGER_INSIDE_FOCUSED_SELECTOR = `[${ANCHOR_ATTRIBUTE}]:has(:focus-visible) > &`;
+/*
+ * Leading `*` on purpose: a nested selector that starts with a pseudo-class is
+ * read as attaching to the element being styled, so `:focus-visible > …` would
+ * compile to the surface focusing itself rather than an ancestor doing so.
+ */
+const TRIGGER_AROUND_FOCUSED_SELECTOR = `*:focus-visible > [${ANCHOR_ATTRIBUTE}] > &`;
+
+/** Anchor for the tooltip's positioning, named per instance so surfaces can't cross. */
+function createAnchorSx(anchorName: string): TooltipAnchorSx {
+  return {
+    '@supports not (position-area: block-end)': {
+      position: 'relative',
+    },
+    anchorName,
+    display: 'inline-flex',
+  };
+}
+
+function createSurfaceSx(anchorName: string, placement: TooltipPlacement): TooltipPopoverSx {
+  const isAbove = placement === 'top';
+  return {
+    /* Browsers without anchor positioning fall back to centring on the anchor. */
+    '@supports not (position-area: block-end)': {
+      left: '50%',
+      position: 'absolute',
+      transform: 'translateX(-50%)',
+      ...(isAbove ? { bottom: '100%', top: 'auto' } : { bottom: 'auto', top: '100%' }),
+    },
+    [HOVERED_SELECTOR]: revealedSx,
+    [TRIGGER_AROUND_FOCUSED_SELECTOR]: revealedSx,
+    [TRIGGER_INSIDE_FOCUSED_SELECTOR]: revealedSx,
+    background: 'var(--mui-palette-background-paper)',
+    border: 'thin solid var(--mui-palette-card-border)',
+    borderRadius: '12px',
+    boxShadow: 'var(--mui-extraShadows-card-main)',
+    color: 'var(--mui-palette-text-primary)',
+    marginBlockEnd: isAbove ? '6px' : 0,
+    marginBlockStart: isAbove ? 0 : '6px',
+    opacity: 0,
+    padding: '4px 10px',
+    pointerEvents: 'none',
+    position: 'fixed',
+    positionAnchor: anchorName,
+    positionArea: isAbove ? 'block-start' : 'block-end',
+    positionTryFallbacks: 'flip-block',
+    translate: '0',
+    visibility: 'hidden',
+    whiteSpace: 'nowrap',
+    zIndex: 1500,
+    ...createTransition(false),
+  };
+}
+
+/**
+ * Tooltip with adaptive bottom/top placement, revealed entirely in CSS.
+ *
+ * Hover and `:focus-visible` do the showing, so the hint works with scripting
+ * off; CSS anchor positioning does the placing and flips the surface to the
+ * other side of the trigger when there is no room. Because the tooltip is a
+ * hint rather than the only home for its text, every trigger that uses one also
+ * names itself — `aria-label` on icon-only controls, visible text otherwise.
  *
  * @example
  * ```tsx
@@ -80,42 +172,22 @@ type TooltipPopoverSx = SxObject & { positionAnchor?: string };
  * </Tooltip>
  * ```
  */
-export function Tooltip({ title, children, id: providedId, placement = 'bottom' }: TooltipProps) {
+export function Tooltip({
+  title,
+  children,
+  id: providedId,
+  placement = 'bottom',
+  sx,
+}: TooltipProps) {
   const generatedId = useId();
   const tooltipId = providedId ?? `tooltip-${generatedId}`;
-  const anchorName = tooltipId ? `--anchor-${tooltipId.replace(/:/g, '-')}` : undefined;
+  const anchorName = `--anchor-${tooltipId.replace(/:/g, '-')}`;
+  const surfaceRef = useRef<HTMLSpanElement>(null);
 
-  const popoverRef = useRef<HTMLSpanElement>(null);
-  const hideTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const showTooltip = () => {
-    if (hideTimeoutRef.current) {
-      clearTimeout(hideTimeoutRef.current);
-      hideTimeoutRef.current = null;
+  const refinePlacement = () => {
+    if (surfaceRef.current) {
+      insetFromViewportEdges(surfaceRef.current);
     }
-    const tooltip = popoverRef.current;
-    if (!tooltip) {
-      return;
-    }
-    tooltip.showPopover();
-    insetFromViewportEdges(tooltip);
-  };
-
-  const hideTooltip = () => {
-    // Small delay to prevent flickering when moving between trigger and tooltip
-    hideTimeoutRef.current = setTimeout(() => {
-      popoverRef.current?.hidePopover();
-    }, TIMING_FAST);
-  };
-
-  // A mouse click focuses its target, so focus alone would pop a tooltip open
-  // on click and leave it there. `:focus-visible` is the browser's own answer
-  // to "was this focus keyboard-driven", so keyboard users keep the hint.
-  const showTooltipFromFocus = (event: React.FocusEvent<HTMLSpanElement>) => {
-    if (!event.target.matches(':focus-visible')) {
-      return;
-    }
-    showTooltip();
   };
 
   // Don't render wrapper if no title
@@ -123,81 +195,25 @@ export function Tooltip({ title, children, id: providedId, placement = 'bottom' 
     return <>{children}</>;
   }
 
-  const anchorSx: TooltipAnchorSx = {
-    ...(anchorName ? { anchorName } : {}),
-    '@supports not (position-area: block-end)': {
-      position: 'relative',
-    },
-    display: 'inline-flex',
-  };
-  const popoverSx: TooltipPopoverSx = {
-    ...(anchorName ? { positionAnchor: anchorName } : {}),
-    '@keyframes tooltip-in': {
-      from: { opacity: 0 },
-      to: { opacity: 1 },
-    },
-    '@supports not (position-area: block-end)': {
-      left: '50%',
-      marginBlockEnd: placement === 'top' ? '6px' : 0,
-      marginBlockStart: placement === 'top' ? 0 : '6px',
-      position: 'absolute',
-      transform: 'translateX(-50%)',
-      ...(placement === 'top'
-        ? {
-            bottom: '100%',
-            top: 'auto',
-          }
-        : {
-            bottom: 'auto',
-            top: '100%',
-          }),
-    },
-    '&:popover-open': {
-      animation: `tooltip-in ${TIMING_FAST}ms ${EASING_EASE_OUT}`,
-      opacity: 1,
-    },
-    background: 'var(--mui-palette-background-paper)',
-    border: 'thin solid var(--mui-palette-card-border)',
-    borderRadius: '12px',
-    boxShadow: 'var(--mui-extraShadows-card-main)',
-    color: 'var(--mui-palette-text-primary)',
-    marginBlockEnd: placement === 'top' ? '6px' : 0,
-    marginBlockStart: placement === 'top' ? 0 : '6px',
-    opacity: 0,
-    padding: '4px 10px',
-    position: 'fixed',
-    positionArea: placement === 'top' ? 'block-start' : 'block-end',
-    positionTryFallbacks: 'flip-block',
-    transition: `opacity ${TIMING_FAST}ms ${EASING_EASE_OUT}, overlay ${TIMING_FAST}ms ${EASING_EASE_OUT} allow-discrete, display ${TIMING_FAST}ms ${EASING_EASE_OUT} allow-discrete`,
-    translate: '0',
-    whiteSpace: 'nowrap',
-    zIndex: 1500,
-  };
-  const describedByProps = tooltipId ? { 'aria-describedby': tooltipId } : {};
-
   return (
     <Box
+      {...{ [ANCHOR_ATTRIBUTE]: true }}
       component="span"
-      onBlur={hideTooltip}
-      onFocus={showTooltipFromFocus}
-      onMouseEnter={showTooltip}
-      onMouseLeave={hideTooltip}
-      sx={anchorSx}
+      onFocus={refinePlacement}
+      onMouseEnter={refinePlacement}
+      sx={{ ...createAnchorSx(anchorName), ...sx }}
     >
       {/* Clone children to add aria-describedby */}
       {React.isValidElement<{ 'aria-describedby'?: string }>(children)
-        ? React.cloneElement(children, describedByProps)
+        ? React.cloneElement(children, { 'aria-describedby': tooltipId })
         : children}
       <Typography
         component="span"
         data-placement={placement}
         id={tooltipId}
-        onMouseEnter={showTooltip}
-        onMouseLeave={hideTooltip}
-        popover="manual"
-        ref={popoverRef}
+        ref={surfaceRef}
         role="tooltip"
-        sx={popoverSx}
+        sx={createSurfaceSx(anchorName, placement)}
         variant="caption"
       >
         {title}

--- a/packages/ui/core/__tests__/GlassDisclosurePanel.test.tsx
+++ b/packages/ui/core/__tests__/GlassDisclosurePanel.test.tsx
@@ -1,7 +1,14 @@
+import { Box } from '@mui/material';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Disc3, Sun } from 'lucide-react';
 import { EASING_BOUNCY, TIMING_BOUNCY, TIMING_NORMAL } from '../../helpers/timing';
-import { GlassDisclosurePanel, GlassDisclosureRow } from '../GlassDisclosurePanel';
+import {
+  DISCLOSURE_HOST_ATTRIBUTE,
+  disclosureHostProps,
+  GlassDisclosurePanel,
+  GlassDisclosureRow,
+} from '../GlassDisclosurePanel';
 
 /** The emitted rule for a panel, which is where its transition actually lives. */
 function panelRule(panel: HTMLElement): string {
@@ -33,6 +40,51 @@ describe('GlassDisclosurePanel', () => {
     );
 
     expect(screen.getByLabelText('Closed menu')).toHaveAttribute('inert');
+  });
+
+  /**
+   * Omitting `isOpen` hands the panel to a host `<details>`, which is the only
+   * disclosure state a browser keeps without scripting. `inert` and `aria-hidden`
+   * have to stay off that path: rendered on the server they would never flip, so
+   * they would permanently bury the panel for visitors with no script.
+   */
+  it('takes its open state from a host details when no script owns it', () => {
+    render(
+      <Box {...disclosureHostProps}>
+        <details>
+          <summary>Open</summary>
+        </details>
+        <GlassDisclosurePanel label="Scriptless menu" role="menu">
+          <GlassDisclosureRow icon={<Sun />} label="Light" />
+        </GlassDisclosurePanel>
+      </Box>,
+    );
+
+    const panel = screen.getByRole('menu', { hidden: true });
+    expect(panel).not.toHaveAttribute('inert');
+    expect(panel).not.toHaveAttribute('aria-hidden');
+
+    const rule = panelRule(panel);
+    expect(rule).toContain(`[${DISCLOSURE_HOST_ATTRIBUTE}]:has(> details[open])`);
+    expect(rule).toContain('visibility: visible');
+  });
+
+  it('reveals a details-driven panel as soon as the disclosure opens', async () => {
+    const user = userEvent.setup();
+    render(
+      <Box {...disclosureHostProps}>
+        <details>
+          <summary>Open</summary>
+        </details>
+        <GlassDisclosurePanel label="Scriptless menu" role="menu">
+          <GlassDisclosureRow icon={<Sun />} label="Light" />
+        </GlassDisclosurePanel>
+      </Box>,
+    );
+
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    await user.click(screen.getByText('Open'));
+    expect(screen.getByRole('menu', { name: 'Scriptless menu' })).toBeInTheDocument();
   });
 
   /**

--- a/packages/ui/core/__tests__/GlassSwitcher.test.tsx
+++ b/packages/ui/core/__tests__/GlassSwitcher.test.tsx
@@ -86,7 +86,8 @@ describe('GlassSwitcher', () => {
     await user.click(secondRadio);
     expect(handleChange).toHaveBeenCalledWith('second');
 
-    expect(screen.getAllByRole('tooltip')).toHaveLength(1);
+    // Hidden until hover or keyboard focus reveals it, which CSS alone does
+    expect(screen.getAllByRole('tooltip', { hidden: true })).toHaveLength(1);
   });
 
   it('renders visible labels without tooltips for text-only options', async () => {
@@ -107,7 +108,7 @@ describe('GlassSwitcher', () => {
 
     expect(desktop().getByText('Recently added')).toBeInTheDocument();
     expect(desktop().getByText('Album')).toBeInTheDocument();
-    expect(screen.queryAllByRole('tooltip')).toHaveLength(0);
+    expect(screen.queryAllByRole('tooltip', { hidden: true })).toHaveLength(0);
     expect(screen.getByTestId('mobile-icon')).toBeInTheDocument();
 
     await user.click(desktop().getByRole('radio', { hidden: true, name: 'Album' }));

--- a/packages/ui/core/__tests__/JsOnlyStyle.test.tsx
+++ b/packages/ui/core/__tests__/JsOnlyStyle.test.tsx
@@ -1,0 +1,34 @@
+import { render } from '@testing-library/react';
+import { JsOnlyStyle, jsOnlyProps } from '../JsOnlyStyle';
+
+describe('JsOnlyStyle', () => {
+  it('hides script-only chrome from a noscript stylesheet', () => {
+    const { container } = render(<JsOnlyStyle />);
+
+    const noscript = container.querySelector('noscript');
+    expect(noscript).not.toBeNull();
+
+    const [attribute] = Object.keys(jsOnlyProps);
+    expect(noscript?.textContent).toContain(`[${attribute}]`);
+    expect(noscript?.textContent).toContain('display:none!important');
+  });
+
+  /**
+   * The rule has to be a `<noscript>` stylesheet rather than a class some script
+   * removes on boot: a browser with scripting on never parses this content, so
+   * there is nothing to race, and a browser with it off applies the rule before
+   * first paint instead of flashing a control it is about to take away.
+   */
+  it('ships the rule as a stylesheet, not a marker script has to clean up', () => {
+    const { container } = render(<JsOnlyStyle />);
+
+    expect(container.querySelector('noscript')?.textContent).toContain('<style>');
+    expect(container.querySelector('script')).toBeNull();
+  });
+
+  it('marks chrome with an attribute that rule selects', () => {
+    const [attribute, value] = Object.entries(jsOnlyProps)[0] ?? [];
+    expect(attribute).toBe('data-js-only');
+    expect(value).toBe(true);
+  });
+});

--- a/packages/ui/core/__tests__/RelativeTime.test.tsx
+++ b/packages/ui/core/__tests__/RelativeTime.test.tsx
@@ -1,5 +1,4 @@
 import { act, render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import type { ReactNode } from 'react';
 import { RelativeTime } from '../RelativeTime';
 import { ServerTimeProvider } from '../ServerTimeContext';
@@ -10,42 +9,8 @@ function TestWrapper({ children }: { children: ReactNode }) {
   return <ServerTimeProvider serverTime={TEST_SERVER_TIME}>{children}</ServerTimeProvider>;
 }
 
-function setupPopoverMocks() {
-  const showPopover = jest.fn();
-  const hidePopover = jest.fn();
-  const originalShow = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'showPopover');
-  const originalHide = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'hidePopover');
-
-  Object.defineProperty(HTMLElement.prototype, 'showPopover', {
-    configurable: true,
-    value: showPopover,
-  });
-  Object.defineProperty(HTMLElement.prototype, 'hidePopover', {
-    configurable: true,
-    value: hidePopover,
-  });
-
-  const restore = () => {
-    if (originalShow) {
-      Object.defineProperty(HTMLElement.prototype, 'showPopover', originalShow);
-    } else {
-      Object.defineProperty(HTMLElement.prototype, 'showPopover', {
-        configurable: true,
-        value: undefined,
-      });
-    }
-    if (originalHide) {
-      Object.defineProperty(HTMLElement.prototype, 'hidePopover', originalHide);
-    } else {
-      Object.defineProperty(HTMLElement.prototype, 'hidePopover', {
-        configurable: true,
-        value: undefined,
-      });
-    }
-  };
-
-  return { hidePopover, restore, showPopover };
-}
+/** Closed tooltips are hidden, so the full date has to be asked for by name. */
+const fullDateTooltip = () => screen.getByRole('tooltip', { hidden: true });
 
 describe('RelativeTime', () => {
   beforeEach(() => {
@@ -119,7 +84,7 @@ describe('RelativeTime', () => {
     expect(timeEl).toBeInTheDocument();
     expect(timeEl).toHaveAttribute('dateTime', '2026-02-10T09:00:00.000Z');
 
-    const tooltip = screen.getByRole('tooltip');
+    const tooltip = fullDateTooltip();
     expect(tooltip).toBeInTheDocument();
     // Intl formats per environment locale (date + time)
     expect(tooltip).toHaveTextContent(/2026/);
@@ -132,8 +97,7 @@ describe('RelativeTime', () => {
 
     const timeEl = screen.getByText('2 days ago').closest('time');
     expect(timeEl).toHaveAttribute('dateTime', '2026-02-08T14:30:00.000Z');
-    const tooltip = screen.getByRole('tooltip');
-    expect(tooltip).toHaveTextContent(/2026/);
+    expect(fullDateTooltip()).toHaveTextContent(/2026/);
   });
 
   it('tooltip and dateTime are correct for timestamp number input', () => {
@@ -143,29 +107,18 @@ describe('RelativeTime', () => {
     // Formatter may show "1 day ago" or "Yesterday"
     const timeEl = screen.getByText(/1 day ago|Yesterday/).closest('time');
     expect(timeEl).toHaveAttribute('dateTime', '2026-02-09T00:00:00.000Z');
-    const tooltip = screen.getByRole('tooltip');
-    expect(tooltip).toHaveTextContent(/2026/);
+    expect(fullDateTooltip()).toHaveTextContent(/2026/);
   });
 
-  it('shows tooltip on hover', async () => {
-    jest.useFakeTimers();
-    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-    const { restore, showPopover } = setupPopoverMocks();
+  /**
+   * The exact instant is only ever *shown* by the tooltip, so it has to be
+   * announced with the relative text rather than left to a hover a keyboard or
+   * a screen reader never performs.
+   */
+  it('describes the relative time with the full date', () => {
+    render(<RelativeTime date="2026-02-10T09:00:00Z" />, { wrapper: TestWrapper });
 
-    render(<RelativeTime date="2026-02-10T09:00:00Z" />, {
-      wrapper: TestWrapper,
-    });
-
-    const timeEl = screen.getByText(/ago|Yesterday/).closest('time');
-    const anchor = timeEl?.parentElement;
-    if (!anchor) {
-      throw new Error('Tooltip anchor not found');
-    }
-
-    await user.hover(anchor);
-    expect(showPopover).toHaveBeenCalledTimes(1);
-
-    restore();
-    jest.useRealTimers();
+    const timeEl = screen.getByText('3 hours ago').closest('time');
+    expect(timeEl).toHaveAttribute('aria-describedby', fullDateTooltip().id);
   });
 });

--- a/packages/ui/core/__tests__/Tooltip.test.tsx
+++ b/packages/ui/core/__tests__/Tooltip.test.tsx
@@ -1,58 +1,27 @@
-import { act, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Tooltip } from '../Tooltip';
 
-const setupPopoverMocks = () => {
-  const showPopover = jest.fn();
-  const hidePopover = jest.fn();
-  const originalShow = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'showPopover');
-  const originalHide = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'hidePopover');
-
-  Object.defineProperty(HTMLElement.prototype, 'showPopover', {
-    configurable: true,
-    value: showPopover,
-  });
-  Object.defineProperty(HTMLElement.prototype, 'hidePopover', {
-    configurable: true,
-    value: hidePopover,
-  });
-
-  const restore = () => {
-    if (originalShow) {
-      Object.defineProperty(HTMLElement.prototype, 'showPopover', originalShow);
-    } else {
-      Object.defineProperty(HTMLElement.prototype, 'showPopover', {
-        configurable: true,
-        value: undefined,
-      });
-    }
-
-    if (originalHide) {
-      Object.defineProperty(HTMLElement.prototype, 'hidePopover', originalHide);
-    } else {
-      Object.defineProperty(HTMLElement.prototype, 'hidePopover', {
-        configurable: true,
-        value: undefined,
-      });
-    }
-  };
-
-  return { hidePopover, restore, showPopover };
-};
-
 /**
- * jsdom's selector engine answers `:focus-visible` the same way it answers
- * `:focus`, so it can't tell a click from a Tab on its own. Stubbing the
- * trigger's `matches` is the only way to exercise both branches here.
+ * Rules emotion has emitted for the tooltip surface. jsdom can't simulate
+ * `:hover` or `:focus-visible`, so the stylesheet is where the reveal has to be
+ * checked — and checking it there is the point: a rule in the stylesheet is a
+ * rule the browser applies with no script running.
  */
-const stubFocusVisible = (element: Element, isFocusVisible: boolean) => {
-  const actualMatches = element.matches.bind(element);
-  jest
-    .spyOn(element, 'matches')
-    .mockImplementation((selector: string) =>
-      selector === ':focus-visible' ? isFocusVisible : actualMatches(selector),
-    );
+const surfaceRules = () => {
+  const surfaceClass = [...screen.getByRole('tooltip', { hidden: true }).classList].find((name) =>
+    name.startsWith('css-'),
+  );
+  if (!surfaceClass) {
+    throw new Error('Tooltip surface has no emotion class');
+  }
+  // Emotion inserts through the CSSOM here, so the tags themselves have no text
+  return [...document.querySelectorAll('style')]
+    .flatMap((tag) => [...(tag.sheet?.cssRules ?? [])].map((rule) => rule.cssText))
+    .filter((rule) => rule.includes(surfaceClass));
 };
+
+const rulesMatching = (pattern: RegExp) => surfaceRules().filter((rule) => pattern.test(rule));
 
 describe('Tooltip', () => {
   it('adds aria-describedby and respects placement', () => {
@@ -63,7 +32,7 @@ describe('Tooltip', () => {
     );
 
     const button = screen.getByRole('button', { name: 'Trigger' });
-    const tooltip = screen.getByRole('tooltip');
+    const tooltip = screen.getByRole('tooltip', { hidden: true });
     const describedBy = button.getAttribute('aria-describedby');
     if (!describedBy) {
       throw new Error('aria-describedby not set');
@@ -82,121 +51,71 @@ describe('Tooltip', () => {
 
     const button = screen.getByRole('button', { name: 'Trigger' });
 
-    expect(screen.queryByRole('tooltip')).toBeNull();
+    expect(screen.queryByRole('tooltip', { hidden: true })).toBeNull();
     expect(button).not.toHaveAttribute('aria-describedby');
   });
 
-  it('shows and hides with the popover API', async () => {
-    jest.useFakeTimers();
-    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-    const { hidePopover, restore, showPopover } = setupPopoverMocks();
+  /**
+   * The whole point of the rewrite: hovering must not need a script. A tooltip
+   * that called `showPopover()` was invisible with scripting off.
+   */
+  it('reveals from CSS rather than the popover API', async () => {
+    const user = userEvent.setup();
+    const showPopover = jest.fn();
+    Object.defineProperty(HTMLElement.prototype, 'showPopover', {
+      configurable: true,
+      value: showPopover,
+    });
 
     render(
-      <Tooltip title="Popover">
+      <Tooltip title="Hint">
         <button type="button">Trigger</button>
       </Tooltip>,
     );
-
-    const button = screen.getByRole('button', { name: 'Trigger' });
-    const anchor = button.parentElement;
+    const anchor = screen.getByRole('button', { name: 'Trigger' }).parentElement;
     if (!anchor) {
       throw new Error('Tooltip anchor not found');
     }
 
     await user.hover(anchor);
-    expect(showPopover).toHaveBeenCalledTimes(1);
 
-    await user.unhover(anchor);
-    act(() => {
-      jest.advanceTimersByTime(100);
-    });
-    expect(hidePopover).toHaveBeenCalledTimes(1);
-
-    restore();
-    jest.useRealTimers();
-  });
-
-  it('shows on keyboard focus', async () => {
-    const user = userEvent.setup();
-    const { restore, showPopover } = setupPopoverMocks();
-
-    render(
-      <Tooltip title="Keyboard">
-        <button type="button">Trigger</button>
-      </Tooltip>,
-    );
-
-    const button = screen.getByRole('button', { name: 'Trigger' });
-    stubFocusVisible(button, true);
-
-    await user.tab();
-
-    expect(button).toHaveFocus();
-    expect(showPopover).toHaveBeenCalledTimes(1);
-
-    restore();
-  });
-
-  it('ignores focus the browser does not treat as keyboard focus', () => {
-    const { restore, showPopover } = setupPopoverMocks();
-
-    render(
-      <Tooltip title="Mouse">
-        <button type="button">Trigger</button>
-      </Tooltip>,
-    );
-
-    const button = screen.getByRole('button', { name: 'Trigger' });
-    stubFocusVisible(button, false);
-
-    act(() => {
-      button.focus();
-    });
-
-    // Focus really did land, so this pins the guard rather than absent focus
-    expect(button).toHaveFocus();
     expect(showPopover).not.toHaveBeenCalled();
-
-    restore();
+    expect(screen.getByRole('tooltip', { hidden: true })).not.toHaveAttribute('popover');
+    expect(rulesMatching(/\[data-tooltip-anchor\]:hover/)).not.toHaveLength(0);
   });
 
-  it('does not keep the tooltip open after a click once the pointer leaves', async () => {
-    jest.useFakeTimers();
-    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-    const { hidePopover, restore, showPopover } = setupPopoverMocks();
-
+  /**
+   * A mouse click focuses its target, so plain `:focus` would pop a tooltip open
+   * on click and leave it there. Keyboard users still get the hint because
+   * `:focus-visible` is the browser's own answer to "was this focus keyboard-driven".
+   */
+  it('reveals on keyboard focus only, from either side of the anchor', () => {
     render(
-      <Tooltip title="Mouse">
+      <Tooltip title="Hint">
         <button type="button">Trigger</button>
       </Tooltip>,
     );
 
-    const button = screen.getByRole('button', { name: 'Trigger' });
-    const anchor = button.parentElement;
-    if (!anchor) {
-      throw new Error('Tooltip anchor not found');
-    }
-    stubFocusVisible(button, false);
+    expect(rulesMatching(/:focus(?!-visible)/)).toHaveLength(0);
+    // Trigger inside the anchor, and an anchor that has to sit inside its trigger
+    expect(rulesMatching(/\[data-tooltip-anchor\]:has\(:focus-visible\)/)).not.toHaveLength(0);
+    expect(rulesMatching(/\*:focus-visible>\[data-tooltip-anchor\]/)).not.toHaveLength(0);
+  });
 
-    await user.click(button);
-    const showsFromHover = showPopover.mock.calls.length;
+  it('keeps a closed tooltip out of the accessibility tree and the tab order', () => {
+    render(
+      <Tooltip title="Hint">
+        <button type="button">Trigger</button>
+      </Tooltip>,
+    );
 
-    await user.unhover(anchor);
-    act(() => {
-      jest.advanceTimersByTime(100);
-    });
-
-    expect(button).toHaveFocus();
-    expect(hidePopover).toHaveBeenCalled();
-    expect(showPopover).toHaveBeenCalledTimes(showsFromHover);
-
-    restore();
-    jest.useRealTimers();
+    // `visibility: hidden` is what does this, in place of the old `popover` attribute
+    expect(screen.queryByRole('tooltip')).toBeNull();
+    expect(screen.getByRole('tooltip', { hidden: true })).toBeInTheDocument();
   });
 
   it('shifts inline to stay inset from the viewport edge', async () => {
     const user = userEvent.setup();
-    const { restore } = setupPopoverMocks();
 
     render(
       <Tooltip title="Near the edge">
@@ -204,7 +123,7 @@ describe('Tooltip', () => {
       </Tooltip>,
     );
 
-    const tooltip = screen.getByRole('tooltip');
+    const tooltip = screen.getByRole('tooltip', { hidden: true });
     const anchor = screen.getByRole('button', { name: 'Trigger' }).parentElement;
     if (!anchor) {
       throw new Error('Tooltip anchor not found');
@@ -219,7 +138,5 @@ describe('Tooltip', () => {
     await user.hover(anchor);
 
     expect(tooltip.style.translate).toBe('-20px');
-
-    restore();
   });
 });


### PR DESCRIPTION
## Summary

The music menu and every tooltip needed JavaScript to open at all, so with scripting off the header was decoration. Now the navigation and the hints work from markup and CSS, and the enhanced experience is unchanged.

- **Tooltips** reveal from CSS alone — `:hover`, plus `:focus-visible` on the control wrapping the anchor — instead of calling `showPopover()`. Script only nudges placement near a viewport edge, so it is an enhancement rather than the mechanism. Anchor positioning and the edge padding are untouched.
- **Music menu** is a `<details>`/`<summary>`, the one disclosure a browser tracks by itself. The panel stays a *sibling* of the `<details>` — a `<details>` hides its own content outright, which would cut the open/close motion, and nesting it would put it inside the capsule glass — so a `:has(> details[open])` selector on the host reveals it. React follows that state rather than owning it, which is what keeps the two header panels mutually exclusive.
- **Theme picker and album sorter** genuinely need script: one persists a preference, the other sorts client state. They are marked `data-js-only` and hidden by a `<noscript>` stylesheet rather than left on screen pretending to work. Without them the site respects `prefers-color-scheme` and albums keep their default order — and album selection is already a query param, so nothing is only reachable through the sorter.

`aria-expanded` is deliberately *not* rendered on the `<summary>`: browsers expose a summary as a button carrying the parent's expanded state, and a server-rendered attribute would be frozen at "closed" for exactly the visitors this path is for. Same reasoning for `inert`/`aria-hidden` on the scriptless panel, where `visibility: hidden` already takes it out of the tab order and the accessibility tree.

## Verification

Driven over CDP against a production build with `Emulation.setScriptExecutionDisabled`, so scripting is genuinely off rather than simulated. 41/41 checks pass at 390 and 1280, light and dark.

With scripting off: the menu opens on click and both links navigate; the tooltip reveals on hover; the panel keeps `backdrop-filter: blur(12px) saturate(1.5)`; the capsule glass stays childless; no header chrome has an idle `view-transition-name`; the theme picker and sorter have no box at all.

With scripting on, nothing regressed: mutual exclusivity (both directions), keyboard reaches the trigger, `:focus-visible` shows the hint, Enter opens and moves focus to the first destination, arrows walk the list, Escape closes and returns focus to the trigger, `role="radiogroup"` with three real radios, 48px targets, and the scheme choice still persists.

One pre-existing limit found and left alone: the albums grid streams behind a Suspense boundary, and resolving a boundary is React's own inline script, so with scripting off that grid stays behind its skeleton. The links are in the markup; making streamed content paint without script is an architectural change well outside this PR.

## Test plan

- [x] `turbo check`, `turbo check:types`, `turbo test` filtered to `@dg/ui` and `@dg/web` — 194 web tests, full UI suite
- [x] Scripting disabled in a real browser at 390 and 1280, light and dark
- [x] Keyboard-only operation with scripting on
- [x] Glass and view-transition naming asserted from computed styles

Made with [Cursor](https://cursor.com)